### PR TITLE
 fix: use `git ls-remote` to verify if the remote branch is ahead

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,17 +56,16 @@ async function run(options, plugins) {
 
   options.repositoryUrl = await getGitAuthUrl(options);
 
-  if (!(await isBranchUpToDate(options.branch))) {
-    logger.log(
-      "The local branch %s is behind the remote one, therefore a new version won't be published.",
-      options.branch
-    );
-    return false;
-  }
-
   try {
     await verifyAuth(options.repositoryUrl, options.branch);
   } catch (err) {
+    if (!(await isBranchUpToDate(options.repositoryUrl, options.branch))) {
+      logger.log(
+        "The local branch %s is behind the remote one, therefore a new version won't be published.",
+        options.branch
+      );
+      return false;
+    }
     logger.error(`The command "${err.cmd}" failed with the error message %s.`, err.stderr);
     throw getError('EGITNOPERMISSION', {options});
   }

--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ async function run(options, plugins) {
 
   await verify(options);
 
-  const {repositoryUrl} = options;
   options.repositoryUrl = await getGitAuthUrl(options);
 
   if (!(await isBranchUpToDate(options.branch))) {
@@ -69,7 +68,7 @@ async function run(options, plugins) {
     await verifyAuth(options.repositoryUrl, options.branch);
   } catch (err) {
     logger.error(`The command "${err.cmd}" failed with the error message %s.`, err.stderr);
-    throw getError('EGITNOPERMISSION', {options, repositoryUrl});
+    throw getError('EGITNOPERMISSION', {options});
   }
 
   logger.log('Run automated release from branch %s', options.branch);

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -27,11 +27,11 @@ Please make sure to add the \`repositoryUrl\` to the [semantic-release configura
       'docs/usage/configuration.md'
     )}).`,
   }),
-  EGITNOPERMISSION: ({options, repositoryUrl}) => ({
+  EGITNOPERMISSION: ({options}) => ({
     message: 'The push permission to the Git repository is required.',
     details: `**semantic-release** cannot push the version tag to the branch \`${
       options.branch
-    }\` on remote Git repository with URL \`${repositoryUrl}\`.
+    }\` on remote Git repository with URL \`${options.repositoryUrl}\`.
 
 Please refer to the [authentication configuration documentation](${linkify(
       'docs/usage/ci-configuration.md#authentication'

--- a/lib/git.js
+++ b/lib/git.js
@@ -141,12 +141,19 @@ async function verifyTagName(tagName) {
 /**
  * Verify the local branch is up to date with the remote one.
  *
+ * @param {String} repositoryUrl The remote repository URL.
  * @param {String} branch The repository branch for which to verify status.
  *
  * @return {Boolean} `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
  */
-async function isBranchUpToDate(branch) {
-  return isRefInHistory(await execa.stdout('git', ['rev-parse', `origin/${branch}`]));
+async function isBranchUpToDate(repositoryUrl, branch) {
+  try {
+    return await isRefInHistory(
+      (await execa.stdout('git', ['ls-remote', '--heads', repositoryUrl, branch])).match(/^(\w+)?/)[1]
+    );
+  } catch (err) {
+    debug(err);
+  }
 }
 
 module.exports = {

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -24,7 +24,6 @@ import {
   gitCommitTag,
   gitRemoteTagHead,
   push as pushUtil,
-  reset,
 } from './helpers/git-utils';
 
 // Save the current working diretory
@@ -189,31 +188,35 @@ test.serial('Throws error if obtaining the tags fails', async t => {
 });
 
 test.serial('Return "true" if repository is up to date', async t => {
-  await gitRepo(true);
+  const repositoryUrl = await gitRepo(true);
   await gitCommits(['First']);
   await pushUtil();
 
-  t.true(await isBranchUpToDate('master'));
+  t.true(await isBranchUpToDate(repositoryUrl, 'master'));
 });
 
 test.serial('Return falsy if repository is not up to date', async t => {
-  await gitRepo(true);
+  const repositoryUrl = await gitRepo(true);
+  const repoDir = process.cwd();
   await gitCommits(['First']);
   await gitCommits(['Second']);
   await pushUtil();
 
-  t.true(await isBranchUpToDate('master'));
+  t.true(await isBranchUpToDate(repositoryUrl, 'master'));
 
-  await reset();
+  await gitShallowClone(repositoryUrl);
+  await gitCommits(['Third']);
+  await pushUtil();
+  process.chdir(repoDir);
 
-  t.falsy(await isBranchUpToDate('master'));
+  t.falsy(await isBranchUpToDate(repositoryUrl, 'master'));
 });
 
 test.serial('Return "true" if local repository is ahead', async t => {
-  await gitRepo(true);
+  const repositoryUrl = await gitRepo(true);
   await gitCommits(['First']);
   await pushUtil();
   await gitCommits(['Second']);
 
-  t.true(await isBranchUpToDate('master'));
+  t.true(await isBranchUpToDate(repositoryUrl, 'master'));
 });

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -212,12 +212,3 @@ export async function gitCommitTag(gitHead) {
 export async function push(repositoryUrl = 'origin', branch = 'master') {
   await execa('git', ['push', '--tags', repositoryUrl, `HEAD:${branch}`]);
 }
-
-/**
- * Reset repository to a commit.
- *
- * @param {String} [commit='HEAD~1'] Commit reference to reset the repo to.
- */
-export async function reset(commit = 'HEAD~1') {
-  await execa('git', ['reset', commit]);
-}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,7 +15,6 @@ import {
   gitRemoteTagHead,
   push,
   gitShallowClone,
-  reset,
 } from './helpers/git-utils';
 
 // Save the current process.env
@@ -645,11 +644,15 @@ test.serial('Returns falsy value if triggered by a PR', async t => {
 test.serial('Returns falsy value if triggered on an outdated clone', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const repositoryUrl = await gitRepo(true);
+  const repoDir = process.cwd();
   // Add commits to the master branch
   await gitCommits(['First']);
   await gitCommits(['Second']);
   await push();
-  await reset();
+  await gitShallowClone(repositoryUrl);
+  await gitCommits(['Third']);
+  await push();
+  process.chdir(repoDir);
 
   const semanticRelease = proxyquire('..', {
     './lib/logger': t.context.logger,

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import {writeJson, readJson} from 'fs-extra';
 import {stub} from 'sinon';
 import execa from 'execa';
-import {gitHead as getGitHead, gitTagHead, gitRepo, gitCommits, gitRemoteTagHead} from './helpers/git-utils';
+import {gitHead as getGitHead, gitTagHead, gitRepo, gitCommits, gitRemoteTagHead, push} from './helpers/git-utils';
 import gitbox from './helpers/gitbox';
 import mockServer from './helpers/mockserver';
 import npmRegistry from './helpers/npm-registry';
@@ -609,6 +609,7 @@ test.serial('Exit with 1 if missing permission to push to the remote repository'
   /* Initial release */
   t.log('Commit a feature');
   await gitCommits(['feat: Initial commit']);
+  await push();
   t.log('$ semantic-release');
   const {stdout, code} = await execa(
     cli,


### PR DESCRIPTION
Fix #793

This change use `git ls-remote` instead of `git rev-parse origin/branch` to obtain the head sha of the remote branch. This way it's the actual remote head that is retrieved instead of the one present in the local `.git/refs/heads/branch`.

The problem in #793 happens when a commit is pushed to the repo after the CI created the clone. In that situation the remote repo is ahead but the clone is not aware of that. Using `git ls-remote` solve this issue.