### PR TITLE
fix: prioritize `GIT_CREDENTIALS` for gtit credentials

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -2,7 +2,7 @@ const {parse, format} = require('url');
 const {isUndefined} = require('lodash');
 const gitUrlParse = require('git-url-parse');
 
-const GIT_TOKENS = ['GH_TOKEN', 'GITHUB_TOKEN', 'GL_TOKEN', 'GITLAB_TOKEN', 'GIT_CREDENTIALS'];
+const GIT_TOKENS = ['GIT_CREDENTIALS', 'GH_TOKEN', 'GITHUB_TOKEN', 'GL_TOKEN', 'GITLAB_TOKEN'];
 
 /**
  * Generate the git repository URL with creadentials.


### PR DESCRIPTION
Allow to defined a both `GIT_CREDENTIALS` for repository access and `GH_TOKEN` or `GL_TOKEN` for API access