### PR TITLE
fix: Remove loglevel notice error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3009,7 +3009,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
         "are-we-there-yet": "1.1.4",
         "console-control-strings": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nopt": "^4.0.0",
     "normalize-package-data": "^2.3.4",
     "npmconf": "^2.1.2",
-    "npmlog": "^4.0.0",
+    "npmlog": "^4.1.2",
     "parse-github-repo-url": "^1.3.0",
     "require-relative": "^0.8.7",
     "run-auto": "^2.0.0",


### PR DESCRIPTION
`notice` was added as a loglevl in 4.1.0 (See https://github.com/npm/npmlog/commit/77b3b95c3474afdc164eae9caa80749452d42300). Here, I up the `npmlog` version to stop an error I've been getting. Should close #430, but I don't know how to test that.