### PR TITLE
Update commitizen config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "bugs": {
     "url": "https://github.com/semantic-release/semantic-release/issues"
   },
-  "czConfig": {
-    "path": "node_modules/cz-conventional-changelog/"
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   },
   "dependencies": {
     "@semantic-release/commit-analyzer": "^3.0.1",


### PR DESCRIPTION
Use of `czConfig` is deprecated, now it's `config.commitizen`
Docs state as well that (since recently?) they support lookup in `node_modules`.

[Relevant `commitizen` docs](https://github.com/commitizen/cz-cli#commitizen-for-project-maintainers)
