### PR TITLE
Handle errors when verifyConditions and verifyRelease are a pipeline

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ module.exports = async () => {
     log.verbose('pre', 'Running pre-script.');
     log.verbose('pre', 'Veriying conditions.');
     try {
-      await promisify(plugins.verifyConditions)(config);
+      await plugins.verifyConditions(config);
     } catch (err) {
       log[options.debug ? 'warn' : 'error']('pre', err.message);
       if (!options.debug) process.exit(1);

--- a/src/pre.js
+++ b/src/pre.js
@@ -17,7 +17,7 @@ module.exports = async config => {
     version: type === 'initial' ? '1.0.0' : semver.inc(lastRelease.version, type),
   };
 
-  await promisify(verifyRelease)(assign({commits, lastRelease, nextRelease}, config));
+  await verifyRelease(assign({commits, lastRelease, nextRelease}, config));
 
   return nextRelease;
 };

--- a/test/pre.test.js
+++ b/test/pre.test.js
@@ -44,7 +44,7 @@ test.serial('Increase version', async t => {
     plugins: {
       getLastRelease: callbackify(getLastRelease),
       analyzeCommits: callbackify(analyzeCommits),
-      verifyRelease: callbackify(verifyRelease),
+      verifyRelease: verifyRelease,
     },
   });
 
@@ -89,7 +89,7 @@ test.serial('Initial version', async t => {
     plugins: {
       getLastRelease: callbackify(getLastRelease),
       analyzeCommits: callbackify(analyzeCommits),
-      verifyRelease: callbackify(verifyRelease),
+      verifyRelease: verifyRelease,
     },
   });
 
@@ -137,7 +137,7 @@ test.serial('Throws error if verifyRelease fails', async t => {
       plugins: {
         getLastRelease: callbackify(getLastRelease),
         analyzeCommits: callbackify(analyzeCommits),
-        verifyRelease: callbackify(verifyRelease),
+        verifyRelease: verifyRelease,
       },
     })
   );


### PR DESCRIPTION
The plugin module for `verifyConditions` and `verifyRelease` was returning:
- A `Promise` returning function if multiple plugins are defined
- The plugin itself (a function with callback) when there is only one plugin in the chain

The rest of the code expected `verifyConditions` and `verifyRelease` to be a function with callback and was promisifying it.
If there was multiple plugins in the pipeline that that was resulting in promisifying a promise and the errors returned were not caught and node was warning with ` UnhandledPromiseRejectionWarning: Unhandled promise rejection`.

With this fix the plugin module always return a `Promise` returning function for `verifyConditions` and `verifyRelease` and the rest of the code doesn't promisify them anymore.

See #406