### PR TITLE
fix: remove the github plugin from default success and fail hooks

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -166,3 +166,27 @@ CLI argument: `--publish`
 Define the list of [publish plugins](plugins.md#publish-plugin). Plugins will run in series, in the order defined in the `Array`.
 
 See [Plugins configuration](plugins.md#configuration) for more details.
+
+### success
+
+Type: `Array`, `String`, `Object`
+
+Default: `[]`
+
+CLI argument: `--success`
+
+Define the list of [success plugins](plugins.md#success-plugin). Plugins will run in series, in the order defined in the `Array`.
+
+See [Plugins configuration](plugins.md#configuration) for more details.
+
+### fail
+
+Type: `Array`, `String`, `Object`
+
+Default: `[]`
+
+CLI argument: `--fail`
+
+Define the list of [fail plugins](plugins.md#fail-plugin). Plugins will run in series, in the order defined in the `Array`.
+
+See [Plugins configuration](plugins.md#configuration) for more details.

--- a/lib/definitions/plugins.js
+++ b/lib/definitions/plugins.js
@@ -47,13 +47,13 @@ module.exports = {
     },
   },
   success: {
-    default: ['@semantic-release/github'],
+    default: false,
     config: {
       validator: conf => !conf || (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
     },
   },
   fail: {
-    default: ['@semantic-release/github'],
+    default: false,
     config: {
       validator: conf => !conf || (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -596,7 +596,7 @@ test.serial('Returns falsy value if triggered by a PR', async t => {
 
   t.falsy(await semanticRelease({repositoryUrl}));
   t.is(
-    t.context.log.args[9][0],
+    t.context.log.args[t.context.log.args.length - 1][0],
     "This run was triggered by a pull request and therefore a new version won't be published."
   );
 });
@@ -723,8 +723,8 @@ test.serial('Hide sensitive environment variable values from the logs', async t 
 
   await t.throws(semanticRelease(options));
 
-  t.regex(t.context.stdout.args[9][0], /Console: The token \[secure\] is invalid/);
-  t.regex(t.context.stdout.args[10][0], /Log: The token \[secure\] is invalid/);
+  t.regex(t.context.stdout.args[t.context.stdout.args.length - 2][0], /Console: The token \[secure\] is invalid/);
+  t.regex(t.context.stdout.args[t.context.stdout.args.length - 1][0], /Log: The token \[secure\] is invalid/);
   t.regex(t.context.stderr.args[0][0], /Error: The token \[secure\] is invalid/);
   t.regex(t.context.stderr.args[1][0], /Invalid token \[secure\]/);
 });


### PR DESCRIPTION
Fix #664 

TODO:
- [ ] Deprecate `13.3.0`, `13.3.1` and `13.4.0` on npm
- [ ] Make a breaking change commit that re-enable `@semantic-release/github` as the default for `success` and `fail`
- [ ] Update the release note of `14.0.0` with a migration guide, indicating to users who don't use `@semantic-release/github` to set `success` and `fail` to `false`

No need to change the `peerDependencies` of any plugin.