### PR TITLE
feat: support custom release tag in GitHub

### DIFF
--- a/test/mocks/github.js
+++ b/test/mocks/github.js
@@ -6,6 +6,12 @@ module.exports = function () {
     gitdata: {
       createReference: function (release, cb) {
         cb(null)
+      },
+      getReference: function (reference, cb) {
+        cb(null)
+      },
+      deleteReference: function (reference, cb) {
+        cb(null)
       }
     },
     repos: {

--- a/test/specs/post.js
+++ b/test/specs/post.js
@@ -12,6 +12,14 @@ var pkg = {
   repository: {url: 'http://github.com/whats/up.git'}
 }
 
+var customTagPkg = {
+  version: '1.0.0',
+  repository: {url: 'http://github.com/whats/up.git'},
+  publishConfig: {
+    tag: 'beta'
+  }
+}
+
 var plugins = {
   generateNotes: function (pkg, cb) {
     cb(null, 'the log')
@@ -66,6 +74,19 @@ test('full post run', function (t) {
       tt.is(published, true)
       tt.match(release, defaultRelease)
 
+      tt.end()
+    })
+  })
+
+  t.test('production with custom tag', function (tt) {
+    post({
+      options: {githubToken: 'yo', branch: 'master'},
+      pkg: customTagPkg,
+      plugins: plugins
+    }, function (err, published, release) {
+      tt.error(err)
+      tt.is(published, true)
+      tt.match(release, defaultRelease)
       tt.end()
     })
   })


### PR DESCRIPTION
It's just a simple change, but as mentioned in https://github.com/semantic-release/semantic-release/issues/97, this PR should make GitHub releases use a custom tag whenever defined - just as it happens with npm release.

Does it need anything else? @gr2m said something about resetting the tag. I wonder if that's really needed. 

I have noticed the tests (even before the changes) fail though. Seems to be an issue in plugins?
```
test/specs/plugins.js ................................. 4/8
  export plugins
  not ok Unexpected token function
```
