### PR TITLE
Allow custom plugins when running globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "fs-extra": "^4.0.2",
     "git-head": "^1.2.1",
     "github": "^11.0.0",
+    "import-from": "^2.1.0",
     "lodash": "^4.0.0",
     "nerf-dart": "^1.0.0",
     "nopt": "^4.0.0",
@@ -32,7 +33,6 @@
     "npmlog": "^4.0.0",
     "p-series": "^1.0.0",
     "parse-github-repo-url": "^1.3.0",
-    "require-relative": "^0.8.7",
     "semver": "^5.4.1"
   },
   "devDependencies": {

--- a/src/lib/plugins.js
+++ b/src/lib/plugins.js
@@ -1,5 +1,5 @@
 const {promisify} = require('util');
-const relative = require('require-relative');
+const importFrom = require('import-from');
 const pSeries = require('p-series');
 
 module.exports = options => {
@@ -30,13 +30,17 @@ module.exports = options => {
 };
 
 const normalize = (pluginConfig, fallback) => {
-  if (typeof pluginConfig === 'string') return relative(pluginConfig).bind(null, {});
+  if (typeof pluginConfig === 'string') return importPlugin(pluginConfig).bind(null, {});
 
   if (pluginConfig && typeof pluginConfig.path === 'string') {
-    return relative(pluginConfig.path).bind(null, pluginConfig);
+    return importPlugin(pluginConfig.path).bind(null, pluginConfig);
   }
 
   return require(fallback).bind(null, pluginConfig || {});
 };
+
+function importPlugin(path) {
+  return importFrom.silent(__dirname, path) || importFrom(process.cwd(), path);
+}
 
 module.exports.normalize = normalize;


### PR DESCRIPTION
Previously the plugins were imported relatively to `process.cwd()`.
If a custom plugin is defined in `package.json` via a globally installed npm package it would fails even when `semantic-release` is installed and ran globally.

This PR allow to load plugin:
- As an npm packaged depended on in `package.json` when run locally or globally
- A `.js` file, referenced relatively to the root of the repo, when run locally or globally
- A globally installed npm package when run globally

`semantic-release` can now be installed and ran globally, along with globally installed custom plugins without having to be included as a dependency in the `package.json`. It might be convenient for a future Github app :)
