### PR TITLE
Fix link to explanation of commit message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ _Note:_ The current release/tag implementation is tied to GitHub, but could be o
 This module ships with the [AngularJS Commit Message Conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) and changelog generator, but you can [define your own](#plugins) style.
 
 Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
-format that includes a **type**, a **scope** and a **subject** ([full explanation](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md)):
+format that includes a **type**, a **scope** and a **subject** ([full explanation](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)):
 
 ```
 <type>(<scope>): <subject>


### PR DESCRIPTION
The conventions have been split off in ajoslin/conventional-changelog@48580b039197f45574f309b1c2ade18c17c2933b

One could also link to the pinned version, https://github.com/stevemao/conventional-changelog-angular/blob/f07464cd7577e3c0aab9d400e9ca8da219603bba/convention.md