### PR TITLE
docs(README.md): discourage use of pre-patch, pre-minor and pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,11 @@ module.exports = function (pluginConfig, config, callback) {}
 
 ### `analyzeCommits`
 
-This plugin is responsible for determining the type of the next release. It additionally receives a `commits` array inside `config`. One commit is an object with a `message` and `hash` property. Call the callback with `'major'`, `'premajor'`, `'minor'`, `'preminor'`, `'patch'`, `'prepatch'`, `'prerelease'`, or `null` if nothing changed. Have a look at the [default implementation](https://github.com/semantic-release/commit-analyzer/).
+This plugin is responsible for determining the type of the next release. It additionally receives a `commits` array inside `config`. One commit is an object with a `message` and `hash` property. Call the callback with `'major'`, `'premajor'`, `'minor'`, `'preminor'`, `'patch'`, `'prepatch'`, `'prerelease'`, or `null` if nothing changed. 
+
+While it may be tempting to use `'prepatch'`, `'preminor'` & `'prerelease'` as part of a release process, this is strongly discouraged. A better approach is to use [dist-tags](https://docs.npmjs.com/cli/dist-tag) to create release channels (such as 'latest', 'next', 'stable') and to return only `'major'`, `'premajor'` and `'minor'` from the commit analyzer.
+
+Have a look at the [default implementation](https://github.com/semantic-release/commit-analyzer/).
 
 ### `generateNotes`
 


### PR DESCRIPTION
In my initial use of semantic-release, I spent a considerable amount of time mucking about and trying to determine how to best make use of 'pre' tags, only to later realize that I shouldn't be trying to use them at all (and that dist-tags are a better fit for a CI/CD process).

I hope that, by explicitly discouraging their use, future users can avoid accidentally going down the same path.
