### PR TITLE
Add error messages for unknown rejections

### DIFF
--- a/bin/semantic-release.js
+++ b/bin/semantic-release.js
@@ -23,6 +23,8 @@ npx is bundled with npm >= 5.4, or available via npm. More info: npm.im/npx`
 }
 
 // node 8+ from this point on
-require('../src')().catch(() => {
+require('../src')().catch(err => {
+  console.error('An error occurred while running semantic-release');
+  console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
I found the CLI extremely hard to use when writing custom plugins, and debugging various access errors when running it on our internal CI servers instead of Travis.

I will therefore propose to output error information when unexpected errors (non `@semantic-release/error`) occur, instead of exiting silently.

For example:
```json
{
    "release": { "verifyConditions": "./some-non-existing-file" }
}
```
Caused me a lot of grief, and I could not figure out why nothing happened.