### PR TITLE
fix: allow empty release notes in dry-run mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,9 @@ async function run(options, plugins) {
     logger.log('Call plugin %s', 'generate-notes');
     const notes = await plugins.generateNotes(generateNotesParam);
     logger.log('Release note for version %s:\n', nextRelease.version);
-    process.stdout.write(`${marked(notes)}\n`);
+    if (notes) {
+      process.stdout.write(`${marked(notes)}\n`);
+    }
   } else {
     logger.log('Call plugin %s', 'generateNotes');
     nextRelease.notes = await plugins.generateNotes(generateNotesParam);


### PR DESCRIPTION
Fix #822