### PR TITLE
fix: fix the `--no-ci` arg parsing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,8 +48,11 @@ module.exports = async () => {
       program.outputHelp();
       process.exitCode = 1;
     } else {
+      const opts = program.opts();
+      // Set the `noCi` options as commander.js sets the `ci` options instead (becasue args starts with `--no`)
+      opts.noCi = opts.ci === false ? true : undefined;
       // Remove option with undefined values, as commander.js sets non defined options as `undefined`
-      await require('.')(pickBy(program.opts(), value => !isUndefined(value)));
+      await require('.')(pickBy(opts, value => !isUndefined(value)));
     }
   } catch (err) {
     process.exitCode = 1;

--- a/index.js
+++ b/index.js
@@ -9,13 +9,15 @@ const {gitHead: getGitHead, isGitRepo} = require('./lib/git');
 
 module.exports = async opts => {
   const {isCi, branch, isPr} = envCi();
+  const config = await getConfig(opts, logger);
+  const {plugins, options} = config;
 
-  if (!isCi && !opts.dryRun && !opts.noCi) {
+  if (!isCi && !options.dryRun && !options.noCi) {
     logger.log('This run was not triggered in a known CI environment, running in dry-run mode.');
-    opts.dryRun = true;
+    options.dryRun = true;
   }
 
-  if (isCi && isPr && !opts.noCi) {
+  if (isCi && isPr && !options.noCi) {
     logger.log("This run was triggered by a pull request and therefore a new version won't be published.");
     return;
   }
@@ -24,9 +26,6 @@ module.exports = async opts => {
     logger.error('Semantic-release must run from a git repository.');
     return;
   }
-
-  const config = await getConfig(opts, logger);
-  const {plugins, options} = config;
 
   if (branch !== options.branch) {
     logger.log(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -209,7 +209,7 @@ test.serial('Dry-run skips publish', async t => {
   t.is(publish.callCount, 0);
 });
 
-test.serial('Force a dry-run if not on a CI and ignore "noCi" is not explicitly set', async t => {
+test.serial('Force a dry-run if not on a CI and "noCi" is not explicitly set', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
   // Add commits to the master branch
@@ -369,7 +369,7 @@ test.serial('Returns falsy value if not running from a git repository', async t 
     './lib/logger': t.context.logger,
     'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
   });
-  t.falsy(await semanticRelease());
+  t.falsy(await semanticRelease({repositoryUrl: 'git@hostname.com:owner/module.git'}));
   t.is(t.context.error.args[0][0], 'Semantic-release must run from a git repository.');
 });
 
@@ -384,7 +384,7 @@ test.serial('Returns falsy value if triggered by a PR', async t => {
 
   t.falsy(await semanticRelease({repositoryUrl: 'git@hostname.com:owner/module.git'}));
   t.is(
-    t.context.log.args[0][0],
+    t.context.log.args[7][0],
     "This run was triggered by a pull request and therefore a new version won't be published."
   );
 });


### PR DESCRIPTION
The `noCi` is no properly set based on the `--no-ci` CLI arg and it is overwritten by the `noCi` option.

Fix #616