### PR TITLE
Unnecessary use of package url

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -1,4 +1,3 @@
-const {parse, format} = require('url');
 const {isUndefined} = require('lodash');
 const gitUrlParse = require('git-url-parse');
 const hostedGitInfo = require('hosted-git-info');
@@ -32,11 +31,12 @@ module.exports = async ({cwd, env, options: {repositoryUrl, branch}}) => {
     // Expand shorthand URLs (such as `owner/repo` or `gitlab:owner/repo`)
     repositoryUrl = info.https();
   } else {
-    const {protocols} = gitUrlParse(repositoryUrl);
+    const {protocols, ...parsed} = gitUrlParse(repositoryUrl);
 
     // Replace `git+https` and `git+http` with `https` or `http`
     if (protocols.includes('http') || protocols.includes('https')) {
-      repositoryUrl = format({...parse(repositoryUrl), protocol: protocols.includes('https') ? 'https' : 'http'});
+      const protocol = protocols.includes('https') ? 'https' : 'http';
+      repositoryUrl = {...parsed, protocols: [protocol]}.toString(protocol);
     }
   }
 


### PR DESCRIPTION
While looking trough the code I noticed that there were two different packages doing the same job, parsing the urls, which seamed unnecessary. So i removed one of the packages and moved all the function to the other one, optimising the necessary number of packages to be imported.

Also, the only other place where the removed package is used is in `lib/definitions/errors.js` , if you want, I can also replace the use of the package there with the other package('git-url-parse) that is now used in the files and changes I made and remove the package('url) completely.