### PR TITLE
Configuration: environment variable `DEBUG` must be set to `semantic-release:*`

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -105,7 +105,7 @@ Default: `false`
 
 CLI argument: `--debug`
 
-Output debugging information. It can also be enabled by set the `DEBUG` environment variable to `semantic-release`.
+Output debugging information. It can also be enabled by set the `DEBUG` environment variable to `semantic-release:*`.
 
 ### verifyConditions
 


### PR DESCRIPTION
`semantic-release` will not work. `semantic-release*` will work, too, and is better because it will also work for logs where we use just 'semantic-release' as scope. Let me know if you’d like me to change that