### PR TITLE
Travis: recommend to use the `deploy` step instead of `script`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: node_js
+
 services:
   - docker
-notifications:
-  email: false
+
 node_js:
   - 9
   - 8
-os:
-  - linux
 
 # Trigger a push build on caribou and greenkeeper branches + PRs build on every branches
 # Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
@@ -25,5 +23,10 @@ script:
 
 after_success:
   - npm run codecov
-  - npm install -g travis-deploy-once@4
-  - travis-deploy-once "npm run semantic-release"
+
+jobs:
+  include:
+    - stage: release
+      node_js: lts/*
+      script:
+        - npm run semantic-release

--- a/docs/recipes/travis.md
+++ b/docs/recipes/travis.md
@@ -16,7 +16,9 @@ For projects that require to be tested only with a single [Node version](https:/
 
 This example is a minimal configuration for semantic-release with a build running Node 8 on Linux. See [Travis - Customizing the Build](https://docs.travis-ci.com/user/customizing-the-build) for additional configuration options.
 
-It's recommended to run the `semantic-release` command in the [Travis `script` step](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle) so if an error happen the build will fail and Travis will send a notification.
+It's recommended to run the `semantic-release` command in the [Travis `deploy` step](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle) so if an error occurs the build will fail and Travis will send a notification.
+
+**Note**: It's not recommended to run the `semantic-release` command in the Travis `script` step as each script in this step will be executed regardless of the outcome of the previous one. See [travis-ci/travis-ci#1066](https://github.com/travis-ci/travis-ci/issues/1066).
 
 **Note**: The`semantic-release` execution command varies depending if you are using a [local](../usage/installation.md#local-installation) or [global](../usage/installation.md#global-installation) semantic-release installation.
 
@@ -29,12 +31,14 @@ script:
   # Run tests
   - npm run test
 
-  # Only for a local semantic-release installation
-  - npm run semantic-release
-
-  # Only for a global semantic-release installation
-  - npm install -g semantic-release
-  - semantic-release
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    # Only for a local semantic-release installation
+    - npm run semantic-release
+    # Only for a global semantic-release installation
+    - npm install -g semantic-release && semantic-release
 ```
 
 ### `package.json` configuration for single Node job
@@ -56,7 +60,7 @@ A `package.json` is required only for [local](../usage/installation.md#local-ins
 
 For projects that require to be tested with multiple [Node versions](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) and/or on multiple [Operating Systems](https://docs.travis-ci.com/user/multi-os).
 
-**Note**: At least one job must run a [Node >= 8 version](../support/FAQ.md#why-does-semantic-release-require-node-version--8).
+**Note**: At least one job must run a [Node >= 8 version](../support/FAQ.md#why-does-semantic-release-require-node-version--83).
 
 ### `.travis.yml` configuration for multiple Node jobs
 
@@ -64,7 +68,9 @@ This example is a minimal configuration for **semantic-release** with a build ru
 
 This example uses [`travis-deploy-once`](https://github.com/semantic-release/travis-deploy-once) in order to command [Run `semantic-release` only after all tests succeeded](../usage/ci-configuration.md#run-semantic-release-only-after-all-tests-succeeded). Alternatively you can use [Travis CI Build Stages recipe](travis-build-stages.md).
 
-It's recommended to run the `semantic-release` command in the [Travis `script` step](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle) so if an error happen the build will fail and Travis will send a notification.
+It's recommended to run the `semantic-release` command in the [Travis `deploy` step](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle) so if an error occurs the build will fail and Travis will send a notification.
+
+**Note**: It's not recommended to run the `semantic-release` command in the Travis `script` step as each script in this step will be executed regardless of the outcome of the previous one. See [travis-ci/travis-ci#1066](https://github.com/travis-ci/travis-ci/issues/1066).
 
 **Note**: The`semantic-release` execution command varies depending if you are using a [local](../usage/installation.md#local-installation) or [global](../usage/installation.md#global-installation) **semantic-release** installation.
 
@@ -84,12 +90,14 @@ script:
   # Run tests
   - npm run test
 
-  # Only for a local semantic-release installation
-  - npm run travis-deploy-once "npm run semantic-release"
-
-  # Only for a global semantic-release installation
-  - npm install -g travis-deploy-once semantic-release
-  - travis-deploy-once "semantic-release"
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    # Only for a local semantic-release installation
+    - npm run travis-deploy-once "npm run semantic-release"
+    # Only for a global semantic-release installation
+    - npm install -g travis-deploy-once semantic-release && travis-deploy-once "semantic-release"
 ```
 
 **Note**: See the `travis-deploy-once` [`pro`](https://github.com/semantic-release/travis-deploy-once#-p---pro) and [`travis-url`](https://github.com/semantic-release/travis-deploy-once#-u---travis-url) options for using with [Travis Pro](https://docs.travis-ci.com/user/travis-pro) and [Travis Enterprise](https://enterprise.travis-ci.com).
@@ -123,7 +131,9 @@ This example is a minimal configuration for semantic-release with a build runnin
 
 This example uses [`travis-deploy-once`](https://github.com/semantic-release/travis-deploy-once) in order to [run `semantic-release` only after all tests succeeded](../usage/ci-configuration.md#run-semantic-release-only-after-all-tests-succeeded). Alternatively you can use [Travis CI Build Stages recipe](travis-build-stages.md).
 
-It's recommended to run the `semantic-release` command in the [Travis `script` step](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle) so if an error happen the build will fail and Travis will send a notification.
+It's recommended to run the `semantic-release` command in the [Travis `deploy` step](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle) so if an error occurs the build will fail and Travis will send a notification.
+
+**Note**: It's not recommended to run the `semantic-release` command in the Travis `script` step as each script in this step will be executed regardless of the outcome of the previous one. See [travis-ci/travis-ci#1066](https://github.com/travis-ci/travis-ci/issues/1066).
 
 ```yaml
 language: go
@@ -140,12 +150,16 @@ script:
   # Run tests
   - go test -v ./...
 
-  # Use nvm to install and use the Node LTS version (nvm is installed on Travis images)
-  - nvm install lts/*
-  # Install travis-deploy-once and semantic-release
-  - npm install -g travis-deploy-once semantic-release
-  # Run semantic-release only on job, after all other are successful
-  - travis-deploy-once "semantic-release"
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    # Use nvm to install and use the Node LTS version (nvm is installed on all Travis images)
+    - nvm install lts/*
+    # Install travis-deploy-once and semantic-release
+    - npm install -g travis-deploy-once semantic-release
+    # Run semantic-release only on job, after all other are successful
+    - travis-deploy-once "semantic-release"
 ```
 
 **Note**: See the `travis-deploy-once` [`pro`](https://github.com/semantic-release/travis-deploy-once#-p---pro) and [`travis-url`](https://github.com/semantic-release/travis-deploy-once#-u---travis-url) options for using with [Travis Pro](https://docs.travis-ci.com/user/travis-pro) and [Travis Enterprise](https://enterprise.travis-ci.com).


### PR DESCRIPTION
Fix #609

When using Build Stages (doc to be written), should we recommend to use the `script` or the `deploy` stage?
`script` would work as long as we only run `semantic-release` in it, which should be the case for the `release` stage. On the other hand using the `deploy` step might make more sense.

If we go with `deploy` even for Build Stages we should change that in each semantic-release repo so the recommendation would match what we do in our repos.