### PR TITLE
Add recipes

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,9 +1,14 @@
 # Recipes
 
 ## CI configurations
-- [CircleCI 2.0 workflows](circleci-workflows.md)
-- [Travis CI](travis.md)
-- [Travis CI with build stages](travis-build-stages.md)
-- [GitLab CI](gitlab-ci.md)
+
+* [CircleCI 2.0 workflows](circleci-workflows.md)
+* [Travis CI](travis.md)
+* [Travis CI with build stages](travis-build-stages.md)
+* [GitLab CI](gitlab-ci.md)
 
 ## Package managers and languages
+
+* [Docker](https://github.com/felixfbecker/semantic-release-docker)
+* [PHP / Composer](php-composer.md)
+* [Visual Studio Code extensions](https://github.com/raix/semantic-release-vsce)

--- a/docs/recipes/circleci-workflows.md
+++ b/docs/recipes/circleci-workflows.md
@@ -1,1 +1,75 @@
-# CircleCI 2.0 workflows
+# Using semantic-release with [CircleCI 2.0 workflows](https://circleci.com/docs/2.0/workflows/)
+
+![CircleCI workflows screenshot](https://github.com/circleci/circleci-docs/raw/928cbb042453ae182996ce05f4e4042b02a24634/jekyll/assets/img/docs/workflow_detail.png)
+
+Similar to Travis build stages, CircleCI 2.0 workflows are a great way to run semantic-release in an independent build step.
+We can let CircleCI take care of only running a release on master, after tests passed and running it on an image with Node 8 - your test jobs could use a completely different environment, your project may not even be written in JavaScript.
+
+Make sure to set `NPM_TOKEN` and `GH_TOKEN` in Circle's project settings UI.
+
+### Annotated example `.circleci/config.yml`
+
+```yml
+version: 2
+
+jobs:
+  # Test on Node 6
+  test_node_6:
+    docker:
+      - image: circleci/node:6
+    steps: *test_steps
+  # Test on Node 8
+  test_node_8:
+    docker:
+      - image: circleci/node:8
+    steps: *test_steps
+  # Release if both test jobs passed
+  release:
+    docker:
+      # Use Node 8 for releasing
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - *restore_cache
+      - run: npm install
+      - *save_cache
+      - run: npm run semantic-release
+
+# Define when/under what conditions the jobs should be executed
+workflows:
+  version: 2
+  chromeless:
+    jobs:
+      # Two jobs to test on Node 6 and Node 8
+      - test_node_6
+      - test_node_8
+      # Release job that runs only on master if the two test jobs succeeded
+      - release:
+          requires:
+            - test_node_6
+            - test_node_8
+          filters:
+            branches:
+              only: master
+
+# The steps shared between the two test jobs
+test_steps: &test_steps
+  - checkout
+  - *restore_cache
+  - run: npm install
+  - *save_cache
+  - run: npm test
+
+# Restore npm cache (important to make the jobs start up fast)
+restore_cache: &restore_cache
+  restore_cache:
+    keys:
+      - npm-cache-{{ checksum "package-lock.json" }}
+
+# Save npm cache (important to make the jobs start up fast)
+save_cache: &save_cache
+  save_cache:
+    key: npm-cache-{{ checksum "package-lock.json" }}
+    paths:
+      - ~/.npm
+```

--- a/docs/recipes/php-composer.md
+++ b/docs/recipes/php-composer.md
@@ -1,0 +1,72 @@
+# 🐘 Using semantic-release to release a PHP/Composer package
+
+You can use semantic-release to release a [Composer](https://getcomposer.org/) package to [packagist.org](https://packagist.org/).
+Composer works with GitHub repositories, so all that needs to happen is tag a new release on GitHub.
+The last release can be figured out by looking at the git tags of the repository.
+
+### Example annotated `package.json`
+
+```js
+{
+  "scripts": {
+    "semantic-release": "semantic-release"
+  },
+  "release": {
+    // Configure verifyConditions to not check conditions for npm publishing
+    "verifyConditions": [
+      "@semantic-release/github"
+    ],
+    // Get the last release from local git tags (instead of from the npm registry)
+    "getLastRelease": "@semantic-release/git",
+    // Only create a release and tag on GitHub (don't publish to npm)
+    "publish": "@semantic-release/github"
+  },
+  "devDependencies": {
+    "@semantic-release/git": "^2.0.0",
+    "semantic-release": "^12.0.0"
+  }
+}
+```
+
+### Example annotated `.travis.yml`
+
+```yml
+language: php
+
+# Makes jobs install dependencies faster
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.npm
+
+jobs:
+  include:
+    # The test stage expands to two jobs on PHP 7.0 and 7.2
+    - stage: test
+      php:
+        - '7.0'
+        - '7.2'
+      install:
+        - composer install --prefer-dist
+      script:
+        - vendor/bin/phpunit
+
+    # The release stage is running Node 8
+    - stage: release
+      language: node_js
+      node_js: '8'
+      script:
+        - npm run semantic-release
+
+stages:
+  - test
+  - name: release
+    if: branch = master AND type = push AND fork = false
+
+# Don't build tags
+branches:
+  except:
+   - /^v\d+\.\d+\.\d+$/
+```
+
+This configuration can be adapted for other CI providers too, see the other recipies for examples.

--- a/docs/recipes/travis-build-stages.md
+++ b/docs/recipes/travis-build-stages.md
@@ -1,1 +1,63 @@
-# Using semantic-release with [Travis CI build stages](https://docs.travis-ci.com/user/build-stages)
+# Using semantic-release with [Travis build stages](https://docs.travis-ci.com/user/build-stages/)
+
+![Travis Build Stages screenshot](https://cloud.githubusercontent.com/assets/3729517/25229553/0868909c-25d1-11e7-9263-b076fdef9288.gif)
+
+Build stages are a great way to run semantic release compared to running it in `after_success`:
+
+* The release stage can use Node 8, while the other stages can use other versions, even use a completely different language.
+* It allows you to easily release a project that is not even written in JavaScript, without impacting the job configuration of your test jobs in any way.
+* Instead of having to figure out a "build leader" to do the release and poll the Travis API to wait until all jobs passed, Travis can handle only running the release step after the other jobs passed.
+* If the release failed, you can see at a glance that only the release stage failed while your test stage succeded.
+* Travis can take care of not running the whole release stage at all on non-master branches and PRs.
+
+### Annotated example `.travis.yml`
+
+```yml
+# This could even be a different language
+language: node_js
+
+# Define any version matrix you want for testing
+node_js:
+  - '8'
+  - '6'
+
+# This is inherited by all jobs
+cache:
+  directories:
+    - ~/.npm
+
+# This is the script that will only run for your test stage
+script:
+  - npm run build
+  - npm run lint
+  - npm test
+
+jobs:
+  include:
+    - stage: release
+      # Set the language to node if you used a different language at the top
+      # Otherwise this will be inherited
+      language: node_js
+      # Explicitely use only Node 8 for release (no matrix)
+      node_js: '8'
+      # Override script to build and release
+      # We use script, not after_success, so we get notified if the release failed for unexpected reasons.
+      script:
+        # Don't forget to build before releasing if your project has a build step.
+        # The release stage doesn't share state with the test stage.
+        # Alternatively you could add a prepublishOnly script to package.json
+        - npm run build
+        - npm run semantic-release
+
+# Define when/under what conditions the jobs should be executed
+stages:
+  - test
+    # Make sure that semantic-release only runs on master and not on PR builds
+  - name: release
+    if: branch = master AND type = push AND fork = false
+
+# Don't build tags
+branches:
+  except:
+   - /^v\d+\.\d+\.\d+$/
+```


### PR DESCRIPTION
I love how powerful semantic-release 11 is. It enables so many workflows, especially with third-party plugins. But figuring out the configuration needed to get all of them working was quite a bit of work, and I feel like we should share this so future users don't have to figure it out themselves.
Not all config possibilities will become part of the CLI and it is way easier to share some examples than extending a CLI.

That's why I think it's a good idea to add a folder of recipes to the repo, that people can refer to and extend with PRs. It should contain both information of how to configure semantic-release and CI to enable specific workflows, but also link to external plugins to give them some visibility.

This is much inspired by prior art:
https://github.com/gulpjs/gulp/tree/master/docs/recipes
