### PR TITLE
feat(commit-analyzer): Change to new commit-analyzer API

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@semantic-release/error": "^1.0.0",
     "@semantic-release/last-release-npm": "^1.1.1",
     "@semantic-release/release-notes-generator": "^2.0.0",
+    "async": "^1.4.2",
     "git-head": "^1.2.1",
     "github": "^0.2.4",
     "lodash": "^3.9.3",

--- a/src/lib/type.js
+++ b/src/lib/type.js
@@ -1,12 +1,30 @@
 const SemanticReleaseError = require('@semantic-release/error')
+const _ = require('lodash')
+const async = require('async')
 
 module.exports = function (config, cb) {
-  const { plugins, lastRelease } = config
+  const { plugins, lastRelease, commits } = config
 
-  plugins.analyzeCommits(config, (err, type) => {
+  async.map(commits, (commit, cb) => {
+    plugins.analyzeCommits(_.defaults({ commit }, config), cb)
+  },
+  (err, types) => {
     if (err) return cb(err)
 
-    if (!type) {
+    if (types[types.length - 1] === 'rskip') {
+      return cb(new SemanticReleaseError(
+        'The release was skipped',
+        'ERSKIP'
+      ))
+    }
+
+    const typeOrder = ['patch', 'minor', 'major']
+
+    const type = types
+                  .map(t => typeOrder.indexOf(t))
+                  .reduce((type, t) => (type < t) ? t : type, -1)
+
+    if (type < 0) {
       return cb(new SemanticReleaseError(
         'There are no relevant changes, so no new version is released.',
         'ENOCHANGE'
@@ -15,6 +33,6 @@ module.exports = function (config, cb) {
 
     if (!lastRelease.version) return cb(null, 'initial')
 
-    cb(null, type)
+    cb(null, typeOrder[type])
   })
 }

--- a/test/specs/type.js
+++ b/test/specs/type.js
@@ -23,8 +23,11 @@ test('get type from commits', (t) => {
     tt.plan(1)
 
     type({
-      commits: [],
-      lastRelease: {},
+      commits: [{
+        hash: '0',
+        message: 'a'
+      }],
+      lastRelease: {version: '1.0.0'},
       plugins: {analyzeCommits: (config, cb) => cb(null, null)}
     }, (err) => {
       tt.is(err.code, 'ENOCHANGE')
@@ -35,7 +38,10 @@ test('get type from commits', (t) => {
     tt.plan(2)
 
     type({
-      commits: [],
+      commits: [{
+        hash: '0',
+        message: 'a'
+      }],
       lastRelease: {},
       plugins: {analyzeCommits: (config, cb) => cb(null, 'major')}
     }, (err, type) => {


### PR DESCRIPTION
Support the new commit-analyzer API. With the new API, we call the plugin once
for each commit, and keep track of the changes ourselfs.
This also adds support for the 'rskip' release type, which skips the release.

This revealed a major problem with the pre.js unit tests (test/specs/pre.js),
child process was not actually being mocked, and was simply returning an empty
array. With the old system, the mocked commit-analyzer was still called and
could still trigger a release (this is actually a flaw with the whole system.
With the new system, this is no longer true, so the unit tests fail. I did not
fix this both because it's not related to this branch/pull request, and because
it would mean a major revamp, which I would need to think about more. (this
means that travis will fail).

Fixes #41
Refs semantic-release/commit-analyzer#1, semantic-release/commit-analyzer#2
BREAKING CHANGE:
	The commit-analyzer is now called multiple times, and with a single commit
	(passed in as `commit`, vs `commits` as an array). The plugin also no longer
	has to deal with keeping track of the release type between commits.