### PR TITLE
Add create-npmrc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ These options are currently available:
 - `branch`: The branch on which releases should happen. Default: `'master'`
 - `debug`: If true doesn’t actually publish to npm or write things to file. Default: `!process.env.CI`
 - `githubToken`: The token used to authenticate with GitHub. Default: `process.env.GH_TOKEN`
+- `createNpmrc`: If true, it will create a `.npmrc` file at the project level using the NPM credentials. Default: `true`
 - `githubUrl`: Optional. Pass your GitHub Enterprise endpoint.
 - `githubApiPathPrefix`: Optional. The path prefix for your GitHub Enterprise API.
 
@@ -254,7 +255,7 @@ Of course you can, but this doesn’t necessarily mean you should. Running your 
 
 ### Can I manually trigger the release of a specific version?
 
-You can trigger a release by pushing to your GitHub repository. You deliberately cannot trigger a _specific_ version release, because this is the whole point of `semantic-release`. Start your packages with `1.0.0` and semver on.  
+You can trigger a release by pushing to your GitHub repository. You deliberately cannot trigger a _specific_ version release, because this is the whole point of `semantic-release`. Start your packages with `1.0.0` and semver on.
 
 ### Is it _really_ a good idea to release on every push?
 

--- a/src/lib/define-version.js
+++ b/src/lib/define-version.js
@@ -1,0 +1,40 @@
+var log = require('npmlog')
+var fs = require('fs')
+var _ = require('lodash')
+
+module.exports = function (config, options, originalPkg, npm) {
+  require('../pre')(config, function (err, release) {
+    if (err) {
+      log.error('pre', 'Failed to determine new version.')
+
+      var args = ['pre', (err.code ? err.code + ' ' : '') + err.message]
+      if (err.stack) args.push(err.stack)
+      log.error.apply(log, args)
+      process.exit(1)
+    }
+
+    var message = 'Determined version ' + release.version + ' as "' + npm.tag + '".'
+
+    log.verbose('pre', message)
+
+    if (options.debug) {
+      log.error('pre', message + ' Not publishing in debug mode.', release)
+      process.exit(1)
+    }
+
+    try {
+      var shrinkwrap = JSON.parse(fs.readFileSync('./npm-shrinkwrap.json'))
+      shrinkwrap.version = release.version
+      fs.writeFileSync('./npm-shrinkwrap.json', JSON.stringify(shrinkwrap, null, 2))
+      log.verbose('pre', 'Wrote version ' + release.version + 'to npm-shrinkwrap.json.')
+    } catch (e) {
+      log.silly('pre', 'Couldn\'t find npm-shrinkwrap.json.')
+    }
+
+    fs.writeFileSync('./package.json', JSON.stringify(_.assign(originalPkg, {
+      version: release.version
+    }), null, 2))
+
+    log.verbose('pre', 'Wrote version ' + release.version + ' to package.json.')
+  })
+}

--- a/src/lib/verify.js
+++ b/src/lib/verify.js
@@ -29,6 +29,8 @@ module.exports = function (config) {
     ))
   }
 
+  if (options.createNpmrc === false) return errors
+
   if (!(env.NPM_TOKEN || (env.NPM_OLD_TOKEN && env.NPM_EMAIL))) {
     errors.push(new SemanticReleaseError(
       'No npm token specified.',

--- a/test/specs/verify.js
+++ b/test/specs/verify.js
@@ -58,13 +58,20 @@ test('verify pkg, options and env', function (t) {
 
     tt.is(noErrors.length, 0)
 
-    var errors = verify({env: {}, options: {}, pkg: {}})
+    var allErrors = verify({env: {}, options: {}, pkg: {}})
 
-    tt.is(errors.length, 4)
-    tt.is(errors[0].code, 'ENOPKGNAME')
-    tt.is(errors[1].code, 'ENOPKGREPO')
-    tt.is(errors[2].code, 'ENOGHTOKEN')
-    tt.is(errors[3].code, 'ENONPMTOKEN')
+    tt.is(allErrors.length, 4)
+    tt.is(allErrors[0].code, 'ENOPKGNAME')
+    tt.is(allErrors[1].code, 'ENOPKGREPO')
+    tt.is(allErrors[2].code, 'ENOGHTOKEN')
+    tt.is(allErrors[3].code, 'ENONPMTOKEN')
+
+    var allButNpmTokenErrors = verify({env: {}, options: { createNpmrc: false }, pkg: {}})
+
+    tt.is(allButNpmTokenErrors.length, 3)
+    tt.is(allButNpmTokenErrors[0].code, 'ENOPKGNAME')
+    tt.is(allButNpmTokenErrors[1].code, 'ENOPKGREPO')
+    tt.is(allButNpmTokenErrors[2].code, 'ENOGHTOKEN')
 
     tt.end()
   })


### PR DESCRIPTION
While trying to integrate `semantic-release` with [Jenkins Multibranch Pipeline](https://jenkins.io/blog/2015/12/03/pipeline-as-code-with-multibranch-workflows-in-jenkins/), we noticed that the script always tries to create the **.npmrc** file before publishing. In our scenario, we already have a **.npmrc** file in place since we publish our libraries to our internal npm private registry (and thus we need this file to run `npm install`). The current implementation is trying to overwrite this file, something we want to avoid.

This PR adds a new option for `semantic-release` to skip the creation of the **.npmrc** file during the `pre` command. 

## Usage

***via cli***
```bash
semantic-release pre --no-create-npmrc && npm publish && semantic-release post
```

**via package.json**
```js
"release": {
  "createNpmrc": false,
  ...
}
```

## Implementation details

* Added new `options.createNpmrc` config, set to `true` by default (see [here](https://github.com/nanovazquez/semantic-release/blob/7b025f6993186b3277cac53438f47eed1faf210a/bin/semantic-release.js#L21)).
* If this value is explicitly set to `false`, we skip the creation of the **.npmrc** file (see [here](https://github.com/nanovazquez/semantic-release/blob/7b025f6993186b3277cac53438f47eed1faf210a/bin/semantic-release.js#L102)).
* A [lib/define-version.js](https://github.com/nanovazquez/semantic-release/blob/7b025f6993186b3277cac53438f47eed1faf210a/src/lib/define-version.js) file was created to extract the logic that defines the version to publish. 
It was copied _as is_ to avoid extra noise in this PR, but there are some improvement opportunities that could be considered that would also require a bigger refactor of the original code (like moving all the logging logic back to the [bin/semantic-release.js](https://github.com/nanovazquez/semantic-release/blob/7b025f6993186b3277cac53438f47eed1faf210a/bin/semantic-release.js) file).
* Updated [verify.js](https://github.com/nanovazquez/semantic-release/blob/7b025f6993186b3277cac53438f47eed1faf210a/src/lib/verify.js) to skip the validation of the **NPM_TOKEN** environment variable if `options.createNpmrc` is set to `false` (it's not needed in the flow).