### PR TITLE
feat: added --no-tag configuration option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -32,6 +32,7 @@ Usage:
     .option('publish', {...stringList, group: 'Plugins'})
     .option('success', {...stringList, group: 'Plugins'})
     .option('fail', {...stringList, group: 'Plugins'})
+    .option('no-tag', {describe: 'Skip creating git tag for repository', type: 'boolean', group: 'Options'})
     .option('debug', {describe: 'Output debugging information', type: 'boolean', group: 'Options'})
     .option('d', {alias: 'dry-run', describe: 'Skip publishing', type: 'boolean', group: 'Options'})
     .option('h', {alias: 'help', group: 'Options'})

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -100,6 +100,14 @@ CLI arguments: `-d`, `--dry-run`
 
 Dry-run mode, skip publishing, print next version and release notes.
 
+### noTag
+
+Type: `Boolean`<br>
+Default: `false`
+CLI arguments: `--no-tag`
+
+Skip adding and pushing tag for repository.
+
 ### ci
 
 Type: `Boolean`<br>

--- a/index.js
+++ b/index.js
@@ -102,10 +102,12 @@ async function run(context, plugins) {
     nextRelease.notes = await plugins.generateNotes(context);
     await plugins.prepare(context);
 
-    // Create the tag before calling the publish plugins as some require the tag to exists
-    await tag(nextRelease.gitTag, {cwd, env});
-    await push(options.repositoryUrl, options.branch, {cwd, env});
-    logger.success(`Created tag ${nextRelease.gitTag}`);
+    if (!options.noTag) {
+      // Create the tag before calling the publish plugins as some require the tag to exists
+      await tag(nextRelease.gitTag, {cwd, env});
+      await push(options.repositoryUrl, options.branch, {cwd, env});
+      logger.success(`Created tag ${nextRelease.gitTag}`);
+    }
 
     context.releases = await plugins.publish(context);
 


### PR DESCRIPTION
Sometimes I don't need to add and push git tag directly, but I want do it through plugins instead.
So I added option for such cases