### PR TITLE
Make semantic-release CI agnostic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ script:
 
 after_success:
   - npm run codecov
-  - npm run semantic-release
+  - npm install -g semantic-release/travis-deploy-once@4
+  - travis-deploy-once "npm run semantic-release"

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ semantic-release
 These options are currently available:
 - `branch`: The branch on which releases should happen. Default: `'master'`
 - `repositoryUrl`: The git repository URL. Default: `repository` property in `package.json` or git origin url. Any valid git url format is supported (See [Git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols)). If the [Github plugin](https://github.com/semantic-release/github) is used the URL must be a valid Github URL that include the `owner`, the `repository` name and the `host`. The Github shorthand URL is not supported.
-- `dry-run`: Dry-run mode, skipping verifyConditions, publishing and release, printing next version and release notes
+- `dry-run`: Dry-run mode, skip publishing, print next version and release notes
 - `extends`: Array of module or files path containing a shareable configuration. Options defined via CLI or in the `release` property will take precedence over the one defined in a shareable configuration.
 - `debug`: Output debugging information
 

--- a/cli.js
+++ b/cli.js
@@ -48,12 +48,10 @@ module.exports = async () => {
       await require('.')(pickBy(program.opts(), value => !isUndefined(value)));
     }
   } catch (err) {
-    // If error is a SemanticReleaseError then it's an expected exception case (no release to be done, running on a PR etc..) and the cli will return with 0
-    // Otherwise it's an unexpected error (configuration issue, code issue, plugin issue etc...) and the cli will return 1
+    process.exitCode = 1;
     if (err.semanticRelease) {
       logger.log(`%s ${err.message}`, err.code);
     } else {
-      process.exitCode = 1;
       logger.error('An error occurred while running semantic-release: %O', err);
     }
   }

--- a/lib/plugins/definitions.js
+++ b/lib/plugins/definitions.js
@@ -6,7 +6,7 @@ const validatePluginConfig = conf => isString(conf) || isString(conf.path) || is
 
 module.exports = {
   verifyConditions: {
-    default: ['@semantic-release/npm', '@semantic-release/github', '@semantic-release/condition-travis'],
+    default: ['@semantic-release/npm', '@semantic-release/github'],
     config: {
       validator: conf => !conf || (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
       message:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@semantic-release/commit-analyzer": "^5.0.0",
-    "@semantic-release/condition-travis": "^7.0.0",
     "@semantic-release/error": "^2.1.0",
     "@semantic-release/github": "^3.0.0",
     "@semantic-release/npm": "^2.0.0",
@@ -25,6 +24,7 @@
     "commander": "^2.11.0",
     "cosmiconfig": "^3.1.0",
     "debug": "^3.1.0",
+    "env-ci": "^1.0.0",
     "execa": "^0.8.0",
     "get-stream": "^3.0.0",
     "git-log-parser": "^1.2.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,7 +19,6 @@ test.beforeEach(t => {
   t.context.log = stub();
   t.context.error = stub();
   t.context.logger = {log: t.context.log, error: t.context.error};
-  t.context.semanticRelease = proxyquire('../index', {'./lib/logger': t.context.logger});
 });
 
 test.afterEach.always(() => {
@@ -61,7 +60,11 @@ test.serial('Plugins are called with expected values', async t => {
     publish,
   };
 
-  await t.context.semanticRelease(options);
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  t.truthy(await semanticRelease(options));
 
   t.is(verifyConditions1.callCount, 1);
   t.deepEqual(verifyConditions1.args[0][0], config);
@@ -140,7 +143,11 @@ test.serial('Use new gitHead, and recreate release notes if a publish plugin cre
     publish: [publish1, publish2],
   };
 
-  await t.context.semanticRelease(options);
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  t.truthy(await semanticRelease(options));
 
   t.is(generateNotes.callCount, 2);
   t.deepEqual(generateNotes.args[0][1].nextRelease, nextRelease);
@@ -154,7 +161,7 @@ test.serial('Use new gitHead, and recreate release notes if a publish plugin cre
   t.deepEqual(publish2.args[0][1].nextRelease, Object.assign({}, nextRelease, {notes}));
 });
 
-test.serial('Dry-run skips verifyConditions and publish', async t => {
+test.serial('Dry-run skips publish', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
   // Add commits to the master branch
@@ -187,9 +194,62 @@ test.serial('Dry-run skips verifyConditions and publish', async t => {
     publish,
   };
 
-  await t.context.semanticRelease(options);
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  t.truthy(await semanticRelease(options));
 
-  t.is(verifyConditions.callCount, 0);
+  t.not(t.context.log.args[0][0], 'This run was not triggered in a known CI environment, running in dry-run mode.');
+  t.is(verifyConditions.callCount, 1);
+  t.is(getLastRelease.callCount, 1);
+  t.is(analyzeCommits.callCount, 1);
+  t.is(verifyRelease.callCount, 1);
+  t.is(generateNotes.callCount, 1);
+  t.is(publish.callCount, 0);
+});
+
+test.serial('Force a dry-run if not on a CI', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+  // Add commits to the master branch
+  let commits = await gitCommits(['First']);
+  // Create the tag corresponding to version 1.0.0
+  await gitTagVersion('v1.0.0');
+  // Add new commits to the master branch
+  commits = (await gitCommits(['Second'])).concat(commits);
+
+  const lastRelease = {version: '1.0.0', gitHead: commits[commits.length - 1].hash, gitTag: 'v1.0.0'};
+  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead(), gitTag: 'v2.0.0'};
+  const notes = 'Release notes';
+
+  const verifyConditions = stub().resolves();
+  const getLastRelease = stub().resolves(lastRelease);
+  const analyzeCommits = stub().resolves(nextRelease.type);
+  const verifyRelease = stub().resolves();
+  const generateNotes = stub().resolves(notes);
+  const publish = stub().resolves();
+
+  const options = {
+    dryRun: false,
+    branch: 'master',
+    repositoryUrl: 'git@hostname.com:owner/module.git',
+    verifyConditions,
+    getLastRelease,
+    analyzeCommits,
+    verifyRelease,
+    generateNotes,
+    publish,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: false, branch: 'master'}),
+  });
+  t.truthy(await semanticRelease(options));
+
+  t.is(t.context.log.args[0][0], 'This run was not triggered in a known CI environment, running in dry-run mode.');
+  t.is(verifyConditions.callCount, 1);
   t.is(getLastRelease.callCount, 1);
   t.is(analyzeCommits.callCount, 1);
   t.is(verifyRelease.callCount, 1);
@@ -227,7 +287,11 @@ test.serial('Accept "undefined" values for the "getLastRelease" and "generateNot
     publish,
   };
 
-  await t.context.semanticRelease(options);
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  t.truthy(await semanticRelease(options));
 
   t.is(getLastRelease.callCount, 1);
 
@@ -245,29 +309,121 @@ test.serial('Accept "undefined" values for the "getLastRelease" and "generateNot
   t.falsy(publish.args[0][1].nextRelease.notes);
 });
 
-test.serial('Throw SemanticReleaseError if not running from a git repository', async t => {
+test.serial('Returns falsy value if not running from a git repository', async t => {
   // Set the current working directory to a temp directory
   process.chdir(tempy.directory());
 
-  const error = await t.throws(t.context.semanticRelease());
-
-  // Verify error code and type
-  t.is(error.code, 'ENOGITREPO');
-  t.is(error.name, 'SemanticReleaseError');
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  t.falsy(await semanticRelease());
+  t.is(t.context.error.args[0][0], 'Semantic-release must run from a git repository.');
 });
 
-test.serial('Throw SemanticReleaseError if repositoryUrl is not set and cannot be found', async t => {
+test.serial('Returns falsy value if triggered by a PR', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
 
-  const error = await t.throws(t.context.semanticRelease());
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: true}),
+  });
+
+  t.falsy(await semanticRelease({repositoryUrl: 'git@hostname.com:owner/module.git'}));
+  t.is(
+    t.context.log.args[0][0],
+    'This run was triggered by a pull request and therefore a new version won’t be published.'
+  );
+});
+
+test.serial('Returns falsy value if not running from the configured branch', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+
+  const verifyConditions = stub().resolves();
+  const getLastRelease = stub().resolves();
+  const analyzeCommits = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const generateNotes = stub().resolves();
+  const publish = stub().resolves();
+
+  const options = {
+    branch: 'master',
+    repositoryUrl: 'git@hostname.com:owner/module.git',
+    verifyConditions: [verifyConditions],
+    getLastRelease,
+    analyzeCommits,
+    verifyRelease,
+    generateNotes,
+    publish,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'other-branch', isPr: false}),
+  });
+
+  t.falsy(await semanticRelease(options));
+  t.is(
+    t.context.log.args[0][0],
+    'This test run was triggered on the branch other-branch, while semantic-release is configured to only publish from master, therefore a new version won’t be published.'
+  );
+});
+
+test.serial('Returns falsy value if there is no relevant changes', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+  // Add commits to the master branch
+  await gitCommits(['First']);
+
+  const verifyConditions = stub().resolves();
+  const getLastRelease = stub().resolves();
+  const analyzeCommits = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const generateNotes = stub().resolves();
+  const publish = stub().resolves();
+
+  const options = {
+    branch: 'master',
+    repositoryUrl: 'git@hostname.com:owner/module.git',
+    verifyConditions: [verifyConditions],
+    getLastRelease,
+    analyzeCommits,
+    verifyRelease,
+    generateNotes,
+    publish,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+
+  t.falsy(await semanticRelease(options));
+  t.is(analyzeCommits.callCount, 1);
+  t.is(verifyRelease.callCount, 0);
+  t.is(generateNotes.callCount, 0);
+  t.is(publish.callCount, 0);
+  t.is(t.context.log.args[6][0], 'There are no relevant changes, so no new version is released.');
+});
+
+test.serial('Throw SemanticReleaseError if repositoryUrl is not set and cannot be found from repo config', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  const error = await t.throws(semanticRelease());
 
   // Verify error code and type
   t.is(error.code, 'ENOREPOURL');
   t.is(error.name, 'SemanticReleaseError');
 });
 
-test.serial('Throw an Error if returns an unexpected value', async t => {
+test.serial('Throw an Error if plugin returns an unexpected value', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
   // Add commits to the master branch
@@ -287,7 +443,11 @@ test.serial('Throw an Error if returns an unexpected value', async t => {
     getLastRelease,
   };
 
-  const error = await t.throws(t.context.semanticRelease(options), Error);
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  const error = await t.throws(semanticRelease(options), Error);
 
   // Verify error message
   t.regex(error.message, new RegExp(DEFINITIONS.getLastRelease.output.message));


### PR DESCRIPTION
This PR remove the need for a CI `verifyConditions` plugin by:
- Moving the verification of the branch and PR in the core. Works with any major (and not so major) CI services. See [env-ci](https://github.com/pvdlg/env-ci) for the list.
- Leaving the responsibility to run `semantic-release` only on one job to the CI and/or the user.

**Benefits**
- Allow to support any CI out of the box
- Avoid forcing users who do not use Travis to override a big chunk of configuration (the `verifyConditions` plugins)
- Allow users to do a dry-run locally to verify the main and plugins configuration
- Allow to use shareable config more easily (Currently any shareable config user who do not use Travis would have to override the `verifyConditions` configuration defeating the purpose of shareable config)
- Allow to handle errors properly, failing the build in case of error but not if running on a job that is not the build leader. See [comment](https://github.com/semantic-release/semantic-release/issues/569#issuecomment-353502532)
- Detecting the current branch from the core is required in order to implements #563

Checking that `semantic-release` runs only on one job is extremely dependent on the CI as well as the user workflow and personal preferences. Supporting any CI and workflow out there would be a herculean task, and mostly redundant as most CI provider are now starting to provide solutions to do that. In addition, imposing Travis in the default settings creates unnecessary frictions, and make it harder for new users to adopt `semantic-release`.

The only disadvantage is that current Travis users who use the default config will have to slightly change their `.travis.yml`, replacing `npm run semantic-release` by `npm install -g travis-deploy-once && travis-deploy-once "npm run semantic-release"`.

See semantic-release/travis-deploy-once#38.

We can update `semantic-release-cli` do do this setup automatically.

**List of changes**
- Remove `@semantic-release/condition-travis` from the default plugins
- Verify the current branch in the core
- Verify the build is not triggered by a PR in the core
- Run in dry-run mode if not triggered on CI
- Dry-run mode runs the `verifyConditions` plugins, allowing to detect configuration error locally
- Return without error when no version has to be released due to no changes
- Return without error if the build is triggered from a PR
- Return without error if the current branch is not the configured branch
- CLI return with exit code 1 if there is a `semanticReleaseError`, allowing to fail builds in case of config error, missing token etc...

**Breaking change**
`semantic-release` doesn't make sure it runs only on one Travis job anymore.
The CI configuration has to be done such that `semantic-release`
- runs only once per build
- runs only after all tests are successful on every jobs of the build
- runs on Node >=8

This can easily be done with [travis-deploy-once](https://github.com/semantic-release/travis-deploy-once).

**Migration Guide**

Modify your `.travis.yml` to use `travis-deploy-once`.
Replace:
```yaml
after_success:
  - npm run semantic-release
```
by:
Replace
```yaml
after_success:
  - npm install -g travis-deploy-once
  - travis-deploy-once "npm run semantic-release"
```

Fix semantic-release/condition-travis#96, Fix #569

TODO:
- [x] Release semantic-release/travis-deploy-once#38
- [x] Update `.travis.yml` to install `travis-deploy-once` directly rather than from `semantic-release/travis-deploy-once#cli` branch
- [ ] Release semantic-release/cli#165