### PR TITLE
 fix: set repository authentication when `repositoryUrl` is set as an option

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -42,16 +42,16 @@ module.exports = async (opts, logger) => {
     };
   }
 
-  const repositoryUrl = (await pkgRepoUrl()) || (await repoUrl());
-
   // Set default options values if not defined yet
   options = {
     branch: 'master',
-    repositoryUrl: repositoryUrl ? getGitAuthUrl(repositoryUrl) : repositoryUrl,
+    repositoryUrl: (await pkgRepoUrl()) || (await repoUrl()),
     tagFormat: `v\${version}`,
     // Remove `null` and `undefined` options so they can be replaced with default ones
     ...pickBy(options, option => !isUndefined(option) && !isNull(option)),
   };
+
+  options.repositoryUrl = options.repositoryUrl ? getGitAuthUrl(options.repositoryUrl) : options.repositoryUrl;
 
   debug('options values: %O', options);
 

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -31,7 +31,8 @@ test.afterEach.always(() => {
 });
 
 test.serial('Default values, reading repositoryUrl from package.json', async t => {
-  const pkg = {repository: 'git@package.com:owner/module.git'};
+  process.env.GIT_CREDENTIALS = 'user:pass';
+  const pkg = {repository: 'https://package.com/owner/module.git'};
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
   await gitCommits(['First']);
@@ -44,25 +45,27 @@ test.serial('Default values, reading repositoryUrl from package.json', async t =
 
   // Verify the default options are set
   t.is(options.branch, 'master');
-  t.is(options.repositoryUrl, 'git@package.com:owner/module.git');
+  t.is(options.repositoryUrl, 'https://user:pass@package.com/owner/module.git');
   t.is(options.tagFormat, `v\${version}`);
 });
 
 test.serial('Default values, reading repositoryUrl from repo if not set in package.json', async t => {
+  process.env.GIT_CREDENTIALS = 'user:pass';
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
   // Add remote.origin.url config
-  await gitAddConfig('remote.origin.url', 'git@repo.com:owner/module.git');
+  await gitAddConfig('remote.origin.url', 'https://hostname.com/owner/module.git');
 
   const {options} = await t.context.getConfig();
 
   // Verify the default options are set
   t.is(options.branch, 'master');
-  t.is(options.repositoryUrl, 'git@repo.com:owner/module.git');
+  t.is(options.repositoryUrl, 'https://user:pass@hostname.com/owner/module.git');
   t.is(options.tagFormat, `v\${version}`);
 });
 
 test.serial('Default values, reading repositoryUrl (http url) from package.json if not set in repo', async t => {
+  process.env.GIT_CREDENTIALS = 'user:pass';
   const pkg = {repository: 'https://hostname.com/owner/module.git'};
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();
@@ -73,7 +76,7 @@ test.serial('Default values, reading repositoryUrl (http url) from package.json 
 
   // Verify the default options are set
   t.is(options.branch, 'master');
-  t.is(options.repositoryUrl, pkg.repository);
+  t.is(options.repositoryUrl, 'https://user:pass@hostname.com/owner/module.git');
   t.is(options.tagFormat, `v\${version}`);
 });
 

--- a/test/helpers/mockserver.js
+++ b/test/helpers/mockserver.js
@@ -4,7 +4,8 @@ import got from 'got';
 import pRetry from 'p-retry';
 import {mockServerClient} from 'mockserver-client';
 
-const IMAGE = 'jamesdbloom/mockserver:latest';
+// TODO temporarly use `mockserver-5.3.0` due to https://github.com/jamesdbloom/mockserver/issues/435
+const IMAGE = 'jamesdbloom/mockserver:mockserver-5.3.0';
 const MOCK_SERVER_PORT = 1080;
 const MOCK_SERVER_HOST = 'localhost';
 const docker = new Docker();


### PR DESCRIPTION
If `repositoryUrl` is set as a sematnic-release option (via `--repository-url` or `repositoryUrl` in `package.json`) the `GIT_CREDENTIALS` are not applied to the URL.

/cc @trollr 