### PR TITLE
Expose cafile from npm config

### DIFF
--- a/bin/semantic-release.js
+++ b/bin/semantic-release.js
@@ -52,6 +52,7 @@ npmconf.load({}, function (err, conf) {
     auth: {
       token: env.NPM_TOKEN
     },
+    cafile: conf.get('cafile'),
     loglevel: conf.get('loglevel'),
     registry: require('../src/lib/get-registry')(pkg, conf),
     tag: (pkg.publishConfig || {}).tag || conf.get('tag') || 'latest'


### PR DESCRIPTION
Exposing this allows semantic-release to be used in environments with self-signed certificates.  See also: https://github.com/semantic-release/last-release-npm/pull/75