### PR TITLE
fix(post): create git tag properly

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -27,7 +27,7 @@ module.exports = function (config, cb) {
       var tag = {
         owner: ghRepo[0],
         repo: ghRepo[1],
-        ref: 'refs/heads/v' + pkg.version,
+        ref: 'refs/tags/v' + pkg.version,
         sha: hash
       }
       var release = {


### PR DESCRIPTION
Fixes #415, introduced in #335.

I checked any branches will not be created in the following sandbox repository.
https://github.com/umireon/semantic-release-sandbox-target-committish/releases/tag/v1.0.13