### PR TITLE
Run Travis tests under Node.js v4 (argon) and v5 (latest)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
 notifications:
   email: false
 node_js:
+- v5
+- v4
 - iojs-v2
 - iojs-v1
 - '0.12'


### PR DESCRIPTION
This PR adds Node.js v4 (LTS version `argon`) and v5 (latest stable version) to the tested Node.js versions.