### PR TITLE
Make semantic-release language agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,6 @@ module.exports = function (pluginConfig, config, callback) {}
   - `options`: `semantic-release` options like `debug`, or `branch`
   - `pkg`: Parsed `package.json`
   - For certain plugins the `config` object contains even more information. See below.
-- `callback`: If an error occurs pass it as first argument. Otherwise pass your result as second argument.
-
 
 ### `analyzeCommits`
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ semantic-release
 
 These options are currently available:
 - `branch`: The branch on which releases should happen. Default: `'master'`
+- `repositoryUrl`: The git repository URL. Default: `repository` property in `package.json` or git origin url. Any valid git url format is supported (See [Git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols)). If the [Github plugin](https://github.com/semantic-release/github) is used the URL must be a valid Github URL that include the `owner`, the `repository` name and the `host`. The Github shorthand URL is not supported.
 - `dry-run`: Dry-run mode, skipping verifyConditions, publishing and release, printing next version and release notes
 - `debug`: Output debugging information
 
@@ -206,9 +207,7 @@ module.exports = function (pluginConfig, config, callback) {}
 
 - `pluginConfig`: If the user of your plugin specifies additional plugin config in the `package.json` (see the `verifyConditions` example above) then it’s this object.
 - `config`: A config object containing a lot of information to act upon.
-  - `env`: All environment variables
   - `options`: `semantic-release` options like `debug`, or `branch`
-  - `pkg`: Parsed `package.json`
   - For certain plugins the `config` object contains even more information. See below.
 
 ### `analyzeCommits`

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ module.exports = async () => {
     .name('semantic-release')
     .description('Run automated package publishing')
     .option('-b, --branch <branch>', 'Branch to release from')
+    .option('-r, --repositoryUrl <repositoryUrl>', 'Git repository URL')
     .option(
       '--verify-conditions <paths>',
       'Comma separated list of paths or packages name for the verifyConditions plugin(s)',
@@ -41,7 +42,7 @@ module.exports = async () => {
       program.outputHelp();
       process.exitCode = 1;
     } else {
-      await require('./index')(program.opts());
+      await require('.')(program.opts());
     }
   } catch (err) {
     // If error is a SemanticReleaseError then it's an expected exception case (no release to be done, running on a PR etc..) and the cli will return with 0

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,19 +1,27 @@
-const {readJson} = require('fs-extra');
+const readPkgUp = require('read-pkg-up');
 const {defaults} = require('lodash');
-const normalizeData = require('normalize-package-data');
+const cosmiconfig = require('cosmiconfig');
 const debug = require('debug')('semantic-release:config');
+const {repoUrl} = require('./git');
 const plugins = require('./plugins');
 
 module.exports = async (opts, logger) => {
-  const pkg = await readJson('./package.json');
-  normalizeData(pkg);
-  const options = defaults(opts, pkg.release, {branch: 'master'});
+  const {config} = (await cosmiconfig('release', {rcExtensions: true}).load(process.cwd())) || {};
+  const options = defaults(opts, config, {branch: 'master', repositoryUrl: (await pkgRepoUrl()) || (await repoUrl())});
+
+  debug('name: %O', options.name);
   debug('branch: %O', options.branch);
+  debug('repositoryUrl: %O', options.repositoryUrl);
   debug('analyzeCommits: %O', options.analyzeCommits);
   debug('generateNotes: %O', options.generateNotes);
   debug('verifyConditions: %O', options.verifyConditions);
   debug('verifyRelease: %O', options.verifyRelease);
   debug('publish: %O', options.publish);
 
-  return {env: process.env, pkg, options, plugins: await plugins(options, logger), logger};
+  return {options, plugins: await plugins(options, logger)};
 };
+
+async function pkgRepoUrl() {
+  const {pkg} = await readPkgUp();
+  return pkg && pkg.repository ? pkg.repository.url : null;
+}

--- a/lib/git.js
+++ b/lib/git.js
@@ -72,4 +72,20 @@ async function gitHead() {
   }
 }
 
-module.exports = {gitTagHead, gitCommitTag, isCommitInHistory, unshallow, gitHead};
+/**
+ * @return {string|null} The value of the remote git URL.
+ */
+async function repoUrl() {
+  return (await execa.stdout('git', ['remote', 'get-url', 'origin'], {reject: false})) || null;
+}
+
+/**
+ * @return {Boolean} `true` if the current working directory is in a git repository, `false` otherwise.
+ */
+async function isGitRepo() {
+  const shell = await execa('git', ['rev-parse', '--git-dir'], {reject: false});
+  debugShell('Check if the current working directory is a git repository', shell, debug);
+  return shell.code === 0;
+}
+
+module.exports = {gitTagHead, gitCommitTag, isCommitInHistory, unshallow, gitHead, repoUrl, isGitRepo};

--- a/lib/plugins/normalize.js
+++ b/lib/plugins/normalize.js
@@ -1,4 +1,4 @@
-const {promisify, inspect} = require('util');
+const {inspect} = require('util');
 const {isString, isObject, isFunction, noop, cloneDeep} = require('lodash');
 const importFrom = require('import-from');
 
@@ -14,9 +14,9 @@ module.exports = (pluginType, pluginConfig, logger, validator) => {
 
   let func;
   if (isFunction(plugin)) {
-    func = promisify(plugin.bind(null, cloneDeep(config)));
+    func = plugin.bind(null, cloneDeep(config));
   } else if (isObject(plugin) && plugin[pluginType] && isFunction(plugin[pluginType])) {
-    func = promisify(plugin[pluginType].bind(null, cloneDeep(config)));
+    func = plugin[pluginType].bind(null, cloneDeep(config));
   } else {
     throw new Error(
       `The ${pluginType} plugin must be a function, or an object with a function in the property ${pluginType}.`

--- a/package.json
+++ b/package.json
@@ -15,25 +15,25 @@
     }
   },
   "dependencies": {
-    "@semantic-release/commit-analyzer": "^4.0.0",
-    "@semantic-release/condition-travis": "^6.0.0",
+    "@semantic-release/commit-analyzer": "^5.0.0",
+    "@semantic-release/condition-travis": "^7.0.0",
     "@semantic-release/error": "^2.1.0",
-    "@semantic-release/github": "^1.0.0",
-    "@semantic-release/npm": "^1.0.0",
-    "@semantic-release/release-notes-generator": "^5.0.0",
+    "@semantic-release/github": "^2.0.0",
+    "@semantic-release/npm": "^2.0.0",
+    "@semantic-release/release-notes-generator": "^6.0.0",
     "chalk": "^2.3.0",
     "commander": "^2.11.0",
+    "cosmiconfig": "^3.1.0",
     "debug": "^3.1.0",
     "execa": "^0.8.0",
-    "fs-extra": "^4.0.2",
     "get-stream": "^3.0.0",
     "git-log-parser": "^1.2.0",
     "import-from": "^2.1.0",
     "lodash": "^4.0.0",
     "marked": "^0.3.6",
     "marked-terminal": "^2.0.0",
-    "normalize-package-data": "^2.3.4",
     "p-reduce": "^1.0.0",
+    "read-pkg-up": "^3.0.0",
     "semver": "^5.4.1"
   },
   "devDependencies": {
@@ -44,11 +44,13 @@
     "dockerode": "^2.5.2",
     "eslint-config-prettier": "^2.5.0",
     "eslint-plugin-prettier": "^2.3.0",
+    "file-url": "^2.0.2",
+    "fs-extra": "^4.0.2",
+    "js-yaml": "^3.10.0",
     "mockserver-client": "^2.0.0",
     "nock": "^9.0.2",
     "npm-registry-couchapp": "^2.6.12",
     "nyc": "^11.2.1",
-    "p-map-series": "^1.0.0",
     "prettier": "~1.8.0",
     "proxyquire": "^1.8.0",
     "sinon": "^4.0.0",
@@ -124,7 +126,8 @@
       "prettier"
     ],
     "rules": {
-      "prettier/prettier": 2
+      "prettier/prettier": 2,
+      "no-duplicate-imports": 2
     }
   }
 }

--- a/test/fixtures/multi-plugin.js
+++ b/test/fixtures/multi-plugin.js
@@ -1,21 +1,8 @@
 module.exports = {
-  verifyConditions(config, options, cb) {
-    cb();
-  },
-
-  getLastRelease(config, options, cb) {
-    cb();
-  },
-  analyzeCommits(config, options, cb) {
-    cb();
-  },
-  verifyRelease(config, options, cb) {
-    cb();
-  },
-  generateNotes(config, options, cb) {
-    cb();
-  },
-  publish(config, options, cb) {
-    cb();
-  },
+  verifyConditions: () => {},
+  getLastRelease: () => {},
+  analyzeCommits: () => {},
+  verifyRelease: () => {},
+  generateNotes: () => {},
+  publish: () => {},
 };

--- a/test/fixtures/plugin-error-inherited.js
+++ b/test/fixtures/plugin-error-inherited.js
@@ -9,6 +9,6 @@ class InheritedError extends SemanticReleaseError {
   }
 }
 
-module.exports = function(config, options, cb) {
-  cb(new InheritedError('Inherited error', 'EINHERITED'));
+module.exports = () => {
+  throw new InheritedError('Inherited error', 'EINHERITED');
 };

--- a/test/fixtures/plugin-error.js
+++ b/test/fixtures/plugin-error.js
@@ -1,5 +1,5 @@
-module.exports = function(config, options, cb) {
+module.exports = () => {
   const error = new Error('a');
   error.errorProperty = 'errorProperty';
-  cb(error);
+  throw error;
 };

--- a/test/fixtures/plugin-noop.js
+++ b/test/fixtures/plugin-noop.js
@@ -1,3 +1,1 @@
-module.exports = (config, options, cb) => {
-  cb(null);
-};
+module.exports = () => {};

--- a/test/fixtures/plugin-result-config.js
+++ b/test/fixtures/plugin-result-config.js
@@ -1,3 +1,1 @@
-module.exports = function(pluginConfig, options, cb) {
-  cb(null, {pluginConfig, options});
-};
+module.exports = (pluginConfig, options) => ({pluginConfig, options});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,3 @@
-import {callbackify} from 'util';
 import test from 'ava';
 import {writeJson} from 'fs-extra';
 import proxyquire from 'proxyquire';
@@ -57,12 +56,12 @@ test.serial('Plugins are called with expected values', async t => {
 
   const options = {
     branch: 'master',
-    verifyConditions: [callbackify(verifyConditions1), callbackify(verifyConditions2)],
-    getLastRelease: callbackify(getLastRelease),
-    analyzeCommits: callbackify(analyzeCommits),
-    verifyRelease: callbackify(verifyRelease),
-    generateNotes: callbackify(generateNotes),
-    publish: callbackify(publish),
+    verifyConditions: [verifyConditions1, verifyConditions2],
+    getLastRelease,
+    analyzeCommits,
+    verifyRelease,
+    generateNotes,
+    publish,
   };
   const pkg = {name, version: '0.0.0-dev'};
   normalizeData(pkg);
@@ -140,12 +139,12 @@ test.serial('Use new gitHead, and recreate release notes if a publish plugin cre
 
   const options = {
     branch: 'master',
-    verifyConditions: callbackify(stub().resolves()),
-    getLastRelease: callbackify(stub().resolves(lastRelease)),
-    analyzeCommits: callbackify(stub().resolves(nextRelease.type)),
-    verifyRelease: callbackify(stub().resolves()),
-    generateNotes: callbackify(generateNotes),
-    publish: [callbackify(publish1), callbackify(publish2)],
+    verifyConditions: stub().resolves(),
+    getLastRelease: stub().resolves(lastRelease),
+    analyzeCommits: stub().resolves(nextRelease.type),
+    verifyRelease: stub().resolves(),
+    generateNotes,
+    publish: [publish1, publish2],
   };
 
   await writeJson('./package.json', {});
@@ -188,12 +187,12 @@ test.serial('Dry-run skips verifyConditions and publish', async t => {
   const options = {
     dryRun: true,
     branch: 'master',
-    verifyConditions: callbackify(verifyConditions),
-    getLastRelease: callbackify(getLastRelease),
-    analyzeCommits: callbackify(analyzeCommits),
-    verifyRelease: callbackify(verifyRelease),
-    generateNotes: callbackify(generateNotes),
-    publish: callbackify(publish),
+    verifyConditions,
+    getLastRelease,
+    analyzeCommits,
+    verifyRelease,
+    generateNotes,
+    publish,
   };
   const pkg = {name, version: '0.0.0-dev'};
   normalizeData(pkg);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -7,7 +7,7 @@ import registry from './helpers/registry';
 import mockServer from './helpers/mockserver';
 import semanticRelease from '..';
 
-/* eslint-disable camelcase */
+/* eslint camelcase: ["error", {properties: "never"}] */
 
 // Environment variables used with cli
 const env = {

--- a/test/plugins/normalize.test.js
+++ b/test/plugins/normalize.test.js
@@ -1,4 +1,3 @@
-import {callbackify} from 'util';
 import test from 'ava';
 import {noop} from 'lodash';
 import {stub, match} from 'sinon';
@@ -39,7 +38,7 @@ test('Normalize and load plugin that retuns multiple functions', t => {
 
 test('Wrap plugin in a function that validate the output of the plugin', async t => {
   const pluginFunction = stub().resolves(1);
-  const plugin = normalize('', callbackify(pluginFunction), t.context.logger, {
+  const plugin = normalize('', pluginFunction, t.context.logger, {
     validator: output => output === 1,
     message: 'The output must be 1',
   });
@@ -53,7 +52,7 @@ test('Wrap plugin in a function that validate the output of the plugin', async t
 
 test('Plugin is called with "pluginConfig" (omitting "path") and input', async t => {
   const pluginFunction = stub().resolves();
-  const conf = {path: callbackify(pluginFunction), conf: 'confValue'};
+  const conf = {path: pluginFunction, conf: 'confValue'};
   const plugin = normalize('', conf, t.context.logger);
   await plugin('param');
 
@@ -61,9 +60,8 @@ test('Plugin is called with "pluginConfig" (omitting "path") and input', async t
 });
 
 test('Prevent plugins to modify "pluginConfig"', async t => {
-  const pluginFunction = stub().callsFake((pluginConfig, options, cb) => {
+  const pluginFunction = stub().callsFake(pluginConfig => {
     pluginConfig.conf.subConf = 'otherConf';
-    cb();
   });
   const conf = {path: pluginFunction, conf: {subConf: 'originalConf'}};
   const plugin = normalize('', conf, t.context.logger);
@@ -73,9 +71,8 @@ test('Prevent plugins to modify "pluginConfig"', async t => {
 });
 
 test('Prevent plugins to modify its input', async t => {
-  const pluginFunction = stub().callsFake((pluginConfig, options, cb) => {
+  const pluginFunction = stub().callsFake((pluginConfig, options) => {
     options.param.subParam = 'otherParam';
-    cb();
   });
   const input = {param: {subParam: 'originalSubParam'}};
   const plugin = normalize('', pluginFunction, t.context.logger);


### PR DESCRIPTION
The last language specific thing `semantic-release` relies on is the `package.json`.
This PR remove this reliance by allowing to configure `semantic-release` with rc files in addition of the current `release` property in the `package.json`.

This way, with the proper plugins, `semantic-release` can release any type of project.
We should now recommend to install `semantic-release` globally:
```
npm install semantic-release -g
semantic-release
```
or with `npx`
```
npx semantic-release
```
or in Unix based CI:
```
if [[ `node -v | egrep -o '[0-9|\.]+'` > 8* ]]; then npm install semantic-release -g && semantic-release; fi
```

Here is the list of changes:
- Do not rely on `package.json` anymore
- Use `cosmiconfig` to load the configation. `semantic-release` can be configured:
  - via CLI options (including plugin names but not plugin options)
  - in the `release` property of `package.json` (as before)
  - in a `.releaserc.yml` or `.releaserc.js` or `.releaserc.js` or `release.config.js` file
  - in a `.releaserc` file containing `json`, `yaml` or `javascript` module
- Add the `repositoryUrl` options (used across `semantic-release` and plugins). The value is determined from CLi option, or option configuration, or package.json or the git remote url
- Verifies that `semantic-release` runs from a git repository
- `pkg` and `env` are not passed to plugin anymore
- `semantic-release` can be run both locally and globally. If ran globally with non default plugins, the plugins can be installed both globally or locally.

In addition with PR `semantic-release` now expect plugin to provide an async or `Promise` returning function rather than a function with a callback.

BREAKING CHANGE: `pkg` and `env` are not passed to plugin anymore.
Plugins relying on a `package.json` must verify the presence of a valid `package.json` and load it.
Plugins can use `process.env` instead of `env`.

BREAKING CHANGE: Each plugin is expected to return an async function or a Promise returning function. The callback parameter is not passed to plugins anymore.

This PR should be merged only after all the default plugin are updated. It currently uses the plugin directly from Github. So we'll have to change the `package.json` to point to the released version of the plugins.

Fix #526, Fix #527, Fix #528, Fix #529  