### PR TITLE
docs: fix grammatical error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ feat(pencil): add 'graphiteWidth' option
 ```
 perf(pencil): remove graphiteWidth option
 
-BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reason.
+BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reasons.
 ```
 
 ## Setup


### PR DESCRIPTION
Just a small fix to make this sentence parse.