### PR TITLE
Make config verification a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ This plugin is responsible for determining the type of the next release. It addi
 
 This plugin is responsible for generating release notes. Call the callback with the notes as a string. Have a look at the [default implementation](https://github.com/semantic-release/release-notes-generator/).
 
+### `verifyConfig`
+
+This plugins is responsible for verifying that the environment contains all the necessary configuration. By default it checks that `package.json` contains a `name` and `repository`. It also checks that
+a GitHub token is provided as weel as a npm one.
+
 ### `verifyConditions`
 
 This plugins is responsible for verifying that a release should happen in the first place. For example, the [default implementation](https://github.com/semantic-release/condition-travis/) verifies that the publish is happening on Travis, that it’s the right branch, and that all other build jobs succeeded. There are more use cases for this, e.g. verifying that test coverage is above a certain threshold or that there are no [vulnerabilities](https://nodesecurity.io/) in your dependencies. Be creative.

--- a/src/lib/plugins.js
+++ b/src/lib/plugins.js
@@ -5,7 +5,8 @@ var exports = module.exports = function (options) {
   var plugins = {
     analyzeCommits: exports.normalize(options.analyzeCommits, '@semantic-release/commit-analyzer'),
     generateNotes: exports.normalize(options.generateNotes, '@semantic-release/release-notes-generator'),
-    getLastRelease: exports.normalize(options.getLastRelease, '@semantic-release/last-release-npm')
+    getLastRelease: exports.normalize(options.getLastRelease, '@semantic-release/last-release-npm'),
+    verifyConfig: exports.normalize(options.verifyConfig, './verify.js')
   }
 
   ;['verifyConditions', 'verifyRelease'].forEach(function (plugin) {

--- a/src/lib/verify.js
+++ b/src/lib/verify.js
@@ -1,6 +1,6 @@
 var SemanticReleaseError = require('@semantic-release/error')
 
-module.exports = function (config) {
+module.exports = function (pluginConfig, config, cb) {
   var pkg = config.pkg
   var options = config.options
   var env = config.env
@@ -20,7 +20,7 @@ module.exports = function (config) {
     ))
   }
 
-  if (options.debug) return errors
+  if (options.debug) return cb(errors)
 
   if (!options.githubToken) {
     errors.push(new SemanticReleaseError(
@@ -36,5 +36,5 @@ module.exports = function (config) {
     ))
   }
 
-  return errors
+  return cb(errors)
 }

--- a/test/registry/local.ini
+++ b/test/registry/local.ini
@@ -2,6 +2,7 @@
 database_dir = data
 view_index_dir = data
 delayed_commits = false
+uuid = 815aaabe2c29644b57bcae504ec04d1c
 
 [couch_httpd_auth]
 public_fields = appdotnet, avatar, avatarMedium, avatarLarge, date, email, fields, freenode, fullname, github, homepage, name, roles, twitter, type, _id, _rev

--- a/test/specs/plugins.js
+++ b/test/specs/plugins.js
@@ -3,7 +3,7 @@ var test = require('tap').test
 var plugins = require('../../src/lib/plugins')
 
 test('export plugins', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   var defaultPlugins = plugins({})
 
@@ -12,6 +12,7 @@ test('export plugins', function (t) {
   t.is(typeof defaultPlugins.verifyConditions, 'function')
   t.is(typeof defaultPlugins.verifyRelease, 'function')
   t.is(typeof defaultPlugins.getLastRelease, 'function')
+  t.is(typeof defaultPlugins.verifyConfig, 'function')
 })
 
 test('plugin pipelines', function (t) {

--- a/test/specs/verify.js
+++ b/test/specs/verify.js
@@ -3,8 +3,12 @@ var test = require('tap').test
 var verify = require('../../src/lib/verify')
 
 test('verify pkg, options and env', function (t) {
+  t.plan(3)
+
   t.test('dry run verification', function (tt) {
-    var noErrors = verify({
+    tt.plan(4)
+
+    verify(null, {
       options: {debug: true},
       pkg: {
         name: 'package',
@@ -12,24 +16,24 @@ test('verify pkg, options and env', function (t) {
           url: 'http://github.com/whats/up.git'
         }
       }
+    }, function (noErrors) {
+      tt.is(noErrors.length, 0)
     })
 
-    tt.is(noErrors.length, 0)
-
-    var errors = verify({
+    verify(null, {
       options: {debug: true},
       pkg: {}
+    }, function (errors) {
+      tt.is(errors.length, 2)
+      tt.is(errors[0].code, 'ENOPKGNAME')
+      tt.is(errors[1].code, 'ENOPKGREPO')
     })
-
-    tt.is(errors.length, 2)
-    tt.is(errors[0].code, 'ENOPKGNAME')
-    tt.is(errors[1].code, 'ENOPKGREPO')
-
-    tt.end()
   })
 
   t.test('dry run verification for gitlab repo', function (tt) {
-    var noErrors = verify({
+    tt.plan(1)
+
+    verify(null, {
       options: {debug: true},
       pkg: {
         name: 'package',
@@ -37,15 +41,15 @@ test('verify pkg, options and env', function (t) {
           url: 'http://gitlab.corp.com/whats/up.git'
         }
       }
+    }, function (noErrors) {
+      tt.is(noErrors.length, 0)
     })
-
-    console.log(noErrors)
-    tt.is(noErrors.length, 0)
-    tt.end()
   })
 
   t.test('publish verification', function (tt) {
-    var noErrors = verify({
+    tt.plan(6)
+
+    verify(null, {
       env: {NPM_TOKEN: 'yo'},
       options: {githubToken: 'sup'},
       pkg: {
@@ -54,20 +58,16 @@ test('verify pkg, options and env', function (t) {
           url: 'http://github.com/whats/up.git'
         }
       }
+    }, function (noErrors) {
+      tt.is(noErrors.length, 0)
     })
 
-    tt.is(noErrors.length, 0)
-
-    var errors = verify({env: {}, options: {}, pkg: {}})
-
-    tt.is(errors.length, 4)
-    tt.is(errors[0].code, 'ENOPKGNAME')
-    tt.is(errors[1].code, 'ENOPKGREPO')
-    tt.is(errors[2].code, 'ENOGHTOKEN')
-    tt.is(errors[3].code, 'ENONPMTOKEN')
-
-    tt.end()
+    verify(null, {env: {}, options: {}, pkg: {}}, function (errors) {
+      tt.is(errors.length, 4)
+      tt.is(errors[0].code, 'ENOPKGNAME')
+      tt.is(errors[1].code, 'ENOPKGREPO')
+      tt.is(errors[2].code, 'ENOGHTOKEN')
+      tt.is(errors[3].code, 'ENONPMTOKEN')
+    })
   })
-
-  t.end()
 })


### PR DESCRIPTION
At the moment, `semantic-release` is very package oriented. Using it for end-of-the-chain app release, which don't get released on npm, isn't really possible.

In our scenario, we just run `semantic-release pre && npm semantic-release post` in order to tag and create a release Github release of the app.

The main blocker is the hard check on npm token config.

While this check is valuable when actually running `npm publish`, it's useless if we omit that step.

That PR makes it so what was in `verify.js` is now used as the `verifyConfig` plugin. I had to make asynchronous and respect regular plugin signature.

That will allow use to write our custom `verifyConfig` that doesn't check for `npm token`.

I hope this is clear enough, please shoot questions!
