### PR TITLE
feat: hide sensitive info in stdout/sdtin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const marked = require('marked');
 const TerminalRenderer = require('marked-terminal');
 const envCi = require('env-ci');
+const hookStd = require('hook-std');
+const hideSensitive = require('./lib/hide-sensitive');
 const getConfig = require('./lib/get-config');
 const getNextVersion = require('./lib/get-next-version');
 const getCommits = require('./lib/get-commits');
@@ -96,8 +98,10 @@ async function run(opts) {
 }
 
 module.exports = async opts => {
+  const unhook = hookStd({silent: false}, hideSensitive);
   try {
     const result = await run(opts);
+    unhook();
     return result;
   } catch (err) {
     const errors = err.name === 'AggregateError' ? Array.from(err).sort(error => !error.semanticRelease) : [err];
@@ -108,6 +112,7 @@ module.exports = async opts => {
         logger.error('An error occurred while running semantic-release: %O', error);
       }
     }
+    unhook();
     throw err;
   }
 };

--- a/lib/hide-sensitive.js
+++ b/lib/hide-sensitive.js
@@ -1,0 +1,11 @@
+const {escapeRegExp} = require('lodash');
+
+const regexp = new RegExp(
+  Object.keys(process.env)
+    .filter(envVar => /token|password|credential|secret|private/i.test(envVar))
+    .map(envVar => escapeRegExp(process.env[envVar]))
+    .join('|'),
+  'g'
+);
+
+module.exports = output => output.replace(regexp, '[secure]');

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "execa": "^0.9.0",
     "get-stream": "^3.0.0",
     "git-log-parser": "^1.2.0",
+    "hook-std": "^0.4.0",
     "lodash": "^4.17.4",
     "marked": "^0.3.9",
     "marked-terminal": "^2.0.0",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "ava": "^0.25.0",
+    "clear-module": "^2.1.0",
     "codecov": "^3.0.0",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",

--- a/test/hide-sensitive.test.js
+++ b/test/hide-sensitive.test.js
@@ -1,0 +1,34 @@
+import test from 'ava';
+import clearModule from 'clear-module';
+
+test.beforeEach(() => {
+  process.env = {};
+  clearModule('../lib/hide-sensitive');
+});
+
+test.serial('Replace multiple sensitive environment variable values', t => {
+  process.env.SOME_PASSWORD = 'password';
+  process.env.SOME_TOKEN = 'secret';
+  t.is(
+    require('../lib/hide-sensitive')(
+      `https://user:${process.env.SOME_PASSWORD}@host.com?token=${process.env.SOME_TOKEN}`
+    ),
+    'https://user:[secure]@host.com?token=[secure]'
+  );
+});
+
+test.serial('Replace multiple occurences of sensitive environment variable values', t => {
+  process.env.secretKey = 'secret';
+  t.is(
+    require('../lib/hide-sensitive')(`https://user:${process.env.secretKey}@host.com?token=${process.env.secretKey}`),
+    'https://user:[secure]@host.com?token=[secure]'
+  );
+});
+
+test.serial('Escape regexp special characters', t => {
+  process.env.SOME_CREDENTIALS = 'p$^{.+}\\w[a-z]o.*rd';
+  t.is(
+    require('../lib/hide-sensitive')(`https://user:${process.env.SOME_CREDENTIALS}@host.com`),
+    'https://user:[secure]@host.com'
+  );
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -61,7 +61,7 @@ test.beforeEach(() => {
 
   // Delete all `npm_config` environment variable set by CI as they take precedence over the `.npmrc` because the process that runs the tests is started before the `.npmrc` is created
   for (let i = 0, keys = Object.keys(process.env); i < keys.length; i++) {
-    if (keys[i].startsWith('npm_config')) {
+    if (keys[i].startsWith('npm_')) {
       delete process.env[keys[i]];
     }
   }


### PR DESCRIPTION
As we use several sensitive information in environment variables, a plugin could by accident output in the logs the value of the tokens or credential.

For example in order to access the git repository we use an https URL like `https:<GH_TOKEN>@github.com/owner/repo.git`. If a Git command fails we don't log the error as it would contains the repo URL with the token.

This PR process each `stdin` and `stdout` text to hide any value that is set via an environment variable containing the keywords `token`, `password`, `credential`, `secret`, `private`. This way both the core and plugins can safely log anything without risking to expose sensitive informations in the CI logs. 

Ref semantic-release/git#21