### PR TITLE
gitlab support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,9 +71,11 @@ npmconf.load({}, (err, conf) => {
     log.verbose('pre', 'Running pre-script.')
     log.verbose('pre', 'Veriying conditions.')
 
-    plugins.verifyConditions(config, (err) => {
-      if (err) {
-        log[options.debug ? 'warn' : 'error']('pre', err.message)
+    plugins.verifyConditions(config, (verifyConditionsErrors) => {
+      if (verifyConditionsErrors) {
+        // ensure errors are listed as array
+        verifyConditionsErrors = [].concat(verifyConditionsErrors);
+        verifyConditionsErrors.forEach((err) => log[options.debug ? 'warn' : 'error']('pre', err.message))
         if (!options.debug) process.exit(1)
       }
 

--- a/src/lib/plugin-verify-github.js
+++ b/src/lib/plugin-verify-github.js
@@ -1,0 +1,29 @@
+const parseSlug = require('parse-github-repo-url')
+
+const SemanticReleaseError = require('@semantic-release/error')
+
+module.exports = function (config, options, cb) {
+  const errors = []
+  const pkg = options.pkg
+
+  if (!pkg.repository || !pkg.repository.url) {
+    errors.push(new SemanticReleaseError(
+      'No "repository" found in package.json.',
+      'ENOPKGREPO'
+    ))
+  } else if (!parseSlug(pkg.repository.url)) {
+    errors.push(new SemanticReleaseError(
+      'The "repository" field in the package.json is malformed.',
+      'EMALFORMEDPKGREPO'
+    ))
+  }
+
+  if (!options.githubToken) {
+    errors.push(new SemanticReleaseError(
+      'No github token specified.',
+      'ENOGHTOKEN'
+    ))
+  }
+
+  cb(errors)
+}

--- a/src/lib/plugins.js
+++ b/src/lib/plugins.js
@@ -3,40 +3,55 @@ const series = require('run-series')
 
 let exports = module.exports = function (options) {
   var plugins = {
-    analyzeCommits: exports.normalize(options.analyzeCommits, '@semantic-release/commit-analyzer'),
-    generateNotes: exports.normalize(options.generateNotes, '@semantic-release/release-notes-generator'),
-    getLastRelease: exports.normalize(options.getLastRelease, '@semantic-release/last-release-npm')
+    analyzeCommits: exports.normalizeArray(options.analyzeCommits, '@semantic-release/commit-analyzer'),
+    generateNotes: exports.normalizeArray(options.generateNotes, '@semantic-release/release-notes-generator'),
+    getLastRelease: exports.normalizeArray(options.getLastRelease, '@semantic-release/last-release-npm'),
+    verifyConditions: exports.normalizeArray(options.verifyConditions, ['./plugin-verify-github', '@semantic-release/condition-travis']),
+    verifyRelease: exports.normalizeArray(options.verifyRelease, exports.noopPlugin)
   }
+  return plugins
+}
 
-  ;['verifyConditions', 'verifyRelease'].forEach((plugin) => {
-    if (!Array.isArray(options[plugin])) {
-      plugins[plugin] = exports.normalize(
-        options[plugin],
-        plugin === 'verifyConditions' ?
-          '@semantic-release/condition-travis' :
-          './plugin-noop'
-      )
-      return
+function loadPlugin(name) {
+  try {
+    return require(name)
+  }
+  catch(err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      return relative(name)
     }
+    else {
+      throw err
+    }
+  }
+}
 
-    plugins[plugin] = function (pluginOptions, cb) {
-      var tasks = options[plugin].map((step) => {
-        return exports.normalize(step, './plugin-noop').bind(null, pluginOptions)
+exports.noopPlugin = './plugin-noop';
+
+exports.normalizeArray = function(pluginConfig, fallback) {
+  if(Array.isArray(pluginConfig)) {
+
+    return function (pluginOptions, cb) {
+      var tasks = pluginConfig.map((step) => {
+        return exports.normalize(step, exports.noopPlugin).bind(null, pluginConfig)
       })
 
       series(tasks, cb)
     }
-  })
+  }
+  else if (typeof pluginConfig === 'string' || (pluginConfig && (typeof pluginConfig.path === 'string'))) {
+    return exports.normalize(pluginConfig, fallback)
+  }
 
-  return plugins
+  return exports.normalizeArray(fallback, exports.noopPlugin)
 }
 
 exports.normalize = function (pluginConfig, fallback) {
-  if (typeof pluginConfig === 'string') return relative(pluginConfig).bind(null, {})
+  if (typeof pluginConfig === 'string') return loadPlugin(pluginConfig).bind(null, {})
 
   if (pluginConfig && (typeof pluginConfig.path === 'string')) {
-    return relative(pluginConfig.path).bind(null, pluginConfig)
+    return loadPlugin(pluginConfig.path).bind(null, pluginConfig)
   }
 
-  return require(fallback).bind(null, pluginConfig)
+  return loadPlugin(fallback).bind(null, pluginConfig)
 }

--- a/src/lib/verify.js
+++ b/src/lib/verify.js
@@ -1,9 +1,7 @@
-const parseSlug = require('parse-github-repo-url')
-
 const SemanticReleaseError = require('@semantic-release/error')
 
 module.exports = function ({pkg, options, env}) {
-  let errors = []
+  const errors = []
 
   if (!pkg.name) {
     errors.push(new SemanticReleaseError(
@@ -12,26 +10,8 @@ module.exports = function ({pkg, options, env}) {
     ))
   }
 
-  if (!pkg.repository || !pkg.repository.url) {
-    errors.push(new SemanticReleaseError(
-      'No "repository" found in package.json.',
-      'ENOPKGREPO'
-    ))
-  } else if (!parseSlug(pkg.repository.url)) {
-    errors.push(new SemanticReleaseError(
-      'The "repository" field in the package.json is malformed.',
-      'EMALFORMEDPKGREPO'
-    ))
-  }
-
+  // only go on if basic validation reports no problems
   if (options.debug) return errors
-
-  if (!options.githubToken) {
-    errors.push(new SemanticReleaseError(
-      'No github token specified.',
-      'ENOGHTOKEN'
-    ))
-  }
 
   if (!(env.NPM_TOKEN || (env.NPM_OLD_TOKEN && env.NPM_EMAIL))) {
     errors.push(new SemanticReleaseError(

--- a/test/specs/plugin-verify-github.js
+++ b/test/specs/plugin-verify-github.js
@@ -1,0 +1,35 @@
+const { test } = require('tap')
+const SRError = require('@semantic-release/error')
+const verify = require('../../dist/lib/plugin-verify-github')
+
+test('raise errors if github configuration is missing or malformed', (t) => {
+
+  t.test('malformed package repo', (tt) => {
+    verify({}, {pkg:{}, githubToken: 'validToken'}, (err) => {
+
+      tt.is(err.length, 1)
+      tt.is(err[0].code, 'ENOPKGREPO')
+    })
+
+    verify({}, {pkg:{repository: {url:'malformedurl'}}, githubToken: 'validToken'}, (err) => {
+
+      tt.is(err.length, 1)
+      tt.is(err[0].code, 'EMALFORMEDPKGREPO')
+    })
+  })
+
+  t.test('missing github token', (tt) => {
+    verify({}, {pkg:{repository: {url: 'http://github.com/whats/up.git'}}}, (err) => {
+
+      tt.is(err.length, 1)
+      tt.is(err[0].code, 'ENOGHTOKEN')
+    })
+  })
+
+  t.test('no errors', (tt) => {
+    verify({}, {pkg:{repository: {url: 'http://github.com/whats/up.git'}}, githubToken: 'validToken'}, (err) => {
+
+      tt.is(err.length, 0)
+    })
+  })
+})

--- a/test/specs/verify.js
+++ b/test/specs/verify.js
@@ -7,10 +7,7 @@ test('verify pkg, options and env', (t) => {
     const noErrors = verify({
       options: {debug: true},
       pkg: {
-        name: 'package',
-        repository: {
-          url: 'http://github.com/whats/up.git'
-        }
+        name: 'package'
       }
     })
 
@@ -21,22 +18,8 @@ test('verify pkg, options and env', (t) => {
       pkg: {}
     })
 
-    tt.is(errors.length, 2)
+    tt.is(errors.length, 1)
     tt.is(errors[0].code, 'ENOPKGNAME')
-    tt.is(errors[1].code, 'ENOPKGREPO')
-
-    const errors2 = verify({
-      options: {debug: true},
-      pkg: {
-        name: 'package',
-        repository: {
-          url: 'lol'
-        }
-      }
-    })
-
-    tt.is(errors2.length, 1)
-    tt.is(errors2[0].code, 'EMALFORMEDPKGREPO')
 
     tt.end()
   })
@@ -57,11 +40,9 @@ test('verify pkg, options and env', (t) => {
 
     const errors = verify({env: {}, options: {}, pkg: {}})
 
-    tt.is(errors.length, 4)
+    tt.is(errors.length, 2)
     tt.is(errors[0].code, 'ENOPKGNAME')
-    tt.is(errors[1].code, 'ENOPKGREPO')
-    tt.is(errors[2].code, 'ENOGHTOKEN')
-    tt.is(errors[3].code, 'ENONPMTOKEN')
+    tt.is(errors[1].code, 'ENONPMTOKEN')
 
     tt.end()
   })


### PR DESCRIPTION
Provide support for gitlab based repositories. To enable the support the github based verification checks are refactord into own verificationConditions plugin. Also the plugin mechanism is modified a little so that all plugin hooks can be specified with array notation.

The configuration for gitlab scenarios is as follows:
package.json
{
 "release": {
    "debug": false,
    "verifyConditions": "semantic-release/dist/lib/plugin-noop"
  },
  scripts: {
    "semantic-release": "semantic-release pre && npm publish"
  }
}