### PR TITLE
fix(package): update git-url-parse to version 8.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "execa": "^0.10.0",
     "get-stream": "^3.0.0",
     "git-log-parser": "^1.2.0",
-    "git-url-parse": "^8.1.0",
+    "git-url-parse": "^8.3.1",
     "hook-std": "^0.4.0",
     "hosted-git-info": "^2.6.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Explicitly upgrade to `git-url-parse` to 8.3.1 as 8.3.1 has a bug: https://github.com/IonicaBizau/git-url-parse/issues/65

Fix #727