### PR TITLE
feat: allow to disable the publish plugin hook

### DIFF
--- a/lib/definitions/plugins.js
+++ b/lib/definitions/plugins.js
@@ -45,7 +45,7 @@ module.exports = {
   publish: {
     default: ['@semantic-release/npm', '@semantic-release/github'],
     config: {
-      validator: conf => Boolean(conf) && (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
+      validator: conf => !conf || (isArray(conf) ? conf : [conf]).every(conf => validatePluginConfig(conf)),
     },
     output: {
       validator: output => !output || isPlainObject(output),

--- a/test/definitions/plugins.test.js
+++ b/test/definitions/plugins.test.js
@@ -60,9 +60,9 @@ test('The "prepare" plugin, if defined, must be a single or an array of plugins 
 test('The "publish" plugin is mandatory, and must be a single or an array of plugins definition', t => {
   t.false(plugins.publish.config.validator({}));
   t.false(plugins.publish.config.validator({path: null}));
-  t.false(plugins.publish.config.validator());
 
   t.true(plugins.publish.config.validator({path: 'plugin-path.js'}));
+  t.true(plugins.publish.config.validator());
   t.true(plugins.publish.config.validator('plugin-path.js'));
   t.true(plugins.publish.config.validator(() => {}));
   t.true(plugins.publish.config.validator([{path: 'plugin-path.js'}, 'plugin-path.js', () => {}]));


### PR DESCRIPTION
This change allow to disable the `publish` hook (or to configure no plugins for that step).

The rational behind checking a plugin is set for the `publish` step was that there is no reason to run semantic-release at all if nothing get published.
However a lot of thing change since then and we now have the `prepare` step and the core is now creating the git tag.

So there might be situation where a user want to only create a tag, and maybe create a commit with the `@semantic-release/git` plugin during the `prepare` step. In such situation nothing should happen in the `publish` step (no npm release, no github release etc...), therefore it make senses to disable it. 