### PR TITLE
Update commit lint suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ format that includes a **type**, a **scope** and a **subject** ([full explanatio
 <footer>
 ```
 
-You can simplify using this convention for yourself and contributors by using [commitizen](https://github.com/commitizen/cz-cli) and [validate-commit-msg](https://github.com/kentcdodds/validate-commit-msg) or [semantic-git-commit-cli](https://github.com/JPeer264/node-semantic-git-commit-cli).
+You can simplify using this convention for yourself and contributors by using [commitizen](https://github.com/commitizen/cz-cli) and [commitlint](https://github.com/marionebl/commitlint) or [semantic-git-commit-cli](https://github.com/JPeer264/node-semantic-git-commit-cli).
 
 ### Patch Release
 


### PR DESCRIPTION
[validate-commit-msg](https://github.com/kentcdodds/validate-commit-msg) is deprecated, and points to [commitlint](https://github.com/marionebl/commitlint).