### PR TITLE
feat(post): add prerelease option for GitHub releases

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -29,6 +29,7 @@ module.exports = function (config, cb) {
         tag_name: `v${pkg.version}`,
         target_commitish: hash,
         draft: !!options.debug,
+        prerelease: !!options.prerelease,
         body: log
       }
 


### PR DESCRIPTION
Tag a release as "pre-release" on GitHub releases