### PR TITLE
feat: use `@semantic-release/github` as default for `success` and `fail` hooks

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -171,7 +171,7 @@ See [Plugins configuration](plugins.md#configuration) for more details.
 
 Type: `Array`, `String`, `Object`
 
-Default: `[]`
+Default: `['@semantic-release/github']`
 
 CLI argument: `--success`
 
@@ -183,7 +183,7 @@ See [Plugins configuration](plugins.md#configuration) for more details.
 
 Type: `Array`, `String`, `Object`
 
-Default: `[]`
+Default: `['@semantic-release/github']`
 
 CLI argument: `--fail`
 

--- a/lib/definitions/plugins.js
+++ b/lib/definitions/plugins.js
@@ -47,13 +47,13 @@ module.exports = {
     },
   },
   success: {
-    default: false,
+    default: ['@semantic-release/github'],
     config: {
       validator: conf => !conf || (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
     },
   },
   fail: {
-    default: false,
+    default: ['@semantic-release/github'],
     config: {
       validator: conf => !conf || (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
     },


### PR DESCRIPTION
BREAKING CHANGE: `success` and `fail` hooks are now enabled by default

In order to disable the `@semantic-release/github` plugin for the `success` and `fail` hook, the corresponding options have to be set to `false` in the **semantic-release** configuration:

```json
{
  "release": {
    "success": false,
    "fail": false
  }
}
```

Users who do not use the `@semantic-release/github` plugin, should disable it in the `success` and `fail` by setting the corresponding options to `false` or to alternative plugin providing `success` and `fail` hooks.