### PR TITLE
fix(commits): Use `--no-color` for `git branch`-command

### DIFF
--- a/src/lib/commits.js
+++ b/src/lib/commits.js
@@ -13,7 +13,7 @@ module.exports = function (config, cb) {
 
   if (!from) return extract()
 
-  exec('git branch --contains ' + from, function (err, stdout) {
+  exec('git branch --no-color --contains ' + from, function (err, stdout) {
     var inHistory = false
     var branches
 


### PR DESCRIPTION
Running `semantic-release` fails locally if/when `git branch` produces colored output. This PR simply adds `--no-color` to the executed command. With this fix I get the next version correctly, while previously I would get an `ENOTINHISTORY`-error, since the check does not anticipate color codes in the branch names.

| Before | After |
| ------ | ----- |
| ![1____project_stylizr__bash_](https://cloud.githubusercontent.com/assets/463105/20482660/11cb543e-afee-11e6-8dbc-29e3de3df66e.jpg) | ![1____project_stylizr__bash_](https://cloud.githubusercontent.com/assets/463105/20482649/08b5807c-afee-11e6-8cbe-17675be80b66.jpg) |