### PR TITLE
fix: use `git rev-parse origin/${branch}` to verify origin head

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -143,10 +143,10 @@ async function verifyTagName(tagName) {
  *
  * @param {String} branch The repository branch for which to verify status.
  *
- * @return {Boolean} `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, `false` otherwise.
+ * @return {Boolean} `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
  */
 async function isBranchUpToDate(branch) {
-  return isRefInHistory(await execa.stdout('git', ['rev-parse', `${branch}@{u}`]));
+  return isRefInHistory(await execa.stdout('git', ['rev-parse', `origin/${branch}`]));
 }
 
 module.exports = {


### PR DESCRIPTION
Fix #786.

Seems to fix the issue according to https://github.com/semantic-release/semantic-release/issues/786#issuecomment-387830848