### PR TITLE
feat: extract `getCommits` into a plugin

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -14,6 +14,7 @@ module.exports = async (opts, logger) => {
   debug('repositoryUrl: %O', options.repositoryUrl);
   debug('analyzeCommits: %O', options.analyzeCommits);
   debug('generateNotes: %O', options.generateNotes);
+  debug('getCommits: %O', options.getCommits);
   debug('verifyConditions: %O', options.verifyConditions);
   debug('verifyRelease: %O', options.verifyRelease);
   debug('publish: %O', options.publish);

--- a/lib/plugins/definitions.js
+++ b/lib/plugins/definitions.js
@@ -29,6 +29,14 @@ module.exports = {
         'The "getLastRelease" plugin output if defined, must be an object with an optionnal valid semver version in the "version" property.',
     },
   },
+  getCommits: {
+    default: './get-commits.js',
+    config: {
+      validator: conf => Boolean(conf) && validatePluginConfig(conf),
+      message:
+        'The "getCommits" plugin is mandatory, and must be a single plugin definition. A plugin definition is either a string or an object with a path property.',
+    },
+  },
   analyzeCommits: {
     default: '@semantic-release/commit-analyzer',
     config: {

--- a/lib/plugins/get-commits.js
+++ b/lib/plugins/get-commits.js
@@ -1,0 +1,7 @@
+const getCommits = require('../get-commits');
+
+module.exports = {
+  getCommits: async (pluginConfig, {lastRelease, options: {branch}, logger}) => {
+    return getCommits(lastRelease, branch, logger);
+  },
+};

--- a/test/plugins/definitions.test.js
+++ b/test/plugins/definitions.test.js
@@ -23,6 +23,17 @@ test('The "getLastRelease" plugin is mandatory, and must be a single plugin defi
   t.true(definitions.getLastRelease.config.validator(() => {}));
 });
 
+test('The "getCommits" plugin is mandatory, and must be a single plugin definition', t => {
+  t.false(definitions.getCommits.config.validator({}));
+  t.false(definitions.getCommits.config.validator({path: null}));
+  t.false(definitions.getCommits.config.validator([]));
+  t.false(definitions.getCommits.config.validator());
+
+  t.true(definitions.getCommits.config.validator({path: 'plugin-path.js'}));
+  t.true(definitions.getCommits.config.validator('plugin-path.js'));
+  t.true(definitions.getCommits.config.validator(() => {}));
+});
+
 test('The "analyzeCommits" plugin is mandatory, and must be a single plugin definition', t => {
   t.false(definitions.analyzeCommits.config.validator({}));
   t.false(definitions.analyzeCommits.config.validator({path: null}));


### PR DESCRIPTION
This PR, at least initially, is a bit of a POC/suggestion. I think `semantic-release` could work really well for an `npm` package monorepo if...

- [ ] ... the commits could be filtered based on what files they touch (e.g. only include commits that touch files within the same folder as the `package.json` for a given package).

- [x] ... the git tag could be customized (e.g. instead of `v1.0.0`, `my-package-v1.0.0`). The new plugin system allows for this (albeit in kind of a roundabout way)!

Please see the following plugin repo with crude implementation of aforementioned requirements:
https://github.com/Updater/semantic-release-monorepo