### PR TITLE
fix: verify branch first

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,16 @@ async function run(options, plugins) {
     return;
   }
 
-  if (!await verify(options, branch, logger)) {
-    return;
+  if (branch !== options.branch) {
+    logger.log(
+      `This test run was triggered on the branch ${branch}, while semantic-release is configured to only publish from ${
+        options.branch
+      }, therefore a new version won’t be published.`
+    );
+    return false;
   }
+
+  await verify(options);
 
   logger.log('Run automated release from branch %s', options.branch);
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -3,7 +3,7 @@ const AggregateError = require('aggregate-error');
 const {isGitRepo, verifyAuth, verifyTagName} = require('./git');
 const getError = require('./get-error');
 
-module.exports = async (options, branch, logger) => {
+module.exports = async options => {
   const errors = [];
 
   if (!await isGitRepo()) {
@@ -29,15 +29,4 @@ module.exports = async (options, branch, logger) => {
   if (errors.length > 0) {
     throw new AggregateError(errors);
   }
-
-  if (branch !== options.branch) {
-    logger.log(
-      `This test run was triggered on the branch ${branch}, while semantic-release is configured to only publish from ${
-        options.branch
-      }, therefore a new version won’t be published.`
-    );
-    return false;
-  }
-
-  return true;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -302,9 +302,9 @@ test.serial('Log all "verifyConditions" errors', async t => {
     './lib/logger': t.context.logger,
     'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
   });
-  const errors = await t.throws(semanticRelease(options));
+  const errors = [...(await t.throws(semanticRelease(options)))];
 
-  t.deepEqual(Array.from(errors), [error1, error2, error3]);
+  t.deepEqual(errors, [error1, error2, error3]);
   t.deepEqual(t.context.log.args[t.context.log.args.length - 2], ['%s error 2', 'ERR2']);
   t.deepEqual(t.context.log.args[t.context.log.args.length - 1], ['%s error 3', 'ERR3']);
   t.deepEqual(t.context.error.args[t.context.error.args.length - 1], [
@@ -345,9 +345,9 @@ test.serial('Log all "verifyRelease" errors', async t => {
     './lib/logger': t.context.logger,
     'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
   });
-  const errors = await t.throws(semanticRelease(options));
+  const errors = [...(await t.throws(semanticRelease(options)))];
 
-  t.deepEqual(Array.from(errors), [error1, error2]);
+  t.deepEqual(errors, [error1, error2]);
   t.deepEqual(t.context.log.args[t.context.log.args.length - 2], ['%s error 1', 'ERR1']);
   t.deepEqual(t.context.log.args[t.context.log.args.length - 1], ['%s error 2', 'ERR2']);
   t.is(fail.callCount, 1);
@@ -428,9 +428,9 @@ test.serial('Dry-run skips fail', async t => {
     './lib/logger': t.context.logger,
     'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
   });
-  const errors = await t.throws(semanticRelease(options));
+  const errors = [...(await t.throws(semanticRelease(options)))];
 
-  t.deepEqual(Array.from(errors), [error1, error2]);
+  t.deepEqual(errors, [error1, error2]);
   t.deepEqual(t.context.log.args[t.context.log.args.length - 2], ['%s error 1', 'ERR1']);
   t.deepEqual(t.context.log.args[t.context.log.args.length - 1], ['%s error 2', 'ERR2']);
   t.is(fail.callCount, 0);
@@ -785,7 +785,7 @@ test.serial('Throw SemanticReleaseError if repositoryUrl is not set and cannot b
     './lib/logger': t.context.logger,
     'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
   });
-  const errors = Array.from(await t.throws(semanticRelease()));
+  const errors = [...(await t.throws(semanticRelease()))];
 
   // Verify error code and type
   t.is(errors[0].code, 'ENOREPOURL');


### PR DESCRIPTION
Verify the branch is the release branch before doing any other verification.
Otherwise the plugin and Git authentication are verified when building on other branches. If the branch is in a cloned repo (if building pushes from PR's) the environment variables will not be available and semantic-release will wrongly report the authentication error.