### PR TITLE
Use default plugin if the path property is missing from a single plugin configuration

### DIFF
--- a/lib/plugins/definitions.js
+++ b/lib/plugins/definitions.js
@@ -1,17 +1,12 @@
 const {isString, isObject, isFunction, isArray} = require('lodash');
 const semver = require('semver');
-const conditionTravis = require('@semantic-release/condition-travis');
-const commitAnalyzer = require('@semantic-release/commit-analyzer');
-const releaseNotesGenerator = require('@semantic-release/release-notes-generator');
-const npm = require('@semantic-release/npm');
-const github = require('@semantic-release/github');
 
 const RELEASE_TYPE = ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease'];
 const validatePluginConfig = conf => isString(conf) || isString(conf.path) || isFunction(conf);
 
 module.exports = {
   verifyConditions: {
-    default: [npm.verifyConditions, github.verifyConditions, conditionTravis],
+    default: ['@semantic-release/npm', '@semantic-release/github', '@semantic-release/condition-travis'],
     config: {
       validator: conf => !conf || (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
       message:
@@ -19,7 +14,7 @@ module.exports = {
     },
   },
   getLastRelease: {
-    default: npm.getLastRelease,
+    default: '@semantic-release/npm',
     config: {
       validator: conf => Boolean(conf) && validatePluginConfig(conf),
       message:
@@ -35,7 +30,7 @@ module.exports = {
     },
   },
   analyzeCommits: {
-    default: commitAnalyzer,
+    default: '@semantic-release/commit-analyzer',
     config: {
       validator: conf => Boolean(conf) && validatePluginConfig(conf),
       message:
@@ -55,7 +50,7 @@ module.exports = {
     },
   },
   generateNotes: {
-    default: releaseNotesGenerator,
+    default: '@semantic-release/release-notes-generator',
     config: {
       validator: conf => !conf || validatePluginConfig(conf),
       message:
@@ -67,7 +62,7 @@ module.exports = {
     },
   },
   publish: {
-    default: [npm.publish, github.publish],
+    default: ['@semantic-release/npm', '@semantic-release/github'],
     config: {
       validator: conf => Boolean(conf) && (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
       message:

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,4 +1,4 @@
-const {isArray} = require('lodash');
+const {isArray, isObject} = require('lodash');
 const DEFINITIONS = require('./definitions');
 const pipeline = require('./pipeline');
 const normalize = require('./normalize');
@@ -8,6 +8,10 @@ module.exports = (options, logger) =>
     const {config, output, default: def} = DEFINITIONS[pluginType];
     let pluginConfs;
     if (options[pluginType]) {
+      // If an object is passed and the path is missing, set the default one for single plugins
+      if (isObject(options[pluginType]) && !options[pluginType].path && !isArray(def)) {
+        options[pluginType].path = def;
+      }
       if (config && !config.validator(options[pluginType])) {
         throw new Error(config.message);
       }

--- a/test/plugins/plugins.test.js
+++ b/test/plugins/plugins.test.js
@@ -9,8 +9,8 @@ test.beforeEach(t => {
 });
 
 test('Export default plugins', t => {
-  // Call the plugin module
   const plugins = getPlugins({}, t.context.logger);
+
   // Verify the module returns a function for each plugin
   t.is(typeof plugins.verifyConditions, 'function');
   t.is(typeof plugins.getLastRelease, 'function');
@@ -21,7 +21,6 @@ test('Export default plugins', t => {
 });
 
 test('Export plugins based on config', t => {
-  // Call the plugin module
   const plugins = getPlugins(
     {
       verifyConditions: ['./test/fixtures/plugin-noop', {path: './test/fixtures/plugin-noop'}],
@@ -31,6 +30,7 @@ test('Export plugins based on config', t => {
     },
     t.context.logger
   );
+
   // Verify the module returns a function for each plugin
   t.is(typeof plugins.verifyConditions, 'function');
   t.is(typeof plugins.getLastRelease, 'function');
@@ -40,8 +40,26 @@ test('Export plugins based on config', t => {
   t.is(typeof plugins.publish, 'function');
 });
 
-test('Throw an error if plugin configuration is invalid', t => {
+test('Use default when only options are passed for a single plugin', t => {
+  const plugins = getPlugins({getLastRelease: {}, analyzeCommits: {}}, t.context.logger);
+
+  // Verify the module returns a function for each plugin
+  t.is(typeof plugins.getLastRelease, 'function');
+  t.is(typeof plugins.analyzeCommits, 'function');
+});
+
+test('Throw an error if plugin configuration is missing a path for plugin pipeline', t => {
   const error = t.throws(() => getPlugins({verifyConditions: {}}, t.context.logger));
+
+  t.is(
+    error.message,
+    'The "verifyConditions" plugin, if defined, must be a single or an array of plugins definition. A plugin definition is either a string or an object with a path property.'
+  );
+});
+
+test('Throw an error if an array of plugin configuration is missing a path for plugin pipeline', t => {
+  const error = t.throws(() => getPlugins({verifyConditions: [{path: '@semantic-release/npm'}, {}]}, t.context.logger));
+
   t.is(
     error.message,
     'The "verifyConditions" plugin, if defined, must be a single or an array of plugins definition. A plugin definition is either a string or an object with a path property.'


### PR DESCRIPTION
Fix regression introduced in #515

The configuration is now using the default plugin '@semantic-release/commit-analyzer' with passing a parameter instead of throwing an error.
```json
"release": {
  "analyzeCommits": {
    "param": "value"
  }
}
```