### PR TITLE
fix: use spawn instead of exec for 'git log' to avoid maxBuffer err

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "coveralls": "^2.11.4",
     "cz-conventional-changelog": "^1.1.4",
     "mkdirp": "^0.5.1",
+    "mock-spawn": "^0.2.6",
     "nixt": "^0.5.0",
     "nock": "^8.0.0",
     "npm-registry-couchapp": "^2.6.11",

--- a/test/mocks/child-process.js
+++ b/test/mocks/child-process.js
@@ -1,3 +1,15 @@
+var mockSpawn = require('mock-spawn')()
+mockSpawn.setStrategy(function (command, args, opts) {
+  return function (cb) {
+    this.stdout.write(
+      /\.\.HEAD/.test(args.join(' '))
+        ? rawCommits[0]
+        : rawCommits.join()
+    )
+    cb(0)
+  }
+})
+
 const rawCommits = [
   'hash-one==SPLIT==commit-one==END==\n',
   'hash-two==SPLIT==commit-two==END==\n'
@@ -12,13 +24,7 @@ module.exports = {
       if (/notinhistory/.test(command)) return cb(new Error())
       return cb(null, 'whatever\nmaster\n')
     }
-
-    cb(
-      null,
-      /\.\.HEAD/.test(command)
-        ? rawCommits[0]
-        : rawCommits.join()
-    )
   },
+  spawn: mockSpawn,
   '@noCallThru': true
 }


### PR DESCRIPTION
Related to https://github.com/semantic-release/semantic-release/issues/286

Uses `child_process.spawn` instead of `child_process.exec`, as `exec` has a fixed `maxBuffer`.

Only converted `git log` to use the new `spawn` method to reduce PR complexity and `git log` seems like the main culprit for `maxBuffer` errors.