### PR TITLE
feat(commits): check remote branches to determine relevant history

### DIFF
--- a/src/lib/commits.js
+++ b/src/lib/commits.js
@@ -13,14 +13,14 @@ module.exports = function (config, cb) {
 
   if (!from) return extract()
 
-  childProcess.exec('git branch --no-color --contains ' + from, function (err, stdout) {
+  childProcess.exec('git branch --no-color --remote --contains ' + from, function (err, stdout) {
     var inHistory = false
     var branches
 
     if (!err && stdout) {
       branches = stdout.split('\n')
       .map(function (result) {
-        if (branch === result.replace('*', '').trim()) {
+        if (branch === result.replace('*', '').replace('origin/', '').trim()) {
           inHistory = true
           return null
         }


### PR DESCRIPTION
Depending on how the git repository got initialized on a CI system there
might occur issues when not
checking remote branches for the `from` commit.

For example Bitrise initializes it's git repositories as follows:
```
git "init"
git "remote" "add" "origin"
"git@github.com:zetaron/condition-bitrise.git"
git "fetch"
git "checkout" "52ab116ffe04c0f03e24e566b861cc1bde70024b"
git "submodule" "update" "--init" "--recursive"
```

This results in semantic-release being unable to detect which branch
contains the '52ab116ffe04c0f03e24e566b861cc1bde70024b' commit, as git
is in a detatched HEAD mode.
There will be no release as semantic-release breaks with a message just
like the following:
```
$ semantic-release pre && npm publish && semantic-release post
semantic-release ERR! commits The commit the last release of this
package was derived from is not in the direct history of the "master"
branch.
semantic-release ERR! commits This means semantic-release can not
extract the commits between now and then.
semantic-release ERR! commits This is usually caused by force pushing,
releasing from an unrelated branch, or using an already existing package
name.
semantic-release ERR! commits You can recover from this error by
publishing manually or restoring the commit
"52ab116ffe04c0f03e24e566b861cc1bde70024b".
semantic-release ERR! commits Here is a list of branches that still
contain the commit in question:
semantic-release ERR! commits  * * (HEAD detached at 52ab116)
semantic-release ERR! pre Failed to determine new version.
semantic-release ERR! pre ENOTINHISTORY Commit not in history
error Command failed with exit code 1.
```

This commit introduces a small change to the comamnd used to detect the
commits branch, by adding the `--remote` option and normalizing remote
branch names to be matchable against the `options.branch` (eg. master)