### PR TITLE
fix: add debug log for `git fetch` command

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -54,7 +54,11 @@ async function isRefInHistory(ref) {
  * @param {String} repositoryUrl The remote repository URL.
  */
 async function unshallow(repositoryUrl) {
-  await execa('git', ['fetch', '--unshallow', '--tags', repositoryUrl], {reject: false});
+  try {
+    await execa('git', ['fetch', '--unshallow', '--tags', repositoryUrl]);
+  } catch (err) {
+    debug(err);
+  }
 }
 
 /**


### PR DESCRIPTION
Certain CI do not provide the tags, even after a `git fetch --unshallow --tags`.
Logging the error with `debug` would help troubleshooting such CIs environments.