### PR TITLE
fix: match tag to `tagFormat` from the begining of the string

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -28,7 +28,8 @@ module.exports = async (tagFormat, logger) => {
   // by replacing the `version` variable in the template by `(.+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
-  const tagRegexp = escapeRegExp(template(tagFormat)({version: ' '})).replace(' ', '(.+)');
+  const tagRegexp = `^${escapeRegExp(template(tagFormat)({version: ' '})).replace(' ', '(.+)')}`;
+
   const tags = (await gitTags())
     .map(tag => ({gitTag: tag, version: (tag.match(tagRegexp) || new Array(2))[1]}))
     .filter(

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -62,6 +62,19 @@ test.serial('Get the highest tag in the history of the current branch', async t 
   t.deepEqual(result, {gitHead: commits[0].hash, gitTag: 'v2.0.0', version: '2.0.0'});
 });
 
+test.serial('Match the tag name from the begining of the string', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+  const commits = await gitCommits(['First']);
+  await gitTagVersion('prefix/v1.0.0');
+  await gitTagVersion('prefix/v2.0.0');
+  await gitTagVersion('other-prefix/v3.0.0');
+
+  const result = await getLastRelease(`prefix/v\${version}`, t.context.logger);
+
+  t.deepEqual(result, {gitHead: commits[0].hash, gitTag: 'prefix/v2.0.0', version: '2.0.0'});
+});
+
 test.serial('Return empty object if no valid tag is found', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   await gitRepo();


### PR DESCRIPTION
Fix #735