### PR TITLE
Updated proxyquire to version 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nock": "2.13.0",
     "npm-registry-couchapp": "^2.6.11",
     "nyc": "3.2.1",
-    "proxyquire": "1.7.1",
+    "proxyquire": "1.7.3",
     "rimraf": "2.4.2",
     "standard": "5.3.0",
     "tap": "1.4.0"


### PR DESCRIPTION
:rocket:

proxyquire just published version 1.7.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 4 commits (ahead by 4, behind by 0).

- [0a91f0e](https://github.com/thlorenz/proxyquire/commit/0a91f0e5cc4d9df2c8ba5f97f90d77d69e898f37): 1.7.3
- [07a4d0f](https://github.com/thlorenz/proxyquire/commit/07a4d0f518d8bf9dc1353a1b615ffeb03fef6109): Update fill-keys to latest to handle prototype-less fns
- [2f6f006](https://github.com/thlorenz/proxyquire/commit/2f6f0066b4a4783aadbb5eacd7c529c695fca808): 1.7.2
- [9d78c2f](https://github.com/thlorenz/proxyquire/commit/9d78c2f7df5329fc0112d5a4f4c3d417010f7cb3): Added missed single quote in code block

See the [full diff](https://github.com/thlorenz/proxyquire/compare/bc5b1db96858e8ee158bc3c845cfef3ec4651ec0...0a91f0e5cc4d9df2c8ba5f97f90d77d69e898f37).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>