### PR TITLE
Log error properties and check SemanticReleaseError with name

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@semantic-release/commit-analyzer": "^3.0.1",
     "@semantic-release/condition-travis": "^6.0.0",
-    "@semantic-release/error": "^2.0.0",
+    "@semantic-release/error": "^2.1.0",
     "@semantic-release/last-release-npm": "^2.0.0",
     "@semantic-release/release-notes-generator": "^5.0.0",
     "chalk": "^2.3.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -52,7 +52,7 @@ module.exports = async () => {
       logger.log(`%s ${err.message}`, err.code);
     } else {
       process.exitCode = 1;
-      logger.error(err);
+      logger.error('An error occurred while running semantic-release: %O', err);
     }
   }
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,4 @@
 const program = require('commander');
-const SemanticReleaseError = require('@semantic-release/error');
 const logger = require('./lib/logger');
 
 function list(values) {
@@ -49,7 +48,7 @@ module.exports = async () => {
   } catch (err) {
     // If error is a SemanticReleaseError then it's an expected exception case (no release to be done, running on a PR etc..) and the cli will return with 0
     // Otherwise it's an unexpected error (configuration issue, code issue, plugin issue etc...) and the cli will return 1
-    if (err instanceof SemanticReleaseError) {
+    if (err.semanticRelease) {
       logger.log(`%s ${err.message}`, err.code);
     } else {
       process.exitCode = 1;

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -6,13 +6,18 @@ const chalk = require('chalk');
 module.exports = {
   log(...args) {
     const [format, ...rest] = args;
-    console.log(`${chalk.grey('[Semantic release]:')} ${format}`, ...rest.map(arg => chalk.magenta(arg)));
+    console.log(
+      `${chalk.grey('[Semantic release]:')}${typeof format === 'string'
+        ? ` ${format.replace(/%[^%]/g, seq => chalk.magenta(seq))}`
+        : ''}`,
+      ...(typeof format === 'string' ? [] : [format]).concat(rest)
+    );
   },
   error(...args) {
     const [format, ...rest] = args;
     console.error(
-      `${chalk.grey('[Semantic release]:')} ${chalk.red(format instanceof Error ? format.stack : format)}`,
-      ...rest.map(arg => chalk.red(arg instanceof Error ? arg.stack : arg))
+      `${chalk.grey('[Semantic release]:')}${typeof format === 'string' ? ` ${chalk.red(format)}` : ''}`,
+      ...(typeof format === 'string' ? [] : [format]).concat(rest)
     );
   },
 };

--- a/test/fixtures/plugin-error-a.js
+++ b/test/fixtures/plugin-error-a.js
@@ -1,3 +1,5 @@
 module.exports = function(config, options, cb) {
-  cb(new Error('a'));
+  const error = new Error('a');
+  error.errorProperty = 'errorProperty';
+  cb(error);
 };

--- a/test/fixtures/plugin-error-inherited.js
+++ b/test/fixtures/plugin-error-inherited.js
@@ -1,0 +1,14 @@
+const SemanticReleaseError = require('@semantic-release/error');
+
+class InheritedError extends SemanticReleaseError {
+  constructor(message, code, newProperty) {
+    super(message);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.code = code;
+  }
+}
+
+module.exports = function(config, options, cb) {
+  cb(new InheritedError('Inherited error', 'EINHERITED'));
+};

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -36,7 +36,6 @@ test.beforeEach(async t => {
 });
 
 test.afterEach.always(async t => {
-  console.log();
   // Restore process.env
   process.env = Object.assign({}, t.context.env);
   // Restore the current working directory

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -634,8 +634,12 @@ test.serial('Log unexpected errors from plugins and exit with 1', async t => {
   await gitCommits(['feat: Initial commit']);
   t.log('$ semantic-release');
   let {stderr, code} = await execa(cli, [], {env, reject: false});
+  // Verify the type and message are logged
   t.regex(stderr, /Error: a/);
+  // Verify the the stacktrace is logged
   t.regex(stderr, new RegExp(pluginError));
+  // Verify the Error properties are logged
+  t.regex(stderr, /errorProperty: 'errorProperty'/);
   t.is(code, 1);
 });
 

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {stub} from 'sinon';
+import {stub, match} from 'sinon';
 import logger from '../src/lib/logger';
 
 test.beforeEach(t => {
@@ -20,18 +20,29 @@ test.serial('Basic log', t => {
   t.true(t.context.error.calledWithMatch(/.*test error/));
 });
 
+test.serial('Log object', t => {
+  const obj = {a: 1, b: '2'};
+  logger.log(obj);
+  logger.error(obj);
+
+  t.true(t.context.log.calledWithMatch(match.string, obj));
+  t.true(t.context.error.calledWithMatch(match.string, obj));
+});
+
 test.serial('Log with string formatting', t => {
   logger.log('test log %s', 'log value');
   logger.error('test error %s', 'error value');
 
-  t.true(t.context.log.calledWithMatch(/.*test log %s/, 'log value'));
-  t.true(t.context.error.calledWithMatch(/.*test error %s/, 'error value'));
+  t.true(t.context.log.calledWithMatch(/.*test log/, 'log value'));
+  t.true(t.context.error.calledWithMatch(/.*test error/, 'error value'));
 });
 
-test.serial('Log with error stacktrace', t => {
-  logger.error(new Error('error message'));
-  logger.error('test error %s', new Error('other error message'));
+test.serial('Log with error stacktrace and properties', t => {
+  const error = new Error('error message');
+  logger.error(error);
+  const otherError = new Error('other error message');
+  logger.error('test error %O', otherError);
 
-  t.true(t.context.error.calledWithMatch(/.*test error %s/, /Error: other error message(\s|.)*?logger\.test\.js/));
-  t.true(t.context.error.calledWithMatch(/Error: error message(\s|.)*?logger\.test\.js/));
+  t.true(t.context.error.calledWithMatch(match.string, error));
+  t.true(t.context.error.calledWithMatch(/.*test error/, otherError));
 });

--- a/test/verify-pkg.test.js
+++ b/test/verify-pkg.test.js
@@ -2,12 +2,12 @@ import test from 'ava';
 import SemanticReleaseError from '@semantic-release/error';
 import verify from '../src/lib/verify-pkg';
 
-test.only('Verify name and repository', t => {
+test('Verify name and repository', t => {
   // Call the verify module with package
   t.notThrows(() => verify({name: 'package', repository: {url: 'http://github.com/whats/up.git'}}));
 });
 
-test.only('Return error for missing package name', t => {
+test('Return error for missing package name', t => {
   // Call the verify module with package
   const error = t.throws(() => verify({repository: {url: 'http://github.com/whats/up.git'}}));
   // Verify error code and type
@@ -15,7 +15,7 @@ test.only('Return error for missing package name', t => {
   t.true(error instanceof SemanticReleaseError);
 });
 
-test.only('Return error for missing repository', t => {
+test('Return error for missing repository', t => {
   // Call the verify module with package
   const error = t.throws(() => verify({name: 'package'}));
   // Verify error code and type
@@ -23,7 +23,7 @@ test.only('Return error for missing repository', t => {
   t.true(error instanceof SemanticReleaseError);
 });
 
-test.only('Return error for missing repository url', t => {
+test('Return error for missing repository url', t => {
   // Call the verify module with package
   const error = t.throws(() => verify({name: 'package', repository: {}}));
   // Verify error code and type


### PR DESCRIPTION
`semantic-release` now log all information included in unexpected errors.
In order to verify if an error is a `SemanticReleaseError` we now use the `name` property rather than the instance type. The test will work properly if a plugin use a different version of `@semantic-release/error` than `semantic-release`.

We should probably deprecate all version of `@semantic-release/error` < 2.0.1 as it contains a bug that prevent the name and stacktrace to be included. See https://github.com/semantic-release/error/pull/71.

See https://github.com/semantic-release/semantic-release/pull/480#pullrequestreview-72660167

cc /@felixfbecker