### PR TITLE
Set default branch in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: caribou


### PR DESCRIPTION
Codecove should determine the default branch based on Github config but it doesn't seems to work.
Set in codecov.yml until it's fixed