### PR TITLE
Add SemVer compatibility badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
   <a href="https://greenkeeper.io">
     <img alt="Greenkeeper" src="https://badges.greenkeeper.io/semantic-release/semantic-release.svg">
   </a>
+  <a href="https://dependabot.com/compatibility-score.html?dependency-name=semantic-release&package-manager=npm_and_yarn&version-scheme=semver">
+    <img alt="semver-compatibility" src="https://api.dependabot.com/badges/compatibility_score?dependency-name=semantic-release&package-manager=npm_and_yarn&version-scheme=semver">
+  </a>
   <a href="#badge">
     <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
   </a>


### PR DESCRIPTION
Would you be up for adding a badge that shows how SemVer compliant / bug free new releases are? I was looking through the data we gather at Dependabot and realised we could put one together, so threw together the below:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=semantic-release&package-manager=npm_and_yarn&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=semantic-release&package-manager=npm_and_yarn&version-scheme=semver)

Would love your opinion - is it useful? Anything you'd change about it (e.g., keep / lose the logo)? If you click it there's an explanation of how it's calculated. I guess for `semantic-release` there's no reason why this dependency would ever break tests, so your 100% score is pretty much guaranteed.

Any feedback super appreciated!