### PR TITLE
fix: correct `git merge-base` exit code detection

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -36,9 +36,15 @@ async function gitTags() {
  */
 async function isRefInHistory(ref) {
   try {
-    return (await execa('git', ['merge-base', '--is-ancestor', ref, 'HEAD'])).code === 0;
+    await execa('git', ['merge-base', '--is-ancestor', ref, 'HEAD']);
+    return true;
   } catch (err) {
+    if (err.code === 1) {
+      return false;
+    }
+
     debug(err);
+    throw err;
   }
 }
 


### PR DESCRIPTION
### Problem

Seeing some of `git merge-base` errors in CI:

```shell
14:37:33 2018-04-02T21:42:01.215Z semantic-release:git Error: Command failed: git merge-base --is-ancestor v4.4.2 HEAD
14:37:33 
14:37:33 
14:37:33     at makeError (/Users/jenkinspan/jenkins/looperJobs/ReactNative_SharedModule/ws/node_modules/semantic-release/node_modules/execa/index.js:172:9)
14:37:33     at Promise.all.then.arr (/Users/jenkinspan/jenkins/looperJobs/ReactNative_SharedModule/ws/node_modules/semantic-release/node_modules/execa/index.js:277:16)
14:37:33     at <anonymous>
14:37:33     at process._tickCallback (internal/process/next_tick.js:188:7)
14:37:33 2018-04-02T21:42:01.239Z semantic-release:git Error: Command failed: git merge-base --is-ancestor v4.4.1 HEAD
14:37:33 
14:37:33 
14:37:33     at makeError (/Users/jenkinspan/jenkins/looperJobs/ReactNative_SharedModule/ws/node_modules/semantic-release/node_modules/execa/index.js:172:9)
14:37:33     at Promise.all.then.arr (/Users/jenkinspan/jenkins/looperJobs/ReactNative_SharedModule/ws/node_modules/semantic-release/node_modules/execa/index.js:277:16)
14:37:33     at <anonymous>
14:37:33     at process._tickCallback (internal/process/next_tick.js:188:7)
```

What's happening?

It turns out that `git merge-base --is-ancestor` is expected to exit with `1` in certain cases. Via the `git merge-base` documentation for `git version 2.15.1 (Apple Git-101)`:

```
       --is-ancestor
           Check if the first <commit> is an ancestor of the second <commit>, and exit with status 0 if true, or with status
           1 if not. Errors are signaled by a non-zero status that is not 1.
```

### Solution

Check for exit code in `isRefInHistory` and return false when `--is-ancestor` doesn't exist.

### Testing

Help. See if CI passes???