### PR TITLE
fix: use unauthenticated URL to check if branch is up to date

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ async function run(options, plugins) {
   try {
     await verifyAuth(options.repositoryUrl, options.branch);
   } catch (err) {
-    if (!(await isBranchUpToDate(options.repositoryUrl, options.branch))) {
+    if (!(await isBranchUpToDate(options.branch))) {
       logger.log(
         "The local branch %s is behind the remote one, therefore a new version won't be published.",
         options.branch

--- a/lib/git.js
+++ b/lib/git.js
@@ -145,15 +145,14 @@ async function verifyTagName(tagName) {
 /**
  * Verify the local branch is up to date with the remote one.
  *
- * @param {String} repositoryUrl The remote repository URL.
  * @param {String} branch The repository branch for which to verify status.
  *
  * @return {Boolean} `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
  */
-async function isBranchUpToDate(repositoryUrl, branch) {
+async function isBranchUpToDate(branch) {
   try {
     return await isRefInHistory(
-      (await execa.stdout('git', ['ls-remote', '--heads', repositoryUrl, branch])).match(/^(\w+)?/)[1]
+      (await execa.stdout('git', ['ls-remote', '--heads', 'origin', branch])).match(/^(\w+)?/)[1]
     );
   } catch (err) {
     debug(err);

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -206,11 +206,11 @@ test.serial('Throws error if obtaining the tags fails', async t => {
 });
 
 test.serial('Return "true" if repository is up to date', async t => {
-  const repositoryUrl = await gitRepo(true);
+  await gitRepo(true);
   await gitCommits(['First']);
   await gitPush();
 
-  t.true(await isBranchUpToDate(repositoryUrl, 'master'));
+  t.true(await isBranchUpToDate('master'));
 });
 
 test.serial('Return falsy if repository is not up to date', async t => {
@@ -220,21 +220,21 @@ test.serial('Return falsy if repository is not up to date', async t => {
   await gitCommits(['Second']);
   await gitPush();
 
-  t.true(await isBranchUpToDate(repositoryUrl, 'master'));
+  t.true(await isBranchUpToDate('master'));
 
   await gitShallowClone(repositoryUrl);
   await gitCommits(['Third']);
   await gitPush();
   process.chdir(repoDir);
 
-  t.falsy(await isBranchUpToDate(repositoryUrl, 'master'));
+  t.falsy(await isBranchUpToDate('master'));
 });
 
 test.serial('Return "true" if local repository is ahead', async t => {
-  const repositoryUrl = await gitRepo(true);
+  await gitRepo(true);
   await gitCommits(['First']);
   await gitPush();
   await gitCommits(['Second']);
 
-  t.true(await isBranchUpToDate(repositoryUrl, 'master'));
+  t.true(await isBranchUpToDate('master'));
 });


### PR DESCRIPTION
Fix #838

In case the authentication token provided is unauthorized the call to `isBranchUpToDate` will fail due to lack of read permission if that URL is used. As a result the error about outdated local branch will be reported instead of the one about missing permission.
By using the original (unauthenticated) URL `isBranchUpToDate` shouldn't fail due to permission as it requires only read permissions, that are necessarily present as the CI was able to clone the repo.

The issue #838 has been opened for several days now, I tested on my own and @wejendorp tested as well (see https://github.com/semantic-release/semantic-release/issues/838#issuecomment-401775032) so I think we can merge it.
