### PR TITLE
feat: allow to release from local machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ semantic-release
 These options are currently available:
 - `branch`: The branch on which releases should happen. Default: `'master'`
 - `repositoryUrl`: The git repository URL. Default: `repository` property in `package.json` or git origin url. Any valid git url format is supported (See [Git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols)). If the [Github plugin](https://github.com/semantic-release/github) is used the URL must be a valid Github URL that include the `owner`, the `repository` name and the `host`. The Github shorthand URL is not supported.
+- `no-ci`: Skip Continuous Integration environment verifications, allowing to make releases from a local machine
 - `dry-run`: Dry-run mode, skip publishing, print next version and release notes
 - `extends`: Array of module or files path containing a shareable configuration. Options defined via CLI or in the `release` property will take precedence over the one defined in a shareable configuration.
 - `debug`: Output debugging information
@@ -269,7 +270,8 @@ If you run `npm run semantic-release` locally a dry run gets performed, which lo
 
 ### Can I run this on my own machine rather than on a CI server?
 
-Of course you can, but this doesn’t necessarily mean you should. Running your tests on an independent machine before releasing software is a crucial part of this workflow. Also it is a pain to set this up locally, with tokens lying around and everything. That said, you can run the scripts with `--debug=false` explicitly. You have to export `GH_TOKEN=<your_token>` and `NPM_TOKEN=<your_other_token>`.
+Yes, you can by explicitly setting the [`--no-ci` CLI option](#options), but this doesn’t necessarily mean you should. Running your tests on an independent machine before releasing software is a crucial part of this workflow.
+You will need to set all necessary authentication token (like `GH_TOKEN` and `NPM_TOKEN`) on your local machine.
 
 ### Can I manually trigger the release of a specific version?
 

--- a/cli.js
+++ b/cli.js
@@ -27,6 +27,10 @@ module.exports = async () => {
     )
     .option('--generate-notes <path>', 'Path or package name for the generateNotes plugin')
     .option('--publish <paths>', 'Comma separated list of paths or packages name for the publish plugin(s)', list)
+    .option(
+      '--no-ci',
+      'Skip Continuous Integration environment verifications, allowing to make releases from a local machine'
+    )
     .option('--debug', 'Output debugging information')
     .option(
       '-d, --dry-run',

--- a/index.js
+++ b/index.js
@@ -10,13 +10,13 @@ const {gitHead: getGitHead, isGitRepo} = require('./lib/git');
 module.exports = async opts => {
   const {isCi, branch, isPr} = envCi();
 
-  if (!isCi && !opts.dryRun) {
+  if (!isCi && !opts.dryRun && !opts.noCi) {
     logger.log('This run was not triggered in a known CI environment, running in dry-run mode.');
     opts.dryRun = true;
   }
 
-  if (isCi && isPr) {
-    logger.log('This run was triggered by a pull request and therefore a new version won’t be published.');
+  if (isCi && isPr && !opts.noCi) {
+    logger.log("This run was triggered by a pull request and therefore a new version won't be published.");
     return;
   }
 


### PR DESCRIPTION
Doing releases outside a CI environment is not the recommended approach, but it might be useful in specific circumstances (for example #584 and [comment](https://github.com/semantic-release/semantic-release/pull/578#issuecomment-354579201)).

Since #578, `condition-travis` is not a default plugin anymore and verifying that `semantic-release` runs after all other CI jobs are successful is done externally, therefore allowing local releases is just a couple line change. So why not.

In addition the `Can I run this on my own machine rather than on a CI server?` FAQ mention it is possible even though it's not since several releases, so it was probably possible at some point. No real reason to remove (or more exactly continue to remove) a feature that was present before.

The FAQ clearly mention that even if it's possible, it's not the recommended approach.

Fix #584 and [comment](https://github.com/semantic-release/semantic-release/pull/578#issuecomment-354579201).