### PR TITLE
set npm registry from publishConfig.registry if existent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ npmconf.load({}, (err, conf) => {
       token: env.NPM_TOKEN
     },
     loglevel: conf.get('loglevel'),
-    registry: conf.get('registry'),
+    registry: (pkg.publishConfig && pkg.publishConfig.registry) || conf.get('registry'),
     tag: (pkg.publishConfig || {}).tag || conf.get('tag') || 'latest'
   }
 


### PR DESCRIPTION
I've a setup with npm enterprise. `semantic-release` currently sets the registry to the default, as I have a registry set for a scope only. This is what my .npmrc file looks like:

```
@myscope:registry=https://myregistry.example.com/
```

So I think we should do both of these things:

1. check if the current package as a scope. If it does, check for `conf.get('@scope/registry')`
2. If `pkg.publishConfig.registry` and use that if it exists.

My change fixed the issue for me. Happy to help with the tests or anything else, but I'll need guidance 