### PR TITLE
fix: handle missing gitHead issue

### DIFF
--- a/src/lib/commits.js
+++ b/src/lib/commits.js
@@ -9,6 +9,11 @@ module.exports = function (config, cb) {
   var options = config.options
   var branch = options.branch
   var from = lastRelease.gitHead
+  if (!from) {
+    from = config.lastRelease.version ? 'v' + config.lastRelease.version : false
+    console.warn('NPM registry does not contain "gitHead" in latest package version data. It\'s probably because ' +
+      'the publish happened outside of repository folder. Will try last version\'s Git tag instead: "' + from + '"')
+  }
   var range = (from ? from + '..' : '') + 'HEAD'
 
   if (!from) return extract()


### PR DESCRIPTION
This PR does two things:
* logs a warning if gitHead is missing in published version of package.json
* tries to use git tag from last version if it was published

See the [demo](https://circleci.com/gh/artemv/semantic-test/32): 
![2017-09-27_0126](https://user-images.githubusercontent.com/11217/30887220-184ce344-a323-11e7-9f92-6c8247559670.png)


fixes https://github.com/semantic-release/semantic-release/issues/280 (Warn user about nonexistent gitHead returned by npm-registry-client)

re https://github.com/semantic-release/semantic-release/issues/256 (Bump minor version when not needed)