### PR TITLE
fix: get npm global node_modules to resolve global dependencies

### DIFF
--- a/lib/plugins/normalize.js
+++ b/lib/plugins/normalize.js
@@ -3,6 +3,7 @@ const {inspect} = require('util');
 const SemanticReleaseError = require('@semantic-release/error');
 const {isString, isObject, isFunction, noop, cloneDeep} = require('lodash');
 const resolveFrom = require('resolve-from');
+var childProcess = require('child_process');
 
 module.exports = (pluginType, pluginsPath, globalOpts, pluginOpts, logger, validator) => {
   if (!pluginOpts) {
@@ -18,12 +19,15 @@ module.exports = (pluginType, pluginsPath, globalOpts, pluginOpts, logger, valid
     }
   }
 
+  const globalNodeModulesPath = childProcess.execSync('npm root -g').toString().trim();
+  console.log(globalNodeModulesPath);
+
   const basePath = pluginsPath[path]
-    ? dirname(resolveFrom.silent(__dirname, pluginsPath[path]) || resolveFrom(process.cwd(), pluginsPath[path]))
+    ? dirname(resolveFrom.silent(__dirname, pluginsPath[path]) || resolveFrom.silent(globalNodeModulesPath, pluginsPath[path]) || resolveFrom(process.cwd(), pluginsPath[path]))
     : __dirname;
   const plugin = isFunction(path)
     ? path
-    : require(resolveFrom.silent(basePath, path) || resolveFrom(process.cwd(), path));
+    : require(resolveFrom.silent(basePath, path) || resolveFrom.silent(globalNodeModulesPath, path) || resolveFrom(process.cwd(), path));
 
   let func;
   if (isFunction(plugin)) {


### PR DESCRIPTION
We need the option to use global installed node_modules e.g. for dockerized semantic-release independent of tech stack (java, go, node, ..).

This is not the smartest solution and just a suggestion which functionality is needed. 