### PR TITLE
docs: add Waffle.io README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
   </a>
 </p>
 <p align="center">
+  <a href="https://waffle.io/semantic-release/semantic-release">
+    <img alt="Waffle.io" src="https://badge.waffle.io/semantic-release/semantic-release.svg?columns=all">
+  </a>
+</p>
+<p align="center">
   <a href="https://www.npmjs.com/package/semantic-release">
     <img alt="npm latest version" src="https://img.shields.io/npm/v/semantic-release/latest.svg">
   </a>


### PR DESCRIPTION
I created a Waffle board for the semantic-release organization: https://waffle.io/semantic-release/semantic-release.
I've been using it for a couple month and really love it!

Adding the badge on the README would allow user to easily track progress:
- Features currently worked on (In Progress)
- Features that will be implemented at some point (Backlog)
- Blocked issues that require answers (Pending)
- New issues + Issues to fix + feature requests under consideration (Inbox) 