### PR TITLE
fix: exclude empty env var value from replacement

### DIFF
--- a/lib/hide-sensitive.js
+++ b/lib/hide-sensitive.js
@@ -1,6 +1,9 @@
 const {escapeRegExp} = require('lodash');
 
-const toReplace = Object.keys(process.env).filter(envVar => /token|password|credential|secret|private/i.test(envVar));
+const toReplace = Object.keys(process.env).filter(
+  envVar => /token|password|credential|secret|private/i.test(envVar) && process.env[envVar].trim()
+);
+
 const regexp = new RegExp(toReplace.map(envVar => escapeRegExp(process.env[envVar])).join('|'), 'g');
 
 module.exports = output => {

--- a/test/hide-sensitive.test.js
+++ b/test/hide-sensitive.test.js
@@ -40,3 +40,18 @@ test.serial('Accept "undefined" input', t => {
 test.serial('Return same string if no environment variable has to be replaced', t => {
   t.is(require('../lib/hide-sensitive')('test'), 'test');
 });
+
+test.serial('Exclude empty environment variables from the regexp', t => {
+  process.env.SOME_PASSWORD = 'password';
+  process.env.SOME_TOKEN = '';
+  t.is(
+    require('../lib/hide-sensitive')(`https://user:${process.env.SOME_PASSWORD}@host.com?token=`),
+    'https://user:[secure]@host.com?token='
+  );
+});
+
+test.serial('Exclude empty environment variables from the regexp if there is only empty ones', t => {
+  process.env.SOME_PASSWORD = '';
+  process.env.SOME_TOKEN = ' \n ';
+  t.is(require('../lib/hide-sensitive')(`https://host.com?token=`), 'https://host.com?token=');
+});


### PR DESCRIPTION
Fix #646