### PR TITLE
Fix 'home' link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bin",
     "src"
   ],
-  "homepage": "https://github.com/semantic-release/semantic-release/tree/next#readme",
+  "homepage": "https://github.com/semantic-release/semantic-release#readme",
   "keywords": [
     "author",
     "automation",


### PR DESCRIPTION
I noticed your (hilarious) branch names! And also that the `home` link is old and points to a non-existent branch. ✨