### PR TITLE
fix: do not transform repositoryUrl if it allow to push

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -3,7 +3,7 @@ const readPkgUp = require('read-pkg-up');
 const cosmiconfig = require('cosmiconfig');
 const resolveFrom = require('resolve-from');
 const debug = require('debug')('semantic-release:config');
-const {repoUrl} = require('./git');
+const {repoUrl, verifyAuth} = require('./git');
 const PLUGINS_DEFINITIONS = require('./definitions/plugins');
 const plugins = require('./plugins');
 const getGitAuthUrl = require('./get-git-auth-url');
@@ -51,7 +51,9 @@ module.exports = async (opts, logger) => {
     ...pickBy(options, option => !isUndefined(option) && !isNull(option)),
   };
 
-  options.repositoryUrl = options.repositoryUrl ? getGitAuthUrl(options.repositoryUrl) : options.repositoryUrl;
+  if (!await verifyAuth(options.repositoryUrl, options.branch)) {
+    options.repositoryUrl = options.repositoryUrl ? getGitAuthUrl(options.repositoryUrl) : options.repositoryUrl;
+  }
 
   debug('options values: %O', options);
 

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -80,6 +80,19 @@ test.serial('Default values, reading repositoryUrl (http url) from package.json 
   t.is(options.tagFormat, `v\${version}`);
 });
 
+test.serial('Do not add git credential to repositoryUrl if push is allowed', async t => {
+  process.env.GIT_CREDENTIALS = 'user:pass';
+  // Create a git repository, set the current working directory at the root of the repo
+  const repositoryUrl = await gitRepo(true);
+  const pkg = {repository: repositoryUrl};
+  // Create package.json in repository root
+  await outputJson('./package.json', pkg);
+
+  const {options} = await t.context.getConfig();
+
+  t.is(options.repositoryUrl, repositoryUrl);
+});
+
 test.serial('Read options from package.json', async t => {
   const release = {
     analyzeCommits: {path: 'analyzeCommits', param: 'analyzeCommits_param'},

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -603,11 +603,11 @@ test.serial('Exit with 1 if missing permission to push to the remote repository'
 
   // Create a git repository, set the current working directory at the root of the repo
   t.log('Create git repository');
-  const {repositoryUrl} = await gitbox.createRepo(packageName);
+  await gitbox.createRepo(packageName);
   await writeJson('./package.json', {
     name: packageName,
     version: '0.0.0-dev',
-    repository: {url: repositoryUrl},
+    repository: {url: 'http://user:wrong_pass@localhost:2080/git/unauthorized.git'},
   });
 
   /* Initial release */


### PR DESCRIPTION
Fix #667

Use the unmodified configured repositoryUrl (without adding the credentials) if it works, otherwise do as of now and convert the URL to `http`/`https` and add the credentials.

This allow users to push tags and commits via ssh while still using the GitHub/GitLab API.