### PR TITLE
feat(gitlab): added support for parsing hosted gitlab repo urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "path": "node_modules/cz-conventional-changelog/"
   },
   "dependencies": {
+    "@bahmutov/parse-github-repo-url": "^0.1.0",
     "@semantic-release/commit-analyzer": "^2.0.0",
     "@semantic-release/condition-travis": "^5.0.0",
     "@semantic-release/error": "^1.0.0",
@@ -26,7 +27,6 @@
     "normalize-package-data": "^2.3.4",
     "npmconf": "^2.1.2",
     "npmlog": "^2.0.0",
-    "parse-github-repo-url": "^1.0.0",
     "require-relative": "^0.8.7",
     "run-auto": "^1.1.2",
     "run-series": "^1.1.3",

--- a/src/lib/verify.js
+++ b/src/lib/verify.js
@@ -1,4 +1,4 @@
-var parseSlug = require('parse-github-repo-url')
+var parseSlug = require('@bahmutov/parse-github-repo-url')
 
 var SemanticReleaseError = require('@semantic-release/error')
 

--- a/src/post.js
+++ b/src/post.js
@@ -2,7 +2,7 @@ var url = require('url')
 
 var gitHead = require('git-head')
 var GitHubApi = require('github')
-var parseSlug = require('parse-github-repo-url')
+var parseSlug = require('@bahmutov/parse-github-repo-url')
 
 module.exports = function (config, cb) {
   var pkg = config.pkg

--- a/test/specs/verify.js
+++ b/test/specs/verify.js
@@ -41,6 +41,22 @@ test('verify pkg, options and env', function (t) {
     tt.end()
   })
 
+  t.test('dry run verification for gitlab repo', function (tt) {
+    var noErrors = verify({
+      options: {debug: true},
+      pkg: {
+        name: 'package',
+        repository: {
+          url: 'http://gitlab.corp.com/whats/up.git'
+        }
+      }
+    })
+
+    console.log(noErrors)
+    tt.is(noErrors.length, 0)
+    tt.end()
+  })
+
   t.test('publish verification', function (tt) {
     var noErrors = verify({
       env: {NPM_TOKEN: 'yo'},


### PR DESCRIPTION
Replaced parse github url with updated version with more git cases supported, including gitlab domains.
Might be a good complement when/before/after https://github.com/semantic-release/semantic-release/pull/77 lands