### PR TITLE
Get "## commits to master since this release" working

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -43,10 +43,22 @@ module.exports = function (config, cb) {
         token: options.githubToken
       })
 
-      github.repos.createRelease(release, function (err) {
+      github.repos.createRelease(release, function (err, res) {
         if (err) return cb(err)
+        if (options.debug) return cb(null, true, release)
 
-        cb(null, true, release)
+        var editingRelease = {
+          owner: ghRepo[0],
+          repo: ghRepo[1],
+          id: res.id,
+          target_commitish: options.branch
+        }
+
+        github.repos.editRelease(editingRelease, function (err) {
+          if (err) return cb(err)
+
+          cb(null, true, release)
+        })
       })
     })
   })

--- a/test/mocks/github.js
+++ b/test/mocks/github.js
@@ -5,6 +5,9 @@ module.exports = function () {
     },
     repos: {
       createRelease: function (release, cb) {
+        cb(null, {id: 1})
+      },
+      editRelease: function (release, cb) {
         cb(null)
       }
     }

--- a/test/mocks/github.js
+++ b/test/mocks/github.js
@@ -3,11 +3,13 @@ module.exports = function () {
     authenticate: function () {
       return true
     },
+    gitdata: {
+      createReference: function (release, cb) {
+        cb(null)
+      }
+    },
     repos: {
       createRelease: function (release, cb) {
-        cb(null, {id: 1})
-      },
-      editRelease: function (release, cb) {
         cb(null)
       }
     }

--- a/test/specs/post.js
+++ b/test/specs/post.js
@@ -23,14 +23,14 @@ var defaultRelease = {
   repo: 'up',
   name: 'v1.0.0',
   tag_name: 'v1.0.0',
-  target_commitish: 'bar',
+  target_commitish: 'master',
   body: 'the log'
 }
 
 test('full post run', function (t) {
   t.test('in debug mode w/o token', function (tt) {
     post({
-      options: {debug: true},
+      options: {debug: true, branch: 'master'},
       pkg: pkg,
       plugins: plugins
     }, function (err, published, release) {
@@ -44,7 +44,7 @@ test('full post run', function (t) {
 
   t.test('in debug mode w/token', function (tt) {
     post({
-      options: {debug: true, githubToken: 'yo'},
+      options: {debug: true, githubToken: 'yo', branch: 'master'},
       pkg: pkg,
       plugins: plugins
     }, function (err, published, release) {
@@ -58,7 +58,7 @@ test('full post run', function (t) {
 
   t.test('production', function (tt) {
     post({
-      options: {githubToken: 'yo'},
+      options: {githubToken: 'yo', branch: 'master'},
       pkg: pkg,
       plugins: plugins
     }, function (err, published, release) {


### PR DESCRIPTION
GitHub Releases has an awesome feature that shows how many commits are created since the release.
Example: [github/hub releases](https://github.com/github/hub/releases)

![hub 2016-11-30 01-36-23](https://cloud.githubusercontent.com/assets/1067855/20718877/874f39e0-b69d-11e6-95c2-b365b8f35ae3.png)

However, the project which uses semantic-release seems to not to have this awesomeness.
Example: [semantic-release/semantic-release releases](https://github.com/semantic-release/semantic-release/releases)

![semantic-release 2016-11-30 01-37-55](https://cloud.githubusercontent.com/assets/1067855/20719097/44d9cff2-b69e-11e6-825b-e4c1f3a04e91.png)

## Description

`target_commitish` in GitHub Releases has two different meanings:
* Target commit that a new associated tag will be created on
* Target branch to compute how many "commits to since this release"

`target_commitish` is usually the default branch (aka `master`), because the
distance between the release and the latest branch is the primary concern.

Before this change, `target_commitish` was left to be a hash and the
feature of GitHub Releases that shows how much time passed since the
release is ruined, because no tracking branch is given.

By this change, `target_commitish` is changed to be the default branch
given in the configuration (`options.branch`) via edit a release API after
the release and tag are created via crate a release API.