### PR TITLE
fix: always transform `git+https` URLs to `https`

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -19,11 +19,12 @@ module.exports = repositoryUrl => {
     ? `gitlab-ci-token:${process.env[envVar]}`
     : process.env[envVar];
 
-  if (!gitCredentials) {
-    return repositoryUrl;
-  }
-
   const {protocols} = gitUrlParse(repositoryUrl);
   const protocol = protocols.includes('https') ? 'https' : protocols.includes('http') ? 'http' : 'https';
+
+  if (!gitCredentials) {
+    return protocols.includes('https') ? `${gitUrlParse(repositoryUrl).toString(protocol)}.git` : repositoryUrl;
+  }
+
   return format({...parse(`${gitUrlParse(repositoryUrl).toString(protocol)}.git`), ...{auth: gitCredentials}});
 };

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -63,7 +63,7 @@ test.serial('Default values, reading repositoryUrl from repo if not set in packa
 });
 
 test.serial('Default values, reading repositoryUrl (http url) from package.json if not set in repo', async t => {
-  const pkg = {repository: 'git+https://hostname.com/owner/module.git'};
+  const pkg = {repository: 'https://hostname.com/owner/module.git'};
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
   // Create package.json in repository root
@@ -82,7 +82,7 @@ test.serial('Read options from package.json', async t => {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},
     generateNotes: 'generateNotes',
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -103,7 +103,7 @@ test.serial('Read options from .releaserc.yml', async t => {
   const release = {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -124,7 +124,7 @@ test.serial('Read options from .releaserc.json', async t => {
   const release = {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -145,7 +145,7 @@ test.serial('Read options from .releaserc.js', async t => {
   const release = {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -166,7 +166,7 @@ test.serial('Read options from release.config.js', async t => {
   const release = {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -217,7 +217,7 @@ test.serial('Read configuration from file path in "extends"', async t => {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},
     generateNotes: 'generateNotes',
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -245,7 +245,7 @@ test.serial('Read configuration from module path in "extends"', async t => {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},
     generateNotes: 'generateNotes',
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -273,7 +273,7 @@ test.serial('Read configuration from an array of paths in "extends"', async t =>
     verifyRelease: 'verifyRelease1',
     analyzeCommits: {path: 'analyzeCommits1', param: 'analyzeCommits_param1'},
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
   };
 
   const shareable2 = {
@@ -318,7 +318,7 @@ test.serial('Prioritize configuration from config file over "extends"', async t 
     generateNotes: 'generateNotesShareable',
     publish: [{path: 'publishShareable', param: 'publishShareable_param'}],
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
     tagFormat: `v\${version}`,
   };
 
@@ -346,7 +346,7 @@ test.serial('Prioritize configuration from cli/API options over "extends"', asyn
     extends: './shareable2.json',
     branch: 'branch_opts',
     publish: [{path: 'publishOpts', param: 'publishOpts_param'}],
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
   };
   const release = {
     extends: './shareable1.json',
@@ -359,7 +359,7 @@ test.serial('Prioritize configuration from cli/API options over "extends"', asyn
     generateNotes: 'generateNotesShareable1',
     publish: [{path: 'publishShareable', param: 'publishShareable_param1'}],
     branch: 'test_branch1',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
   };
   const shareable2 = {
     analyzeCommits: 'analyzeCommits2',
@@ -388,7 +388,7 @@ test.serial('Allow to unset properties defined in shareable config with "null"',
     extends: './shareable.json',
     analyzeCommits: null,
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
   };
   const shareable = {
     generateNotes: 'generateNotes',
@@ -422,7 +422,7 @@ test.serial('Allow to unset properties defined in shareable config with "undefin
     extends: './shareable.json',
     analyzeCommits: undefined,
     branch: 'test_branch',
-    repositoryUrl: 'git+https://hostname.com/owner/module.git',
+    repositoryUrl: 'https://hostname.com/owner/module.git',
   };
   const shareable = {
     generateNotes: 'generateNotes',

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -14,9 +14,20 @@ test.afterEach.always(() => {
   process.env = envBackup;
 });
 
-test.serial('Return the same "repositoryUrl" is no "gitCredentials" is defined', t => {
+test.serial('Return the same "git" formatted URL if "gitCredentials" is not defined', t => {
   t.is(getAuthUrl('git@host.com:owner/repo.git'), 'git@host.com:owner/repo.git');
 });
+
+test.serial('Return the same "https" formatted URL if "gitCredentials" is not defined', t => {
+  t.is(getAuthUrl('https://host.com/owner/repo.git'), 'https://host.com/owner/repo.git');
+});
+
+test.serial(
+  'Return the "https" formatted URL if "gitCredentials" is not defined and repositoryUrl is a "git+https" URL',
+  t => {
+    t.is(getAuthUrl('git+https://host.com/owner/repo.git'), 'https://host.com/owner/repo.git');
+  }
+);
 
 test.serial('Return the "https" formatted URL if "gitCredentials" is defined and repositoryUrl is a "git" URL', t => {
   process.env.GIT_CREDENTIALS = 'user:pass';


### PR DESCRIPTION
Git url with format `git+https` are not supported when used in `git push <URL> ref`. It errors out with `fatal: Unable to find remote helper for 'git+https'`.

In some rare cases `get-git-auth-url.js` is producing a `git+https` URL.
It happens if:
- The repository is a GitHub `https` URL as `normalize-package-data` transforms it to a `git+https` URL
- No Git authentication is set (for example when the user uses ssh keys) as in that case `get-git-auth-url.js` returns the URL as is