### PR TITLE
Populate gitHead, and use Git tag if it's not there

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ var log = require('npmlog')
 var nopt = require('nopt')
 var npmconf = require('npmconf')
 var normalizeData = require('normalize-package-data')
+var gitHead = require('git-head')
 
 log.heading = 'semantic-release'
 var env = process.env
@@ -138,11 +139,21 @@ npmconf.load({}, function (err, conf) {
             log.silly('pre', 'Couldn\'t find npm-shrinkwrap.json.')
           }
 
-          fs.writeFileSync('./package.json', JSON.stringify(_.assign(originalPkg, {
-            version: release.version
-          }), null, 2))
+          gitHead(function (err, hash) {
+            var add = {
+              version: release.version
+            }
+            var msg = 'Wrote version ' + release.version
+            if (err) {
+              log.error("Couldn't determine gitHead", hash, err)
+            } else {
+              add.gitHead = hash
+              msg += ', gitHead ' + add.gitHead
+            }
+            fs.writeFileSync('./package.json', JSON.stringify(_.assign(originalPkg, add), null, 2))
 
-          log.verbose('pre', 'Wrote version ' + release.version + ' to package.json.')
+            log.verbose('pre', msg + ' to package.json.')
+          })
         })
       })
     })

--- a/src/lib/commits.js
+++ b/src/lib/commits.js
@@ -11,8 +11,14 @@ module.exports = function (config, cb) {
   var from = lastRelease.gitHead
   if (!from) {
     from = config.lastRelease.version ? 'v' + config.lastRelease.version : false
-    console.warn('NPM registry does not contain "gitHead" in latest package version data. It\'s probably because ' +
-      'the publish happened outside of repository folder. Will try last version\'s Git tag instead: "' + from + '"')
+    var msg = 'NPM registry does not contain "gitHead" in latest package version data. It\'s probably because ' +
+      'the publish happened outside of repository folder.'
+    if (from) {
+      msg = msg + ' Will try last version\'s Git tag instead: "' + from + '".'
+    } else {
+      msg = msg + ' Using all the commits history to HEAD then.'
+    }
+    log.warn(msg)
   }
   var range = (from ? from + '..' : '') + 'HEAD'
 

--- a/src/lib/commits.js
+++ b/src/lib/commits.js
@@ -9,6 +9,11 @@ module.exports = function (config, cb) {
   var options = config.options
   var branch = options.branch
   var from = lastRelease.gitHead
+  if (!from) {
+    from = config.lastRelease.version ? 'v' + config.lastRelease.version : false
+    console.warn('NPM registry does not contain "gitHead" in latest package version data. It\'s probably because ' +
+      'the publish happened outside of repository folder. Will try last version\'s Git tag instead: "' + from + '"')
+  }
   var range = (from ? from + '..' : '') + 'HEAD'
 
   if (!from) return extract()


### PR DESCRIPTION
This PR does 2 things:
* let `semantic-release pre` pre-write gitHead property together with version
* if `semantic-release pre` sees that the last released version doesn't have gitHead property, try to use the relevant vX.Y.Z git tag

NPM package's gitHead property is some undocumented thing, not a part of NPM contract (see e.g. npm/npm#3363) and they mostly write it on publish but sometimes not. One non-trivial case I found is after I've split `semantic-release pre && npm publish && semantic-release post` pre-set command to 2 separate CircleCI commands:
```
- semantic-release pre
# ... smth else
- npm publish && semantic-release post
```
In case CircleCI command starts with `npm publish` it doesn't write gitHead to published package.json even if it runs from proper git repo dir - maybe because CircleCI runs each comand in a new shell session. I reproduced it with NPM 3.10.8 on CircleCI (Ubuntu 14.04) but couln't reproduce on MacOS - maybe shell-dependent.


fixes #280 (Warn user about nonexistent gitHead returned by npm-registry-client)