### PR TITLE
docs: add link to shareable configs and plugins list

### DIFF
--- a/docs/usage/plugins.md
+++ b/docs/usage/plugins.md
@@ -2,6 +2,8 @@
 
 Each [release step](../../README.md#release-steps) is implemented within a plugin or a list of plugins that can be configured. This allows for support of different [commit message formats](../../README.md#commit-message-format), release note generators and publishing platforms.
 
+See [plugins list](../extending/plugins-list.md).
+
 ## Plugin types
 
 ### verifyConditions plugin

--- a/docs/usage/shareable-configurations.md
+++ b/docs/usage/shareable-configurations.md
@@ -3,3 +3,5 @@
 A sharable configuration is an [npm](https://www.npmjs.com/) package that exports a **semantic-release** configuration object. It allows for use of the same configuration across several projects.
 
 The shareable configurations to use can be set with the [extends](configuration.md#extends) option.
+
+See [shareable configurations list](../extending/shareable-configurations-list.md).


### PR DESCRIPTION
Fix #737