### PR TITLE
feat(post): Adds GitHub Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ These options are currently available:
 - `debug`: If true doesn’t actually publish to npm or write things to file. Default: `!process.env.CI`
 - `githubToken`: The token used to authenticate with GitHub. Default: `process.env.GH_TOKEN`
 - `githubUrl`: Optional. Pass your GitHub Enterprise endpoint.
+- `githubApiPathPrefix`: Optional. The path prefix for your GitHub Enterprise API.
 
 _A few notes on `npm` config_:
 1. The `npm` token can only be defined in the environment as `NPM_TOKEN`, because that’s where `npm` itself is going to read it from.

--- a/src/lib/verify.js
+++ b/src/lib/verify.js
@@ -1,5 +1,3 @@
-var parseSlug = require('@bahmutov/parse-github-repo-url')
-
 var SemanticReleaseError = require('@semantic-release/error')
 
 module.exports = function (config) {
@@ -19,11 +17,6 @@ module.exports = function (config) {
     errors.push(new SemanticReleaseError(
       'No "repository" found in package.json.',
       'ENOPKGREPO'
-    ))
-  } else if (!parseSlug(pkg.repository.url)) {
-    errors.push(new SemanticReleaseError(
-      'The "repository" field in the package.json is malformed.',
-      'EMALFORMEDPKGREPO'
     ))
   }
 

--- a/src/post.js
+++ b/src/post.js
@@ -14,7 +14,8 @@ module.exports = function (config, cb) {
     version: '3.0.0',
     port: ghConfig.port,
     protocol: (ghConfig.protocol || '').split(':')[0] || null,
-    host: ghConfig.hostname
+    host: ghConfig.hostname,
+    pathPrefix: options.githubApiPathPrefix || null
   })
 
   plugins.generateNotes(config, function (err, log) {

--- a/test/specs/verify.js
+++ b/test/specs/verify.js
@@ -25,19 +25,6 @@ test('verify pkg, options and env', function (t) {
     tt.is(errors[0].code, 'ENOPKGNAME')
     tt.is(errors[1].code, 'ENOPKGREPO')
 
-    var errors2 = verify({
-      options: {debug: true},
-      pkg: {
-        name: 'package',
-        repository: {
-          url: 'lol'
-        }
-      }
-    })
-
-    tt.is(errors2.length, 1)
-    tt.is(errors2[0].code, 'EMALFORMEDPKGREPO')
-
     tt.end()
   })
 


### PR DESCRIPTION
- Adds GitHub enterprise support by adding a `githubApiPathPrefix` option to the configuration to be passed to `node-github`, given that Enterprise APIs have a `/api/v3/` prefix.
- Removes checking of the repository URL in `package.json` as per @boennemann's suggestion in #146 to allow for custom git URLs

Tested with both GitHub and GitHub Enterprise. 

closes #146