### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@semantic-release/release-notes-generator": "^6.0.0",
     "aggregate-error": "^1.0.0",
     "chalk": "^2.3.0",
-    "commander": "^2.11.0",
     "cosmiconfig": "^4.0.0",
     "debug": "^3.1.0",
     "env-ci": "^1.0.0",


### PR DESCRIPTION
It doesn't seem Semantic Release still uses commander anywhere