### PR TITLE
docs: fix grammar and typos in CI configuration, configuration, and shareable configuration guides

### DIFF
--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -20,7 +20,7 @@ See [CI configuration recipes](../recipes/README.md#ci-configurations) for more 
 
 Alternatively the Git authentication can be set up via [SSH keys](../recipes/git-auth-ssh-keys.md).
 
-Most **semantic-release** [plugins](plugins.md) require to set up authentication in order to publish to a package manager registry. The default [npm](https://github.com/semantic-release/npm#environment-variables) and [github](https://github.com/semantic-release/github#environment-variables) plugins require the following environment variables:
+Most **semantic-release** [plugins](plugins.md) require setting up authentication in order to publish to a package manager registry. The default [npm](https://github.com/semantic-release/npm#environment-variables) and [github](https://github.com/semantic-release/github#environment-variables) plugins require the following environment variables:
 
 | Variable    | Description                                                                                                                                                                                                                                                                                                               |
 |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -35,7 +35,7 @@ See [CI configuration recipes](../recipes/README.md#ci-configurations) for more 
 
 ## Automatic setup with `semantic-release-cli`
 
-[`semantic-release-cli`](https://github.com/semantic-release/cli) allow to easily [install](installation.md) **semantic-release** in your Node project and set up the CI configuration:
+[`semantic-release-cli`](https://github.com/semantic-release/cli) allows for easy [installation](installation.md) of **semantic-release** in your Node project as well as setting up the CI configuration:
 
 ```bash
 npm install -g semantic-release-cli

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -27,7 +27,7 @@ $ semantic-release
 
 **Note**: CLI arguments take precedence over options configured in the configuration file.
 
-**Note**: Plugins options cannot be defined via CLI arguments and must be defined in the configuration file.
+**Note**: Plugin options cannot be defined via CLI arguments and must be defined in the configuration file.
 
 ## Options
 
@@ -37,7 +37,7 @@ Type: `Array`, `String`
 
 CLI arguments: `-e`, `--extends`
 
-List of modules or file paths containing a [shareable configuration](shareable-configurations.md). If multiple shareable configuration are set, they will be imported in the order defined with each configuration option taking precedence over the options defined in a previous shareable configuration.
+List of modules or file paths containing a [shareable configuration](shareable-configurations.md). If multiple shareable configurations are set, they will be imported in the order defined with each configuration option taking precedence over the options defined in a previous shareable configuration.
 
 **Note**: Options defined via CLI arguments or in the configuration file will take precedence over the ones defined in any shareable configuration.
 
@@ -79,7 +79,7 @@ The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) format used by 
 
 Type: `Boolean`
 
-Default: `false` if running in a CI environment, `false` otherwise
+Default: `false` if running in a CI environment, `true` otherwise
 
 CLI arguments: `-d`, `--dry-run`
 
@@ -93,7 +93,7 @@ Default: `false`
 
 CLI arguments: `--no-ci`
 
-Skip Continuous Integration environment verifications, allowing to make releases from a local machine.
+Skip Continuous Integration environment verifications. This allows for making releases from a local machine.
 
 ### debug
 
@@ -103,7 +103,7 @@ Default: `false`
 
 CLI argument: `--debug`
 
-Output debugging information. It can also be enabled by set the `DEBUG` environment variable to `semantic-release:*`.
+Output debugging information. It can also be enabled by setting the `DEBUG` environment variable to `semantic-release:*`.
 
 ### verifyConditions
 

--- a/docs/usage/shareable-configurations.md
+++ b/docs/usage/shareable-configurations.md
@@ -1,5 +1,5 @@
 # Shareable configurations
 
-A sharable configuration is an [npm](https://www.npmjs.com/) package that exports a **semantic-release** configuration object. It allows to easily use the same configuration across several projects.
+A sharable configuration is an [npm](https://www.npmjs.com/) package that exports a **semantic-release** configuration object. It allows for use of the same configuration across several projects.
 
 The shareable configurations to use can be set with the [extends](configuration.md#extends) option.


### PR DESCRIPTION
This PR relates to issue #653 

Fix minor grammar and spelling errors in  ci-configuration.md, configuration.md, and shareable-configurations.md.

Fix default value in the documentation for dryRun option, dryRun is set to `true` when not running in CI environment