### PR TITLE
fix: add clarification in EGITNOPERMISSION error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ async function run(options, plugins) {
 
   await verify(options);
 
+  const {repositoryUrl} = options;
   options.repositoryUrl = await getGitAuthUrl(options);
 
   if (!(await isBranchUpToDate(options.branch))) {
@@ -68,7 +69,7 @@ async function run(options, plugins) {
     await verifyAuth(options.repositoryUrl, options.branch);
   } catch (err) {
     logger.error(`The command "${err.cmd}" failed with the error message %s.`, err.stderr);
-    throw getError('EGITNOPERMISSION', {options});
+    throw getError('EGITNOPERMISSION', {options, repositoryUrl});
   }
 
   logger.log('Run automated release from branch %s', options.branch);

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -27,15 +27,17 @@ Please make sure to add the \`repositoryUrl\` to the [semantic-release configura
       'docs/usage/configuration.md'
     )}).`,
   }),
-  EGITNOPERMISSION: ({options}) => ({
+  EGITNOPERMISSION: ({options, repositoryUrl}) => ({
     message: 'The push permission to the Git repository is required.',
     details: `**semantic-release** cannot push the version tag to the branch \`${
       options.branch
-    }\` on remote Git repository.
+    }\` on remote Git repository with URL \`${repositoryUrl}\`.
 
 Please refer to the [authentication configuration documentation](${linkify(
       'docs/usage/ci-configuration.md#authentication'
-    )}) to configure the Git credentials on your CI environment.`,
+    )}) to configure the Git credentials on your CI environment and make sure the [repositoryUrl](${linkify(
+      'docs/usage/configuration.md#repositoryurl'
+    )}) is configured with a [valid Git URL](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols).`,
   }),
   EINVALIDTAGFORMAT: ({tagFormat}) => ({
     message: 'Invalid `tagFormat` option.',


### PR DESCRIPTION
Clarify that the error might be due to an invalid `repositoryUrl` configuration.

Fix #795