### PR TITLE
feat: log all verification errors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,5 @@
 const program = require('commander');
 const {pickBy, isUndefined} = require('lodash');
-const logger = require('./lib/logger');
 
 function list(values) {
   return values.split(',').map(value => value.trim());
@@ -56,10 +55,5 @@ module.exports = async () => {
     }
   } catch (err) {
     process.exitCode = 1;
-    if (err.semanticRelease) {
-      logger.log(`%s ${err.message}`, err.code);
-    } else {
-      logger.error('An error occurred while running semantic-release: %O', err);
-    }
   }
 };

--- a/lib/plugins/pipeline.js
+++ b/lib/plugins/pipeline.js
@@ -1,19 +1,33 @@
 const {identity} = require('lodash');
+const pReflect = require('p-reflect');
 const pReduce = require('p-reduce');
+const AggregateError = require('aggregate-error');
 
-module.exports = steps => async (input, getNextInput = identity) => {
+module.exports = steps => async (input, settleAll = false, getNextInput = identity) => {
   const results = [];
+  const errors = [];
   await pReduce(
     steps,
     async (prevResult, nextStep) => {
-      // Call the next step with the input computed at the end of the previous iteration
-      const result = await nextStep(prevResult);
-      // Save intermediary result
-      results.push(result);
+      let result;
+
+      // Call the next step with the input computed at the end of the previous iteration and save intermediary result
+      if (settleAll) {
+        const {isFulfilled, value, reason} = await pReflect(nextStep(prevResult));
+        result = isFulfilled ? value : reason;
+        (isFulfilled ? results : errors).push(result);
+      } else {
+        result = await nextStep(prevResult);
+        results.push(result);
+      }
+
       // Prepare input for next step, passing the result of the previous iteration and the current one
       return getNextInput(prevResult, result);
     },
     input
   );
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
+  }
   return results;
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@semantic-release/github": "^3.0.1",
     "@semantic-release/npm": "^2.0.0",
     "@semantic-release/release-notes-generator": "^6.0.0",
+    "aggregate-error": "^1.0.0",
     "chalk": "^2.3.0",
     "commander": "^2.11.0",
     "cosmiconfig": "^4.0.0",
@@ -36,6 +37,7 @@
     "marked": "^0.3.9",
     "marked-terminal": "^2.0.0",
     "p-reduce": "^1.0.0",
+    "p-reflect": "^1.0.0",
     "read-pkg-up": "^3.0.0",
     "resolve-from": "^4.0.0",
     "semver": "^5.4.1"

--- a/test/plugins/pipeline.test.js
+++ b/test/plugins/pipeline.test.js
@@ -12,24 +12,50 @@ test('Execute each function in series passing the same input', async t => {
   t.true(step1.calledWith(0));
   t.true(step2.calledWith(0));
   t.true(step3.calledWith(0));
+
+  t.true(step1.calledBefore(step2));
+  t.true(step2.calledBefore(step3));
 });
 
 test('Execute each function in series passing a transformed input', async t => {
   const step1 = stub().resolves(1);
   const step2 = stub().resolves(2);
   const step3 = stub().resolves(3);
+  const step4 = stub().resolves(4);
 
-  const result = await pipeline([step1, step2, step3])(0, (prevResult, result) => prevResult + result);
+  const result = await pipeline([step1, step2, step3, step4])(0, false, (prevResult, result) => prevResult + result);
 
-  t.deepEqual(result, [1, 2, 3]);
+  t.deepEqual(result, [1, 2, 3, 4]);
+  t.true(step1.calledWith(0));
+  t.true(step2.calledWith(0 + 1));
+  t.true(step3.calledWith(0 + 1 + 2));
+  t.true(step4.calledWith(0 + 1 + 2 + 3));
+  t.true(step1.calledBefore(step2));
+  t.true(step2.calledBefore(step3));
+  t.true(step3.calledBefore(step4));
+});
+
+test('Execute each function in series passing the result of the previous one', async t => {
+  const step1 = stub().resolves(1);
+  const step2 = stub().resolves(2);
+  const step3 = stub().resolves(3);
+  const step4 = stub().resolves(4);
+
+  const result = await pipeline([step1, step2, step3, step4])(0, false, (prevResult, result) => result);
+
+  t.deepEqual(result, [1, 2, 3, 4]);
   t.true(step1.calledWith(0));
   t.true(step2.calledWith(1));
-  t.true(step3.calledWith(3));
+  t.true(step3.calledWith(2));
+  t.true(step4.calledWith(3));
+  t.true(step1.calledBefore(step2));
+  t.true(step2.calledBefore(step3));
+  t.true(step3.calledBefore(step4));
 });
 
 test('Stop execution and throw error is a step rejects', async t => {
   const step1 = stub().resolves(1);
-  const step2 = stub().throws(new Error('test error'));
+  const step2 = stub().rejects(new Error('test error'));
   const step3 = stub().resolves(3);
 
   const error = await t.throws(pipeline([step1, step2, step3])(0), Error);
@@ -37,4 +63,38 @@ test('Stop execution and throw error is a step rejects', async t => {
   t.true(step1.calledWith(0));
   t.true(step2.calledWith(0));
   t.true(step3.notCalled);
+});
+
+test('Execute all even if a Promise rejects', async t => {
+  const error1 = new Error('test error 1');
+  const error2 = new Error('test error 2');
+  const step1 = stub().resolves(1);
+  const step2 = stub().rejects(error1);
+  const step3 = stub().rejects(error2);
+
+  const errors = await t.throws(pipeline([step1, step2, step3])(0, true));
+
+  t.deepEqual(Array.from(errors), [error1, error2]);
+  t.true(step1.calledWith(0));
+  t.true(step2.calledWith(0));
+  t.true(step3.calledWith(0));
+});
+
+test('Execute each function in series passing a transformed input even if a Promise rejects', async t => {
+  const error2 = new Error('test error 2');
+  const error3 = new Error('test error 3');
+  const step1 = stub().resolves(1);
+  const step2 = stub().rejects(error2);
+  const step3 = stub().rejects(error3);
+  const step4 = stub().resolves(4);
+
+  const errors = await t.throws(
+    pipeline([step1, step2, step3, step4])(0, true, (prevResult, result) => prevResult + result)
+  );
+
+  t.deepEqual(Array.from(errors), [error2, error3]);
+  t.true(step1.calledWith(0));
+  t.true(step2.calledWith(0 + 1));
+  t.true(step3.calledWith(0 + 1 + error2));
+  t.true(step4.calledWith(0 + 1 + error2 + error3));
 });


### PR DESCRIPTION
Currently if an error is returned by a plugin's `verifyConditions` or `verifyRelease`,  semantic-release log the error and exit.
So if there is multiple plugins configured for `verifyConditions` or `verifyRelease` and several of them returns an error (i.e. multiple plugins are misconfigured) only the first error will be logged. That create a situation of trial and error for the user (run => plugin 1 errors out => fix config => run plugins 2 errors out => etc...).

With this PR all the plugins for `verifyConditions` and `verifyRelease` are executed, and all the errors are logged. This should help users to configure semantic-release more easily. It will also be beneficial if we create a report/notification feature (like GitHub issue or Slack message )

The `publish` step still stop at the first error.

If there are problems within the same `verifyConditions` or `verifyRelease` plugin, only the first issue will be logged though. It would be up to the plugin to test everything and return an [aggregate-error](https://github.com/sindresorhus/aggregate-error). Not sure it worth modifying our plugins though.