### PR TITLE
fix: debug log all options

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -45,23 +45,13 @@ module.exports = async (opts, logger) => {
   // Set default options values if not defined yet
   options = {
     branch: 'master',
-    repositoryUrl: (await pkgRepoUrl()) || (await repoUrl()),
+    repositoryUrl: getGitAuthUrl((await pkgRepoUrl()) || (await repoUrl())),
     tagFormat: `v\${version}`,
     // Remove `null` and `undefined` options so they can be replaced with default ones
     ...pickBy(options, option => !isUndefined(option) && !isNull(option)),
   };
 
-  debug('options values: %O', Object.keys(options));
-  debug('name: %O', options.name);
-  debug('branch: %O', options.branch);
-  debug('repositoryUrl: %O', options.repositoryUrl);
-  debug('analyzeCommits: %O', options.analyzeCommits);
-  debug('generateNotes: %O', options.generateNotes);
-  debug('verifyConditions: %O', options.verifyConditions);
-  debug('verifyRelease: %O', options.verifyRelease);
-  debug('publish: %O', options.publish);
-
-  options.repositoryUrl = options.repositoryUrl ? getGitAuthUrl(options.repositoryUrl) : options.repositoryUrl;
+  debug('options values: %O', options);
 
   return {options, plugins: await plugins(options, pluginsPath, logger)};
 };


### PR DESCRIPTION
Since #623, it's now safe to log more debug info. This way we log all options with `debug`, including the one specific to plugins. That would help troubleshooting.