### PR TITLE
feat: allow to exclude commits from analysis

### DIFF
--- a/docs/support/FAQ.md
+++ b/docs/support/FAQ.md
@@ -123,6 +123,10 @@ See [Artifactory - npm Registry](https://www.jfrog.com/confluence/display/RTF/Np
 
 You can trigger a release by pushing to your Git repository. You deliberately cannot trigger a *specific* version release, because this is the whole point of semantic-release.
 
+### Can I exclude commits from the analysis?
+
+Yes, every commits that contains `[skip release]` or `[release skip]` in their message will be excluded from the commit analysis and won't participate in the release type determination.
+
 ## Is it *really* a good idea to release on every push?
 
 It is indeed a great idea because it *forces* you to follow best practices. If you don’t feel comfortable releasing every feature or fix on your `master` you might not treat your `master` branch as intended.

--- a/index.js
+++ b/index.js
@@ -50,7 +50,12 @@ module.exports = async opts => {
   );
 
   logger.log('Call plugin %s', 'analyze-commits');
-  const type = await plugins.analyzeCommits({options, logger, lastRelease, commits});
+  const type = await plugins.analyzeCommits({
+    options,
+    logger,
+    lastRelease,
+    commits: commits.filter(commit => !/\[skip\s+release\]|\[release\s+skip\]/i.test(commit.message)),
+  });
   if (!type) {
     logger.log('There are no relevant changes, so no new version is released.');
     return;


### PR DESCRIPTION
Exclude commits from the analysis if they contains `[skip release]` or `[release skip]` in the subject or the body.

Fix #41