### PR TITLE
feat: support multiple branches and distribution channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,14 @@ node_js:
   - 10
   - 8
 
-# Trigger a push build on master and greenkeeper branches + PRs build on every branches
+# Trigger a push build on release and greenkeeper branches + PRs build on every branches
 # Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
 branches:
   only:
     - master
+    - next
+    - beta
+    - /^\d+(.\d+)?.x$/
     - /^greenkeeper.*$/
 
 # Retry install on fail to avoid failing a build on network/disk/external errors

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
   <a href="https://www.npmjs.com/package/semantic-release">
     <img alt="npm next version" src="https://img.shields.io/npm/v/semantic-release/next.svg">
   </a>
+  <a href="https://www.npmjs.com/package/semantic-release">
+    <img alt="npm beta version" src="https://img.shields.io/npm/v/semantic-release/beta.svg">
+  </a>
 </p>
 
 **semantic-release** automates the whole package release workflow including: determining the next version number, generating the release notes and publishing the package.
@@ -44,6 +47,7 @@ This removes the immediate connection between human emotions and version numbers
 - New features and fixes are immediately available to users
 - Notify maintainers and users of new releases
 - Use formalized commit message convention to document changes in the codebase
+- Publish on different distribution channels (such as [npm dist-tags](https://docs.npmjs.com/cli/dist-tag)) based on git merges
 - Integrate with your [continuous integration workflow](docs/recipes/README.md#ci-configurations)
 - Avoid potential errors associated with manual releases
 - Support any [package managers and languages](docs/recipes/README.md#package-managers-and-languages) via [plugins](docs/usage/plugins.md)

--- a/cli.js
+++ b/cli.js
@@ -19,7 +19,7 @@ module.exports = async () => {
 Usage:
   semantic-release [options] [plugins]`);
     })
-    .option('b', {alias: 'branch', describe: 'Git branch to release from', type: 'string', group: 'Options'})
+    .option('b', {alias: 'branches', describe: 'Git branches to release from', ...stringList, group: 'Options'})
     .option('r', {alias: 'repository-url', describe: 'Git repository URL', type: 'string', group: 'Options'})
     .option('t', {alias: 'tag-format', describe: 'Git tag format', type: 'string', group: 'Options'})
     .option('p', {alias: 'plugins', describe: 'Plugins', ...stringList, group: 'Options'})

--- a/docs/developer-guide/js-api.md
+++ b/docs/developer-guide/js-api.md
@@ -123,11 +123,12 @@ Type: `Object`
 
 Information related to the last release found:
 
-| Name    | Type     | Description                                                                                        |
-|---------|----------|----------------------------------------------------------------------------------------------------|
-| version | `String` | The version of the last release.                                                                   |
-| gitHead | `String` | The sha of the last commit being part of the last release.                                         |
-| gitTag  | `String` | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the last release. |
+| Name    | Type     | Description                                                                                                                         |
+|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------|
+| version | `String` | The version of the last release.                                                                                                    |
+| gitHead | `String` | The sha of the last commit being part of the last release.                                                                          |
+| gitTag  | `String` | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the last release.                                  |
+| channel | `String` | The distribution channel on which the last release was initially made available (`undefined` for the default distribution channel). |
 
 **Notes**: If no previous release is found, `lastRelease` will be an empty `Object`.
 
@@ -137,6 +138,7 @@ Example:
   gitHead: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
   version: '1.0.0',
   gitTag: 'v1.0.0',
+  channel: 'next'
 }
 ```
 
@@ -206,13 +208,14 @@ Type: `Object`
 
 Information related to the newly published release:
 
-| Name    | Type     | Description                                                                                       |
-|---------|----------|---------------------------------------------------------------------------------------------------|
-| type    | `String` | The [semver](https://semver.org) type of the release (`patch`, `minor` or `major`).               |
-| version | `String` | The version of the new release.                                                                   |
-| gitHead | `String` | The sha of the last commit being part of the new release.                                         |
-| gitTag  | `String` | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the new release. |
-| notes   | `String` | The release notes for the new release.                                                            |
+| Name    | Type     | Description                                                                                                                   |
+|---------|----------|-------------------------------------------------------------------------------------------------------------------------------|
+| type    | `String` | The [semver](https://semver.org) type of the release (`patch`, `minor` or `major`).                                           |
+| version | `String` | The version of the new release.                                                                                               |
+| gitHead | `String` | The sha of the last commit being part of the new release.                                                                     |
+| gitTag  | `String` | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the new release.                             |
+| notes   | `String` | The release notes for the new release.                                                                                        |
+| channel | `String` | The distribution channel on which the next release will be made available (`undefined` for the default distribution channel). |
 
 Example:
 ```js
@@ -222,6 +225,7 @@ Example:
   version: '1.1.0',
   gitTag: 'v1.1.0',
   notes: 'Release notes for version 1.1.0...',
+  channel : 'next'
 }
 ```
 
@@ -229,19 +233,20 @@ Example:
 
 Type: `Array<Object>`
 
-The list of releases published, one release per [publish plugin](../usage/plugins.md#publish-plugin).<br>
+The list of releases published or made available to a distribution channel.<br>
 Each release object has the following properties:
 
-| Name       | Type     | Description                                                                                   |
-|------------|----------|-----------------------------------------------------------------------------------------------|
-| name       | `String` | **Optional.** The release name, only if set by the corresponding `publish` plugin.            |
-| url        | `String` | **Optional.** The release URL, only if set by the corresponding `publish` plugin.             |
-| type       | `String` | The [semver](https://semver.org) type of the release (`patch`, `minor` or `major`).           |
-| version    | `String` | The version of the release.                                                                   |
-| gitHead    | `String` | The sha of the last commit being part of the release.                                         |
-| gitTag     | `String` | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the release. |
-| notes      | `String` | The release notes for the release.                                                            |
-| pluginName | `String` | The name of the plugin that published the release.                                            |
+| Name       | Type     | Description                                                                                                    |
+|------------|----------|----------------------------------------------------------------------------------------------------------------|
+| name       | `String` | **Optional.** The release name, only if set by the corresponding `publish` plugin.                             |
+| url        | `String` | **Optional.** The release URL, only if set by the corresponding `publish` plugin.                              |
+| type       | `String` | The [semver](https://semver.org) type of the release (`patch`, `minor` or `major`).                            |
+| version    | `String` | The version of the release.                                                                                    |
+| gitHead    | `String` | The sha of the last commit being part of the release.                                                          |
+| gitTag     | `String` | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the release.                  |
+| notes      | `String` | The release notes for the release.                                                                             |
+| pluginName | `String` | The name of the plugin that published the release.                                                             |
+| channel    | `String` | The distribution channel on which the release is available (`undefined` for the default distribution channel). |
 
 Example:
 ```js
@@ -255,6 +260,7 @@ Example:
     gitTag: 'v1.1.0',
     notes: 'Release notes for version 1.1.0...',
     pluginName: '@semantic-release/github'
+    channel: 'next'
   },
   {
     name: 'npm package (@latest dist-tag)',
@@ -265,6 +271,7 @@ Example:
     gitTag: 'v1.1.0',
     notes: 'Release notes for version 1.1.0...',
     pluginName: '@semantic-release/npm'
+    channel: 'next'
    }
  ]
 ```

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -9,4 +9,9 @@
 ## Git hosted services
 - [Git authentication with SSH keys](git-auth-ssh-keys.md)
 
+## Release workflow
+- [Publishing on distribution channels](distribution-channels.md)
+- [Publishing maintenance releases](maintenance-releases.md)
+- [Publishing pre-releases](pre-releases.md)
+
 ## Package managers and languages

--- a/docs/recipes/distribution-channels.md
+++ b/docs/recipes/distribution-channels.md
@@ -1,0 +1,116 @@
+# Publishing on distribution channels
+
+This recipe will walk you through a simple example that uses distribution channels to make releases available only to a subset of users, in order to collect feedbacks before distributing the release to all users.
+
+This example uses the **semantic-release** default configuration:
+- [branches](../usage/configuration.md#branches): `['+([1-9])?(.{+([1-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
+- [plugins](../usage/configuration.md#plugins): `['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']`
+
+## Initial release
+
+We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit` to `master`. When pushing that commit, **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
+
+The Git history of the repository is:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+```
+
+## Releasing a bug fix
+
+We can now continue to commit changes and release updates to our users. For example we can commit a bug fix with the message `fix: a fix` to `master`. When pushing that commit, **semantic-release** will release the version `1.0.1` on the dist-tag `@latest`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+* fix: a fix # => v1.0.1 on @latest
+```
+
+## Releasing a feature on next
+
+We now want to develop an important feature, which is a breaking change. Considering the scope of this feature we want to make it available, at first, only to our most dedicated users in order to get feedback. Once we get that feedback we can make improvements and ultimately make the new feature available to all users.
+
+To implement that workflow we can create the branch `next` and commit our feature to this branch. When pushing that commit, **semantic-release** will release the version `2.0.0` on the dist-tag `@next`. That means only the users installing our module with `npm install example-module@next` will receive the version `2.0.0`. Other users installing with `npm install example-module` will still receive the version `1.0.1`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+* fix: a fix # => v1.0.1 on @latest
+| \
+|  * feat: a big feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0 on @next
+```
+
+## Releasing a bug fix on next
+
+One of our users starts to use the new `2.0.0` release and reports a bug. We develop a bug fix and commit it to the `next` branch with the message `fix: fix something on the big feature`. When pushing that commit, **semantic-release** will release the version `2.0.1` on the dist-tag `@next`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+* fix: a fix # => v1.0.1 on @latest
+| \
+|  * feat: a big feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0 on @next
+|  * fix: fix something on the big feature # => v2.0.1 on @next
+```
+
+## Releasing a feature on latest
+
+We now want to develop a smaller, non-breaking feature. Its scope is small enough that we don't need to have a phase of feedback and we can release it to all users right away.
+
+If we were to commit that feature on `next` only a subset of users would get it, and we would need to wait for the end of our feedback period in order to make both the big and the small feature available to all users.
+
+Instead, we develop that small feature commit it to `master` with the message `feat: a small feature`. When pushing that commit, **semantic-release** will release the version `1.1.0` on the dist-tag `@latest` so all users can benefit from it right away.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+* fix: a fix # => v1.0.1 on @latest
+| \
+|  * feat: a big feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0 on @next
+|  * fix: fix something on the big feature # => v2.0.1 on @next
+*  | feat: a small feature # => v1.1.0 on @latest
+```
+
+## Porting a feature to next
+
+Most of our users now have access to the small feature, but we still need to make it available to our users using the `@next` dist-tag. To do so we need to merge our changes made on `master` (the commit `feat: a small feature`) into `next`. As `master` and `next` branches have diverged, this merge might require to resolve conflicts.
+
+Once the conflicts are resolved and the merge commit is pushed to `next`, **semantic-release** will release the version `2.1.0` on the dist-tag `@next` which contains both our small and big feature.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+* fix: a fix # => v1.0.1 on @latest
+| \
+|  * feat: a big feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0 on @next
+|  * fix: fix something on the big feature # => v2.0.1 on @next
+*  | feat: a small feature # => v1.1.0 on @latest
+|  * Merge branch master into next # => v2.1.0 on @next
+```
+
+## Adding a version to latest
+
+After a period of feedback from our users using the `@next` dist-tag we feel confident to make our big feature available to all users. To do so we merge the `next` branch into `master`. There should be no conflict as `next` is strictly ahead of `master`.
+
+Once the merge commit is pushed to `next`, **semantic-release** will add the version `2.1.0` to the dist-tag `@latest` so all users will receive it when installing out module with `npm install example-module`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+* fix: a fix # => v1.0.1 on @latest
+| \
+|  * feat: a big feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0 on @next
+|  * fix: fix something on the big feature # => v2.0.1 on @next
+*  | feat: a small feature # => v1.1.0 on @latest
+|  * Merge branch master into next # => v2.1.0 on @next
+| /|
+*  | Merge branch next into master # => v2.1.0 on @latest
+```
+
+We can now continue to push new fixes and features on `master`, or a new breaking change on `next` as we did before.

--- a/docs/recipes/maintenance-releases.md
+++ b/docs/recipes/maintenance-releases.md
@@ -1,0 +1,156 @@
+# Publishing maintenance releases
+
+This recipe will walk you through a simple example that uses Git branches and distribution channels to publish fixes and features for old versions of a package.
+
+This example uses the **semantic-release** default configuration:
+- [branches](../usage/configuration.md#branches): `['+([1-9])?(.{+([1-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
+- [plugins](../usage/configuration.md#plugins): `['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']`
+
+## Initial release
+
+We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit`. When pushing that commit, on `master` **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
+
+The Git history of the repository is:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+```
+
+## Releasing a breaking change
+
+We now decide to drop Node.js 6 support for our package, and require Node.js 8 or higher, which is a breaking change.  
+
+We commit that change with the message `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required` to `master`. When pushing that commit, **semantic-release** will release the version `2.0.0` on the dist-tag `@latest`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+* feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required # => v2.0.0 on @latest
+```
+
+## Releasing a feature for version 1.x users
+
+One of our users request a new feature, however they cannot migrate to Node.js 8 or higher due to corporate policies.
+
+If we were to push that feature on `master` and release it, the new version would require Node.js 8 or higher as the release would also contains the commit `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required`.
+
+Instead, we create the branch `1.x` from the tag `v1.0.0` with the command `git checkout -b 1.x v1.0.0` and we commit that feature with the message `feat: a feature` to the branch `1.x`. When pushing that commit, **semantic-release** will release the version `1.1.0` on the dist-tag `@release-1.x` so users who can't migrate to Node.js 8 or higher can benefit from it.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+*  | feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required # => v2.0.0 on @latest
+|  * feat: a feature # => v1.1.0 on @1.x
+```
+
+## Releasing a bug fix for version 1.0.x users
+
+Another user currently using version `1.0.0` reports a bug. They cannot migrate to Node.js 8 or higher and they also cannot migrate to `1.1.0` as they do not use the feature developed in `feat: a feature` and their corporate policies require to go through a costly quality insurance process for each `minor` upgrades.
+
+In order to deliver the bug fix in a `patch` release, we create the branch `1.0.x` from the tag `v1.0.0` with the command `git checkout -b 1.0.x v1.0.0` and we commit that fix with the message `fix: a fix` to the branch `1.0.x`. When pushing that commit, **semantic-release** will release the version `1.0.1` on the dist-tag `@release-1.0.x` so users who can't migrate to `1.1.x` or `2.x` can benefit from it.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+*  | feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required # => v2.0.0 on @latest
+|  | \
+|  *  | feat: a feature # => v1.1.0 on @1.x
+|  |  * fix: a fix # => v1.0.1 on @1.0.x
+```
+
+## Porting a bug fix from 1.0.x to 1.x
+
+Now that we have released a fix in version `1.0.1` we want to make it available to `1.1.x` users as well.
+
+To do so we need to merge the changes made on `1.0.x` (the commit `fix: a fix`) into the `1.x` branch. As `1.0.x` and `1.x` branches have diverged, this merge might require to resolve conflicts.
+
+Once the conflicts are resolved and the merge commit is pushed to the branch `1.x`, **semantic-release** will release the version `1.1.1` on the dist-tag `@release-1.x` which contains both our feature and bug fix.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+*  | feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required # => v2.0.0 on @latest
+|  | \
+|  *  | feat: a feature # => v1.1.0 on @1.x
+|  |  * fix: a fix # => v1.0.1 on @1.0.x
+|  | /|
+|  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
+```
+
+## Porting bug fixes and features to master
+
+Finally we want to make both our feature and bug fix available to users using the `@latest` dist-tag.
+
+To do so we need to merge the changes made on `1.x` (the commits `feat: a feature` and `fix: a fix`) into `master`. As `1.x` and `master` branches have diverged, this merge might require to resolve conflicts.
+
+Once the conflicts are resolved and the merge commit is pushed to `master`, **semantic-release** will release the version `2.1.0` on the dist-tag `@latest` which now contains the breaking change feature, the feature and the bug fix.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+*  | feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required # => v2.0.0 on @latest
+|  | \
+|  *  | feat: a feature # => v1.1.0 on @1.x
+|  |  * fix: a fix # => v1.0.1 on @1.0.x
+|  | /|
+|  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
+| /|  |
+*  |  | Merge branch 1.x into master # => v2.1.0 on @latest
+```
+
+## Releasing a bug fix for version 2.1.0 users
+
+One of our users using the version `2.1.0` version reports a bug.
+
+We can simply commit the bug fix with the message `fix: another fix` to `master`. When pushing that commit, **semantic-release** will release the version `2.1.1` on the dist-tag `@latest`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+*  | feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required # => v2.0.0 on @latest
+|  | \
+|  *  | feat: a feature # => v1.1.0 on @1.x
+|  |  * fix: a fix # => v1.0.1 on @1.0.x
+|  | /|
+|  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
+| /|  |
+*  |  | Merge branch 1.x into master # => v2.1.0 on @latest
+*  |  | fix: another fix # => v2.1.1 on @latest
+```
+
+## Porting a bug fix from master to 1.x
+
+The bug fix `fix: another fix` also affects version `1.1.1` users, so we want to port it to the `1.x` branch.
+
+To do so we need to cherry pick our fix commit made on `master` (`fix: another fix`) into `1.x` with `git checkout 1.x && git cherry-pick <sha of fix: another fix>`. As `master` and `1.x` branches have diverged, the cherry picking might require to resolve conflicts.
+
+Once the conflicts are resolved and the commit is pushed to `1.x`, **semantic-release** will release the version `1.1.2` on the dist-tag `@release-1.x` which contains `feat: a feature`, `fix: a fix` and `fix: another fix` but not `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+*  | feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required # => v2.0.0 on @latest
+|  | \
+|  *  | feat: a feature # => v1.1.0 on @1.x
+|  |  * fix: a fix # => v1.0.1 on @1.0.x
+|  | /|
+|  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
+| /|  |
+*  |  | Merge branch 1.x into master # => v2.1.0 on @latest
+*  |  | fix: another fix # => v2.1.1 on @latest
+|  |  |
+|  *  | fix: another fix # => v1.1.2 on @1.x
+```

--- a/docs/recipes/pre-releases.md
+++ b/docs/recipes/pre-releases.md
@@ -1,0 +1,196 @@
+# Publishing pre-releases
+
+This recipe will walk you through a simple example that uses pre-releases to publish beta versions while working on a future major release and then make only one release on the default distribution.
+
+This example uses the **semantic-release** default configuration:
+- [branches](../usage/configuration.md#branches): `['+([1-9])?(.{+([1-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
+- [plugins](../usage/configuration.md#plugins): `['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']`
+
+## Initial release
+
+We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit`. When pushing that commit, on `master` **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
+
+The Git history of the repository is:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+```
+
+## Working on a future release
+
+We now decide to work on a future major release, which will be composed of multiple features, some of them being breaking changes. We want to publish our package for each new feature developed for test purpose, however we do not want to increment our package version or make it available to our users until all the features are developed and tested.
+
+To implement that workflow we can create the branch `beta` and commit our first feature there. When pushing that commit, **semantic-release** will publish the pre-release version `2.0.0-beta.1` on the dist-tag `@beta`. That allow us to run integration tests by installing our module with `npm install example-module@beta`. Other users installing with `npm install example-module` will still receive the version `1.0.0`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+```
+
+We can continue to work on our future release by committing and pushing other features or bug fixes on the `beta` branch. With each push, **semantic-release** will publish a new pre-release on the dist-tag `@beta`, which allow us to run our integration tests.
+
+With another feature, the Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+```
+
+## Releasing a bug fix on the default distribution channel
+
+In the meantime we can also continue to commit changes and release updates to our users.
+
+For example, we can commit a bug fix with the message `fix: a fix` to `master`. When pushing that commit, **semantic-release** will release the version `1.0.1` on the dist-tag `@latest`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+*  | fix: a fix # => v1.0.1 on @latest
+```
+
+## Working on another future release
+
+We now decide to work on another future major release, in parallel of the beta one, which will also be composed of multiple features, some of them being breaking changes.
+
+To implement that workflow we can create the branch `alpha` from the branch `beta` and commit our first feature there. When pushing that commit, **semantic-release** will publish the pre-release version `3.0.0-alpha.1` on the dist-tag `@alpha`. That allow us to run integration tests by installing our module with `npm install example-module@alpha`. Other users installing with `npm install example-module` will still receive the version `1.0.0`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+*  | fix: a fix # => v1.0.1 on @latest
+|  | \
+|  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
+```
+
+We can continue to work on our future release by committing and pushing other features or bug fixes on the `alpha` branch. With each push, **semantic-release** will publish a new pre-release on the dist-tag `@alpha`, which allow us to run our integration tests.
+
+With another feature, the Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+*  | fix: a fix # => v1.0.1 on @latest
+|  | \
+|  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
+|  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
+```
+
+## Publishing the 2.0.0 beta release to the default distribution channel
+
+Once we've developed and pushed all the feature we want to include in the future version `2.0.0` in the `beta` branch and all our tests are successful we can release it to our users.
+
+To do so we need to merge our changes made on `beta` into `master`. As `beta` and `master` branches have diverged, this merge might require to resolve conflicts.
+
+Once the conflicts are resolved and the merge commit is pushed to `master`, **semantic-release** will release the version `2.0.0` on the dist-tag `@latest`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+*  | fix: a fix # => v1.0.1 on @latest
+|  | \
+|  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
+|  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
+| /|  |
+*  |  | Merge branch beta into master # => v2.0.0 on @latest
+```
+
+## Publishing the 3.0.0 alpha release to the beta distribution channel
+
+Now that we published our the version `2.0.0` that was previously in beta, we decide to promote the version `3.0.0` in alpha to beta.
+
+To do so we need to merge our changes made on `alpha` into `beta`. There should be no conflict as `alpha` is strictly ahead of `master`.
+
+Once the merge commit is pushed to `beta`, **semantic-release** will publish the pre-release version `3.0.0-beta.1` on the dist-tag `@beta`, which allow us to run our integration tests.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+*  | fix: a fix # => v1.0.1 on @latest
+|  | \
+|  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
+|  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
+| /|  |
+*  |  | Merge branch beta into master # => v2.0.0 on @latest
+|  | /|
+|  *  | Merge branch alpha into beta # => v3.0.0-beta.1 on @beta
+```
+
+## Publishing the 3.0.0 beta release to the default distribution channel
+
+Once we've developed and pushed all the feature we want to include in the future version `3.0.0` in the `beta` branch and all our tests are successful we can release it to our users.
+
+To do so we need to merge our changes made on `beta` into `master`. As `beta` and `master` branches have diverged, this merge might require to resolve conflicts.
+
+Once the conflicts are resolved and the merge commit is pushed to `master`, **semantic-release** will release the version `3.0.0` on the dist-tag `@latest`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+*  | fix: a fix # => v1.0.1 on @latest
+|  | \
+|  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
+|  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
+| /|  |
+*  |  | Merge branch beta into master # => v2.0.0 on @latest
+|  | /|
+|  *  | Merge branch alpha into beta # => v3.0.0-beta.1 on @beta
+| /|  |
+*  |  | Merge branch beta into master # => v3.0.0 on @latest
+```
+
+## Working on a third future release
+
+We can now start to work on a new future major release, version `4.0.0`, on the `@beta` distribution channel.
+
+To do so we fist need to update the `beta` branch with all the changes from `master` (the commits `fix: a fix`). As `beta` and `master` branches have diverged, this merge might require to resolve conflicts.
+
+We can now commit our new feature on `beta`. When pushing that commit, **semantic-release** will publish the pre-release version `3.1.0-beta.1` on the dist-tag `@beta`. That allow us to run integration tests by installing our module with `npm install example-module@beta`. Other users installing with `npm install example-module` will still receive the version `3.0.0`.
+
+The Git history of the repository is now:
+
+```
+* feat: initial commit # => v1.0.0 on @latest
+| \
+|  * feat: first feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0-beta.1 on @beta
+|  * feat: second feature # => v2.0.0-beta.2 on @beta
+*  | fix: a fix # => v1.0.1 on @latest
+|  | \
+|  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
+|  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
+| /|  |
+*  |  | Merge branch beta into master # => v2.0.0 on @latest
+|  | /|
+|  *  | Merge branch alpha into beta # => v3.0.0-beta.1 on @beta
+| /|  |
+*  |  | Merge branch beta into master # => v3.0.0 on @latest
+| \|  |
+|  *  | Merge branch master into beta
+|  *  | feat: new feature # => v3.1.0-beta.1 on @beta
+```

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 **semantic-release** configuration consists of:
-- Git repository options ([URL](#repositoryurl), [release branch](#branch) and [tag format](#tagformat))
+- Git repository options ([URL](#repositoryurl), [release branches](#branches) and [tag format](#tagformat))
 - [plugins](#plugins) definition
 - run mode ([debug](#debug), [dry run](#dryrun) and [local (no CI)](#ci))
 
@@ -25,7 +25,7 @@ Via `release` key in the project's `package.json` file:
 ```json
 {
   "release": {
-    "branch": "next"
+    "branches": ["master", "next"]
   }
 }
 ```
@@ -37,7 +37,7 @@ Via `.releaserc` file:
 
 ```json
 {
-  "branch": "next"
+  "branches": ["master", "next"]
 }
 ```
 ```bash
@@ -67,13 +67,23 @@ List of modules or file paths containing a [shareable configuration](shareable-c
 
 **Note**: Options defined via CLI arguments or in the configuration file will take precedence over the ones defined in any shareable configuration.
 
-### branch
+### branches
 
-Type: `String`<br>
-Default: `master`<br>
-CLI arguments: `-b`, `--branch`
+Type: `Array`, `String`, `Object`<br>
+Default: `['+([1-9])?(.{+([1-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`<br>
+CLI arguments: `--branches`
 
-The branch on which releases should happen.
+The branches on which releases should happen. By default **semantic-release** will release:
+- regular releases to the default distribution channel from the branch `master`
+- regular releases to a distribution channel matching the branch name from any existing branch with a name matching a maintenance release range (`N.N.x` or `N.x.x` or `N.x` with `N` being a number)
+- regular releases to the `next` distribution channel from the branch `next` if it exists
+- regular releases  to the `next-major` distribution channel from the branch `next-major` if it exists
+- prereleases to the `beta` distribution channel from the branch `beta` if it exists
+- prereleases to the `alpha` distribution channel from the branch `alpha` if it exists
+
+**Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://help.github.com/articles/about-protected-branches).
+
+See [Plugins configuration](plugins.md#plugins) for more details.
 
 ### repositoryUrl
 
@@ -144,7 +154,7 @@ Output debugging information. This can also be enabled by setting the `DEBUG` en
 
 ## Existing version tags
 
-**semantic-release** uses [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) to determine the commits added since the last release. If a release has been published before setting up **semantic-release** you must make sure the most recent commit included in the last published release is in the [release branch](#branch) history and is tagged with the version released, formatted according to the [tag format](#tagformat) configured (defaults to `vx.y.z`).
+**semantic-release** uses [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) to determine the commits added since the last release. If a release has been published before setting up **semantic-release** you must make sure the most recent commit included in the last published release is in the [release branches](#branches) history and is tagged with the version released, formatted according to the [tag format](#tagformat) configured (defaults to `vx.y.z`).
 
 If the previous releases were published with [`npm publish`](https://docs.npmjs.com/cli/publish) this should already be the case.
 

--- a/docs/usage/workflow-configuration.md
+++ b/docs/usage/workflow-configuration.md
@@ -1,0 +1,187 @@
+# Workflow configuration
+
+**semantic-release** allow to manage and automate complex release workflow, based on multiple Git branches and distribution channels. This allow to:
+- Distributes certain releases to a particular group of users via distribution channels
+- Manage the availability of releases on distribution channels via branches merge
+- Maintain multiple lines of releases in parrallel
+- Work on large future releases outside the normal flow of one version increment per Git push
+
+See [Release workflow recipes](../recipes/README.md#release-workflow) for detailed examples.
+
+The release workflow is configured via the [branches option](./configuration.md#branches) which accepts a single or an array of branch definitions.
+Each branch can be defined either as a string, a [glob](https://github.com/micromatch/micromatch#matching-features) or an object. For string and glob definitions each [property](#branches-properties) will be defaulted.
+
+A branch can defined as one of three types:
+- [release](#release-branches): to make releases on top of the last version released
+- [maintenance](#maintenance-branches): to make release on top of an old release
+- [pre-release](#pre-release-branches): to make pre-releases
+
+The type of the branch is automatically determined based on naming convention and/or [properties](#branches-properties).
+
+## Branches properties
+
+| Property     | Branch type                               | Description                                                                                                                                                                           | Default                                                                                         |
+|--------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `name`       | All                                       | **Required.** The Git branch holding the commits to analyze and the code to release. See [name](#name).                                                                               | - The value itself if defined as a `String` or the matching branches name if defined as a glob. |
+| `channel`    | All                                       | The distribution channel on which to publish releases from this branch. See [channel](#channel).                                                                                      | `undefined` for the first release branch, the value of `name` for subsequent ones.              |
+| `range`      | [maintenance](#maintenance-branches) only | **Required unless `name` is formatted like `N.N.x` or `N.x` (`N` is a number).** The range of [semantic versions](https://semver.org) to support on this branch. See [range](#range). | The value of `name`.                                                                            |
+| `prerelease` | [pre-release](#pre-release-branches) only | **Required.** The pre-release detonation to append to [semantic versions](https://semver.org) released from this branch. See [prerelease](#prerelease).                               | -                                                                                               |
+
+### name
+
+A `name` is required for any type of branch.
+It can be defined as a [glob](https://github.com/micromatch/micromatch#matching-features) in which case the definition will be expanded to one per matching branch existing in the repository.
+
+If `name` doesn't match to any branch existing in the repository, the definition will be ignored. For example the default configuration includes the definition `next` and `next-major` which will become active only when the branches `next` and/or `next-major` are created in the repository. This allow to define your workflow once with all potential branches you might use and have the effective configuration evolving as you create new branches.
+
+For example the configuration `['+([1-9])?(.{+([1-9]),x}).x', 'master', 'next']` will be expanded as:
+```js
+{
+  branches: [
+    {name: '1.x', range: '1.x', channel: '1.x'}, // Only after the `1.x` is created in the repo
+    {name: '2.x', range: '2.x', channel: '2.x'}, // Only after the `2.x` is created in the repo
+    {name: 'master'},
+    {name: 'next', channel: 'next'}, // Only after the `next` is created in the repo
+  ]
+}
+```
+
+### channel
+
+The `channel` can be defined for any branch type. If it's not defined, releases will be done on the default distribution channel (for example the `@latest` [dist-tag](https://docs.npmjs.com/cli/dist-tag) for npm).
+The value of `channel`, if defined, is generated with [Lodash template](https://lodash.com/docs#template) with the variable `name` available.
+
+For example the configuration `['master', {name: 'next', channel: 'channel-${name}'}]` will be expanded as:
+```js
+{
+  branches: [
+    {name: 'master'}, // `channel` is undefined so the default distribution channel will be used
+    {name: 'next', channel: 'channel-next'}, // `channel` is built with the template `channel-${name}`
+  ]
+}
+```
+
+### range
+
+A `range` only applies to maintenance branches, is required and must be formatted like `N.N.x` or `N.x` (`N` is a number). In case the `name` is formatted as a range (for example `1.x` or `1.5.x`) the branch will be considered a maintenance branch and the `name` value will be used for the `range`.
+
+For example the configuration `['1.1.x', '1.2.x', 'master']` will be expanded as:
+```js
+{
+  branches: [
+    {name: '1.1.x', range: '1.1.x', channel: '1.1.x'},
+    {name: '1.2.x', range: '1.2.x', channel: '1.2.x'},
+    {name: 'master'},
+  ]
+}
+```
+
+### prerelease
+
+A `prerelease` property applies only to pre-release branches, is required and The `prerelease` value must be valid per the [Semantic Versioning Specification](https://semver.org/#spec-item-9). It will determine the name of versions (for example if `prerelease` is set to `beta` the version be formatted like `2.0.0-beta.1`, `2.0.0-beta.2` etc...).
+If the `prerelease` property is set to `true` the `name` value will be used.
+
+The value of `prerelease`, if defined as a string, is generated with [Lodash template](https://lodash.com/docs#template) with the variable `name` available.
+
+For example the configuration `['master', {name: 'pre/rc', prerelease: '${name.replace(/^pre\\//g, "")}'}, {name: 'beta', prerelease: true}]` will be expanded as:
+```js
+{
+  branches: [
+    {name: 'master'},
+    {name: 'pre/rc', channel: 'pre/rc', prerelease: 'rc'}, // `prerelease` is built with the template `${name.replace(/^pre\\//g, "")}`
+    {name: 'beta', channel: 'beta', prerelease: 'beta'}, // `prerelease` is set to `beta` as it is the value of `name`
+  ]
+}
+```
+
+## Branch types
+
+### Release branches
+
+A release branch is the base type of branch used by **semantic-release** that allows to publish releases with a [semantic version](https://semver.org), optionally on a specific distribution channel. Distribution channels (for example [npm dist-tags](https://docs.npmjs.com/cli/dist-tag) or [Chrome release channels](https://www.chromium.org/getting-involved/dev-channel)) are a way to distribute new releases only to a subset of users in order to get early feedback. Later on those releases can be added to the general distribution channel to be made available to all users.
+
+**semantic-release** will automatically add releases to the corresponding distribution channel when code is [merged from a release branch to another](#merging-into-a-release-branch).
+
+A project must define a minimum of 1 release branch and can have a maximum of 3. The order of the release branch definitions is significant, as versions released on a given branch must always be higher than the last release made on the previous branch. This allow to avoid situation that would lead to an attempt to publish releases with the same version number but different codebase. When multiple release branches are configured and a commit that would create a version conflict is pushed, **semantic-release** will not perform the release and will throw an `EINVALIDNEXTVERSION` error, listing the problematic commits and the valid branches on which to move them.
+
+**Note:** With **semantic-release** as with most package managers, a release version must be unique, independently of the distribution channel on which it is available.
+
+See [publishing on distribution channels recipe](../recipes/distribution-channels.md) for a detailed example.
+
+#### Pushing to a release branch
+
+With the configuration `"branches": ["master", "next"]`, if the last release published from `master` is `1.0.0` then:
+- Only versions in range `1.x.x` can be published from `master`, so only `fix` and `feat` commits can be pushed to `master`
+- Only versions in range `>=2.0.0` release can be published from `next`, so a `BREAKING CHANGE` commit must be pushed first on `next` and can be followed by any type of commits
+
+With the configuration `"branches": ["master", "next", "next-major"]`, if the last release published from `master` is `1.0.0` then:
+- Only versions in range `1.0.x` can be published from `master`, so only `fix` commits can be pushed to `master`
+- Only versions in range `>=1.1.0` can be published from `next`, so a `feat` commit must be pushed first on `next` and can be followed by `fix` and `feat` commits
+- Only versions in range `>=2.0.0` release can be published from `next`, so a `BREAKING CHANGE` commit must be pushed first on `next-major` and can be followed by any type of commits
+
+Those verifications prevent situations such as:
+1. Create a `feat` commit on `next` which triggers the release of version `1.0.0` on channel `next`
+2. Merge `next` into `master` which adds `1.0.0` on the default channel
+3. Push a `fix` commit to `master` which triggers the release of version `1.0.1` on the default channel
+4. Push a `fix` commit to `next` which would attempt to release the version `1.0.1` on channel `next` and fails as this version already exists
+
+#### Merging into a release branch
+
+When merging commits associated with a release from one release branch to another, **semantic-release** will make the corresponding version available on the channel associated with the target branch.
+
+When merging commits not associated with a release, commits from a [maintenance branch](#maintenance-branches) or commits from a [pre-release branch](#pre-release-branches) **semantic-release** will treat them as [pushed commits](#pushing-to-a-release-branch) and publish a new release if necessary.
+
+### Maintenance branches
+
+A maintenance branch is a type of branch used by **semantic-release** that allows to publish releases with a [semantic version](https://semver.org) on top of the codebase of an old release. This is useful when you need to provide fixes or features to users who cannot upgrade to the last version of your package.
+
+A maintenance branch is characterized by a range which defines the versions that can be published from it. The [`range`](#range) value of each maintenance branch must be unique across the project.
+
+**semantic-release** will always publish releases to a distribution channel specific to the range, so only the users who choose to use that particular line of versions will receive new releases.
+
+Maintenance branches are always considered lower than [release branches](#release-branches) and similarly to them, when a commit that would create a version conflict is pushed, **semantic-release** will not perform the release and will throw an `EINVALIDNEXTVERSION` error, listing the problematic commits and the valid branches on which to move them.
+
+**semantic-release** will automatically add releases to the corresponding distribution channel when code is [merged from a release or maintenance branch to another maintenance branch](#merging-into-a-maintenance-branch), however only version version within the branch `range` can be merged. Ia merged version is outside the maintenance branch `range` **semantic-release** will not add to the corresponding channel and will throw an `EINVALIDMAINTENANCEMERGE` error.
+
+See [publishing maintenance releases recipe](../recipes/maintenance-releases.md) for a detailed example.
+
+#### Pushing to a maintenance branch
+
+With the configuration `"branches": ["1.0.x", "1.x", "master"]`, if the last release published from `master` is `1.5.0` then:
+- Only versions in range `>=1.0.0 <1.1.0` can be published from `1.0.x`, so only `fix` commits can be pushed to `1.0.x`
+- Only versions in range `>=1.1.0 <1.5.0` can be published from `1.x`, so only `fix` and `feat` commits can be pushed to `1.x` as long the resulting release is lower than `1.5.0`
+- Once `2.0.0` is released from `master`, versions in range `>=1.1.0 <2.0.0` can be published from `1.x`, so any number of `fix` and `feat` commits can be pushed to `1.x`
+
+#### Merging into a maintenance branch
+
+With the configuration `"branches": ["1.0.x", "1.x", "master"]`, if the last release published from `master` is `1.0.0` then:
+- Creating the branch `1.0.x` from `master` will make the `1.0.0` release available on the `1.0.x` distribution channel
+- Pushing a `fix` commit on the `1.0.x` branch will release the version `1.0.1` on the `1.0.x` distribution channel
+- Creating the branch `1.x` from `master` will make the `1.0.0` release available on the `1.x` distribution channel
+- Merging the branch `1.0.x` into `1.x` will make the version `1.0.1` available on the `1.x` distribution channel
+
+### Pre-release branches
+
+A pre-release branch is a type of branch used by **semantic-release** that allows to publish releases with a [pre-release version](https://semver.org/#spec-item-9).
+Using a pre-release version allow to publish multiple releases with the same version. Those release will be differentiated via there identifiers (in `1.0.0-alpha.1` the identifier is `alpha.1`).
+This is useful when you need to work on a future major release that will include many breaking changes but you do not want to increment the version number for each breaking change commit.
+
+A pre-release branch is characterized by the `prerelease` property that defines the static part of the version released (in `1.0.0-alpha.1` the static part fo the identifier is `alpha`). The [`prerelease`](#prerelease) value of each pre-release branch must be unique across the project.
+
+**semantic-release** will always publish pre-releases to a specific distribution channel, so only the users who choose to use that particular line of versions will receive new releases.
+
+When merging commits associated with an existing release, **semantic-release** will treat them as [pushed commits](#pushing-to-a-pre-release-branch) and publish a new release if necessary, but it will never add those releases to the distribution channel corresponding to the pre-release branch.
+
+See [publishing pre-releases recipe](../recipes/pre-releases.md) for a detailed example.
+
+#### Pushing to a pre-release branch
+
+With the configuration `"branches": ["master", {"name": "beta", "prerelease": true}]`, if the last release published from `master` is `1.0.0` then:
+- Pushing a `BREAKING CHANGE` commit on the `beta` branch will release the version `2.0.0-beta.1` on the `beta` distribution channel
+- Pushing either a `fix`, `feat` or a `BREAKING CHANGE` commit on the `beta` branch will release the version `2.0.0-beta.2` (then `2.0.0-beta.3`, `2.0.0-beta.4`, etc...) on the `beta` distribution channel
+
+#### Merging into a pre-release branch
+
+With the configuration `"branches": ["master", {"name": "beta", "prerelease": true}]`, if the last release published from `master` is `1.0.0` and the last one published from `beta` is `2.0.0-beta.1` then:
+- Pushing a `fix` commit on the `master` branch will release the version `1.0.1` on the default distribution channel
+- Merging the branch `master` into `beta` will release the version `2.0.0-beta.2` on the `beta` distribution channel

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
-const {template, pick} = require('lodash');
+const {pick} = require('lodash');
 const marked = require('marked');
 const TerminalRenderer = require('marked-terminal');
 const envCi = require('env-ci');
 const hookStd = require('hook-std');
+const pEachSeries = require('p-each-series');
+const semver = require('semver');
+const AggregateError = require('aggregate-error');
 const pkg = require('./package.json');
 const hideSensitive = require('./lib/hide-sensitive');
 const getConfig = require('./lib/get-config');
@@ -10,8 +13,10 @@ const verify = require('./lib/verify');
 const getNextVersion = require('./lib/get-next-version');
 const getCommits = require('./lib/get-commits');
 const getLastRelease = require('./lib/get-last-release');
-const {extractErrors} = require('./lib/utils');
+const getReleasesToAdd = require('./lib/get-releases-to-add');
+const {extractErrors, makeTag} = require('./lib/utils');
 const getGitAuthUrl = require('./lib/get-git-auth-url');
+const getBranches = require('./lib/branches');
 const getLogger = require('./lib/get-logger');
 const {fetch, verifyAuth, isBranchUpToDate, getGitHead, tag, push} = require('./lib/git');
 const getError = require('./lib/get-error');
@@ -19,6 +24,7 @@ const {COMMIT_NAME, COMMIT_EMAIL} = require('./lib/definitions/constants');
 
 marked.setOptions({renderer: new TerminalRenderer()});
 
+/* eslint complexity: ["warn", 25] */
 async function run(context, plugins) {
   const {cwd, env, options, logger} = context;
   const {isCi, branch: ciBranch, isPr} = envCi({env, cwd});
@@ -44,11 +50,19 @@ async function run(context, plugins) {
     return false;
   }
 
-  if (ciBranch !== options.branch) {
+  // Verify config
+  await verify(context);
+
+  await fetch({cwd, env});
+
+  context.branches = await getBranches(context);
+  context.branch = context.branches.find(({name}) => name === ciBranch);
+
+  if (!context.branch) {
     logger.log(
-      `This test run was triggered on the branch ${ciBranch}, while semantic-release is configured to only publish from ${
-        options.branch
-      }, therefore a new version won’t be published.`
+      `This test run was triggered on the branch ${ciBranch}, while semantic-release is configured to only publish from ${context.branches
+        .map(({name}) => name)
+        .join(', ')}, therefore a new version won’t be published.`
     );
     return false;
   }
@@ -56,17 +70,17 @@ async function run(context, plugins) {
     `Run automated release from branch ${ciBranch}${options.dryRun ? ' in dry-run mode' : ''}`
   );
 
-  await verify(context);
-
   options.repositoryUrl = await getGitAuthUrl(context);
 
   try {
     try {
-      await verifyAuth(options.repositoryUrl, options.branch, {cwd, env});
+      await verifyAuth(options.repositoryUrl, context.branch.name, {cwd, env});
     } catch (error) {
-      if (!(await isBranchUpToDate(options.branch, {cwd, env}))) {
+      if (!(await isBranchUpToDate(context.branch.name, {cwd, env}))) {
         logger.log(
-          `The local branch ${options.branch} is behind the remote one, therefore a new version won't be published.`
+          `The local branch ${
+            context.branch.name
+          } is behind the remote one, therefore a new version won't be published.`
         );
         return false;
       }
@@ -81,20 +95,65 @@ async function run(context, plugins) {
 
   await plugins.verifyConditions(context);
 
-  await fetch(options.repositoryUrl, {cwd, env});
+  const releasesToAdd = getReleasesToAdd(context);
+  const errors = [];
+  context.releases = [];
+
+  await pEachSeries(releasesToAdd, async ({lastRelease, currentRelease, nextRelease}) => {
+    if (context.branch['merge-range'] && !semver.satisfies(nextRelease.version, context.branch['merge-range'])) {
+      errors.push(getError('EINVALIDMAINTENANCEMERGE', {nextRelease, branch: context.branch}));
+      return;
+    }
+
+    const commits = await getCommits({...context, lastRelease, nextRelease});
+    nextRelease.notes = await plugins.generateNotes({...context, commits, lastRelease, nextRelease});
+
+    logger.log('Create tag %s', nextRelease.gitTag);
+    await tag(nextRelease.gitTag, nextRelease.gitHead, {cwd, env});
+    await push(options.repositoryUrl, context.branch.name, {cwd, env});
+    context.branch.tags.push({
+      version: nextRelease.version,
+      channel: nextRelease.channel,
+      gitTag: nextRelease.gitTag,
+      gitHead: nextRelease.gitHead,
+    });
+
+    const releases = await plugins.addChannel({...context, commits, lastRelease, currentRelease, nextRelease});
+    context.releases.push(...releases);
+    await plugins.success({...context, lastRelease, commits, nextRelease, releases});
+  });
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
+  }
 
   context.lastRelease = await getLastRelease(context);
+
   context.commits = await getCommits(context);
 
-  const nextRelease = {type: await plugins.analyzeCommits(context), gitHead: await getGitHead({cwd, env})};
-
+  const nextRelease = {
+    type: await plugins.analyzeCommits(context),
+    channel: context.branch.channel,
+    gitHead: await getGitHead({cwd, env}),
+  };
   if (!nextRelease.type) {
     logger.log('There are no relevant changes, so no new version is released.');
-    return false;
+    return context.releases.length > 0 ? {releases: context.releases} : false;
   }
+
   context.nextRelease = nextRelease;
   nextRelease.version = getNextVersion(context);
-  nextRelease.gitTag = template(options.tagFormat)({version: nextRelease.version});
+  nextRelease.gitTag = makeTag(options.tagFormat, nextRelease.version, nextRelease.channel);
+  nextRelease.name = makeTag(options.tagFormat, nextRelease.version);
+
+  if (context.branch.type !== 'prerelease' && !semver.satisfies(nextRelease.version, context.branch.range)) {
+    throw getError('EINVALIDNEXTVERSION', {
+      ...context,
+      validBranches: context.branches.filter(
+        ({type, accept}) => type !== 'prerelease' && accept.includes(nextRelease.type)
+      ),
+    });
+  }
 
   await plugins.verifyRelease(context);
 
@@ -106,12 +165,12 @@ async function run(context, plugins) {
     logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
   } else {
     // Create the tag before calling the publish plugins as some require the tag to exists
-    await tag(nextRelease.gitTag, {cwd, env});
-    await push(options.repositoryUrl, options.branch, {cwd, env});
+    await tag(nextRelease.gitTag, nextRelease.gitHead, {cwd, env});
+    await push(options.repositoryUrl, context.branch.name, {cwd, env});
     logger.success(`Created tag ${nextRelease.gitTag}`);
   }
 
-  context.releases = await plugins.publish(context);
+  context.releases.push(...(await plugins.publish(context)));
 
   await plugins.success(context);
 

--- a/lib/branches/expand.js
+++ b/lib/branches/expand.js
@@ -1,0 +1,18 @@
+const {isString, remove, omit, mapValues, template} = require('lodash');
+const micromatch = require('micromatch');
+const {getBranches} = require('../git');
+
+module.exports = async ({cwd}, branches) => {
+  const gitBranches = await getBranches({cwd});
+
+  return branches.reduce(
+    (branches, branch) => [
+      ...branches,
+      ...remove(gitBranches, name => micromatch(gitBranches, branch.name).includes(name)).map(name => ({
+        name,
+        ...mapValues(omit(branch, 'name'), value => (isString(value) ? template(value)({name}) : value)),
+      })),
+    ],
+    []
+  );
+};

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -1,0 +1,39 @@
+const {template, escapeRegExp} = require('lodash');
+const semver = require('semver');
+const pReduce = require('p-reduce');
+const debug = require('debug')('semantic-release:get-tags');
+const {getTags, isRefInHistory, getTagHead} = require('../../lib/git');
+
+module.exports = async ({cwd, env, options: {tagFormat}}, branches) => {
+  // Generate a regex to parse tags formatted with `tagFormat`
+  // by replacing the `version` variable in the template by `(.+)`.
+  // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
+  // so it's guaranteed to no be present in the `tagFormat`.
+  const tagRegexp = `^${escapeRegExp(template(tagFormat)({version: ' '})).replace(' ', '(.[^@]+)@?(.+)?')}`;
+  const tags = (await getTags({cwd, env}))
+    .map(tag => {
+      const [, version, channel] = tag.match(tagRegexp) || [];
+      return {gitTag: tag, version, channel};
+    })
+    .filter(({version}) => version && semver.valid(semver.clean(version)));
+
+  debug('found tags: %o', tags);
+
+  return pReduce(
+    branches,
+    async (branches, branch) => {
+      const branchTags = await pReduce(
+        tags,
+        async (tags, {gitTag, ...rest}) =>
+          (await isRefInHistory(gitTag, branch.name, true, {cwd, env}))
+            ? [...tags, {...rest, gitTag, gitHead: await getTagHead(gitTag, {cwd, env})}]
+            : tags,
+        []
+      );
+
+      debug('found tags for branch %s: %o', branch.name, branchTags);
+      return [...branches, {...branch, tags: branchTags}];
+    },
+    []
+  );
+};

--- a/lib/branches/index.js
+++ b/lib/branches/index.js
@@ -1,0 +1,62 @@
+const {isString, isRegExp} = require('lodash');
+const AggregateError = require('aggregate-error');
+const pEachSeries = require('p-each-series');
+const DEFINITIONS = require('../definitions/branches');
+const getError = require('../get-error');
+const {verifyBranchName} = require('../git');
+const expand = require('./expand');
+const getTags = require('./get-tags');
+const normalize = require('./normalize');
+
+module.exports = async context => {
+  const branches = await getTags(
+    context,
+    await expand(
+      context,
+      context.options.branches.map(branch => (isString(branch) || isRegExp(branch) ? {name: branch} : branch))
+    )
+  );
+
+  const errors = [];
+  const branchesByType = Object.entries(DEFINITIONS).reduce(
+    (branchesByType, [type, {filter}]) => ({[type]: branches.filter(filter), ...branchesByType}),
+    {}
+  );
+
+  const result = Object.entries(DEFINITIONS).reduce((result, [type, {branchesValidator, branchValidator}]) => {
+    branchesByType[type].forEach(branch => {
+      if (branchValidator && !branchValidator(branch)) {
+        errors.push(getError(`E${type.toUpperCase()}BRANCH`, {branch}));
+      }
+    });
+
+    const branchesOfType = normalize[type](branchesByType);
+
+    if (!branchesValidator(branchesOfType)) {
+      errors.push(getError(`E${type.toUpperCase()}BRANCHES`, {branches: branchesOfType}));
+    }
+
+    return {...result, [type]: branchesOfType};
+  }, {});
+
+  const duplicates = [...branches]
+    .map(branch => branch.name)
+    .sort()
+    .filter((val, idx, arr) => arr[idx] === arr[idx + 1] && arr[idx] !== arr[idx - 1]);
+
+  if (duplicates.length > 0) {
+    errors.push(getError('EDUPLICATEBRANCHES', {duplicates}));
+  }
+
+  await pEachSeries(branches, async branch => {
+    if (!(await verifyBranchName(branch.name))) {
+      errors.push(getError('EINVALIDBRANCHNAME', branch));
+    }
+  });
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
+  }
+
+  return [...result.maintenance, ...result.release, ...result.prerelease];
+};

--- a/lib/branches/normalize.js
+++ b/lib/branches/normalize.js
@@ -1,0 +1,110 @@
+const {sortBy} = require('lodash');
+const semver = require('semver');
+const semverDiff = require('semver-diff');
+const {FIRST_RELEASE, RELEASE_TYPE} = require('../definitions/constants');
+const {
+  tagsToVersions,
+  isMajorRange,
+  getUpperBound,
+  getLowerBound,
+  highest,
+  lowest,
+  getLatestVersion,
+  getFirstVersion,
+  getRange,
+} = require('../utils');
+
+function maintenance({maintenance, release}) {
+  return sortBy(
+    maintenance.map(({name, range, channel, ...rest}) => ({
+      ...rest,
+      name,
+      range: range || name,
+      channel: channel || name,
+    })),
+    'range'
+  ).map(({name, range, tags, ...rest}, idx, branches) => {
+    const versions = tagsToVersions(tags);
+    // Find the lower bound based on Maintenance branches
+    const maintenanceMin =
+      // If the current branch has a major range (1.x or 1.x.x) and the previous doesn't
+      isMajorRange(range) && branches[idx - 1] && !isMajorRange(branches[idx - 1].range)
+        ? // Then the lowest bound is the upper bound of the previous branch range
+          getUpperBound(branches[idx - 1].range)
+        : // Otherwise the lowest bound is the lowest bound of the current branch range
+          getLowerBound(range);
+    // The actual lower bound is the highest version between the current branch last release and `maintenanceMin`
+    const min = highest(getLatestVersion(versions) || FIRST_RELEASE, maintenanceMin);
+    // Determine the first release of the default branch not present in any maintenance branch
+    const base =
+      (release[0] &&
+        (getFirstVersion(tagsToVersions(release[0].tags), branches) ||
+          getLatestVersion(tagsToVersions(release[0].tags)))) ||
+      FIRST_RELEASE;
+    // The upper bound is the lowest version between the `base` version and the upper bound of the current branch range
+    const max = lowest(base, getUpperBound(range));
+    const diff = semverDiff(min, max);
+    return {
+      ...rest,
+      type: 'maintenance',
+      name,
+      tags,
+      range: getRange(min, max),
+      accept: diff ? RELEASE_TYPE.slice(0, RELEASE_TYPE.indexOf(diff)) : [],
+      'merge-range': getRange(maintenanceMin, getUpperBound(range)),
+    };
+  });
+}
+
+function release({release}) {
+  if (release.length === 0) {
+    return release;
+  }
+  const breakpoints = release.length > 2 ? ['minor', 'major'] : ['major'];
+
+  // The intial bound is the last release from the base branch of `FIRST_RELEASE` (1.0.0)
+  let bound = getLatestVersion(tagsToVersions(release[0].tags)) || FIRST_RELEASE;
+
+  return release.map(({name, tags, channel, ...rest}, idx) => {
+    const versions = tagsToVersions(tags);
+    // The lower bound is the highest version between the current branch last release and the previous branch upper bound (`bound`)
+    const min = highest(getLatestVersion(versions), bound);
+    if (release.length - 1 === idx) {
+      // If the current branch is the last one of the release branch, there is no upper bound
+      bound = undefined;
+    } else {
+      // The default upper bound is the lower bound increment with the release type of the current branch position
+      const upperBound = semver.inc(min, breakpoints[idx]);
+      // Find the lowest version that is present on the current branch but none of the previous ones
+      const nextFirstVersion = getFirstVersion(tagsToVersions(release[idx + 1].tags), release.slice(0, idx + 1));
+      // The upper bound is the lowest version between `nextFirstVersion` and the default upper bound
+      bound = lowest(nextFirstVersion, upperBound);
+    }
+    const diff = bound ? semverDiff(min, bound) : null;
+    return {
+      ...rest,
+      channel: idx === 0 ? channel : channel || name,
+      tags,
+      type: 'release',
+      name,
+      range: getRange(min, bound),
+      accept: bound ? RELEASE_TYPE.slice(0, RELEASE_TYPE.indexOf(diff)) : RELEASE_TYPE,
+    };
+  });
+}
+
+function prerelease({prerelease}) {
+  return prerelease.map(({name, prerelease, channel, tags, ...rest}) => {
+    const preid = prerelease === true ? name : prerelease;
+    return {
+      ...rest,
+      channel: channel || name,
+      type: 'prerelease',
+      name,
+      prerelease: preid,
+      tags,
+    };
+  });
+}
+
+module.exports = {maintenance, release, prerelease};

--- a/lib/definitions/branches.js
+++ b/lib/definitions/branches.js
@@ -1,0 +1,23 @@
+const {isUndefined, uniqBy} = require('lodash');
+const semver = require('semver');
+const {isMaintenanceRange} = require('../utils');
+
+const maintenance = {
+  filter: ({name, range}) => !isUndefined(range) || isMaintenanceRange(name),
+  branchValidator: ({range}) => (isUndefined(range) ? true : isMaintenanceRange(range)),
+  branchesValidator: branches => uniqBy(branches, ({range}) => semver.validRange(range)).length === branches.length,
+};
+
+const prerelease = {
+  filter: ({prerelease}) => !isUndefined(prerelease),
+  branchValidator: ({name, prerelease}) =>
+    Boolean(prerelease) && Boolean(semver.valid(`1.0.0-${prerelease === true ? name : prerelease}.1`)),
+  branchesValidator: branches => uniqBy(branches, 'prerelease').length === branches.length,
+};
+
+const release = {
+  filter: branch => !maintenance.filter(branch) && !prerelease.filter(branch),
+  branchesValidator: branches => branches.length <= 3 && branches.length > 0,
+};
+
+module.exports = {maintenance, prerelease, release};

--- a/lib/definitions/constants.js
+++ b/lib/definitions/constants.js
@@ -1,6 +1,8 @@
-const RELEASE_TYPE = ['prerelease', 'prepatch', 'patch', 'preminor', 'minor', 'premajor', 'major'];
+const RELEASE_TYPE = ['patch', 'minor', 'major'];
 
 const FIRST_RELEASE = '1.0.0';
+
+const FIRSTPRERELEASE = '1';
 
 const COMMIT_NAME = 'semantic-release-bot';
 
@@ -15,6 +17,7 @@ const SECRET_MIN_SIZE = 5;
 module.exports = {
   RELEASE_TYPE,
   FIRST_RELEASE,
+  FIRSTPRERELEASE,
   COMMIT_NAME,
   COMMIT_EMAIL,
   RELEASE_NOTES_SEPARATOR,

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -1,12 +1,14 @@
 const url = require('url');
 const {inspect} = require('util');
-const {toLower, isString} = require('lodash');
+const {toLower, isString, trim} = require('lodash');
 const pkg = require('../../package.json');
 const {RELEASE_TYPE} = require('./constants');
 
 const homepage = url.format({...url.parse(pkg.homepage), hash: null});
 const stringify = obj => (isString(obj) ? obj : inspect(obj, {breakLength: Infinity, depth: 2, maxArrayLength: 5}));
 const linkify = file => `${homepage}/blob/master/${file}`;
+const wordsList = words =>
+  `${words.slice(0, -1).join(', ')}${words.length > 1 ? ` or ${words[words.length - 1]}` : trim(words[0])}`;
 
 module.exports = {
   ENOGITREPO: ({cwd}) => ({
@@ -124,5 +126,120 @@ We recommend to report the issue to the \`${pluginName}\` authors, providing the
 - A link to the **semantic-release** plugin developer guide: [${linkify('docs/developer-guide/plugin.md')}](${linkify(
       'docs/developer-guide/plugin.md'
     )})`,
+  }),
+  EADDCHANNELOUTPUT: ({result, pluginName}) => ({
+    message: 'A `addChannel` plugin returned an invalid value. It must return an `Object`.',
+    details: `The \`addChannel\` plugins must return an \`Object\`.
+
+The \`addChannel\` function of the \`${pluginName}\` returned \`${stringify(result)}\` instead.
+
+We recommend to report the issue to the \`${pluginName}\` authors, providing the following informations:
+- The **semantic-release** version: \`${pkg.version}\`
+- The **semantic-release** logs from your CI job
+- The value returned by the plugin: \`${stringify(result)}\`
+- A link to the **semantic-release** plugin developer guide: [${linkify('docs/developer-guide/plugin.md')}](${linkify(
+      'docs/developer-guide/plugin.md'
+    )})`,
+  }),
+  EINVALIDBRANCH: ({branch}) => ({
+    message: 'A branch is invalid in the `branches` configuration.',
+    details: `Each branch in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}) must be either a string, a regexp or an object with a \`name\` property.
+
+Your configuration for the problematic branch is \`${stringify(branch)}\`.`,
+  }),
+  EINVALIDBRANCHNAME: ({branch}) => ({
+    message: 'A branch name is invalid in the `branches` configuration.',
+    details: `Each branch in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}) must be a [valid Git reference](https://git-scm.com/docs/git-check-ref-format#_description).
+
+Your configuration for the problematic branch is \`${stringify(branch)}\`.`,
+  }),
+  EDUPLICATEBRANCHES: ({duplicates}) => ({
+    message: 'The `branches` configuration has duplicate branches.',
+    details: `Each branch in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}) must havea unique name.
+
+Your configuration contains duplicates for the following branch names: \`${stringify(duplicates)}\`.`,
+  }),
+  EMAINTENANCEBRANCH: ({branch}) => ({
+    message: 'A maintenance branch is invalid in the `branches` configuration.',
+    details: `Each maintenance branch in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}) must have a \`range\` property formatted like \`N.x\`, \`N.x.x\` or \`N.N.x\` (\`N\` is a number).
+
+Your configuration for the problematic branch is \`${stringify(branch)}\`.`,
+  }),
+  EMAINTENANCEBRANCHES: ({branches}) => ({
+    message: 'The maintenance branches are invalid in the `branches` configuration.',
+    details: `Each maintenance branch in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}) must have a unique \`range\` property.
+
+Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
+  }),
+  ERELEASEBRANCHES: ({branches}) => ({
+    message: 'The release branches are invalid in the `branches` configuration.',
+    details: `A minimum of 1 and a maximum of 3 release branches are required in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}).
+
+Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
+  }),
+  EPRERELEASEBRANCH: ({branch}) => ({
+    message: 'A pre-release branch configuration is invalid in the `branches` configuration.',
+    details: `Each pre-release branch in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}) must have a \`prerelease\` property valid per the [Semantic Versioning Specification](https://semver.org/#spec-item-9). If the \`prerelease\` property is set to \`true\`, then the \`name\` property is used instead.
+
+Your configuration for the problematic branch is \`${stringify(branch)}\`.`,
+  }),
+  EPRERELEASEBRANCHES: ({branches}) => ({
+    message: 'The pre-release branches are invalid in the `branches` configuration.',
+    details: `Each pre-release branch in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}) must have a unique \`prerelease\` property. If the \`prerelease\` property is set to \`true\`, then the \`name\` property is used instead.
+
+Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
+  }),
+  EINVALIDNEXTVERSION: ({nextRelease, branch, commits, validBranches}) => ({
+    message: `The release \`${nextRelease.version}\` on branch \`${
+      branch.name
+    }\` cannot be published as it is out of range.`,
+    details: `Based on the releases published on other branches, only versions within the range \`${
+      branch.range
+    }\` can be published from branch \`${branch.name}\`.
+
+The following commit${commits.length > 1 ? 's are' : ' is'} responsible for the invalid release:
+${commits.map(({commit: {short}, subject}) => `- ${subject} (${short})`).join('\n')}
+
+${
+      commits.length > 1 ? 'Those commits' : 'This commit'
+    } should be moved to a valid branch with [git merge](https://git-scm.com/docs/git-merge) or [git cherry-pick](https://git-scm.com/docs/git-cherry-pick) and removed from branch \`${
+      branch.name
+    }\` with [git revert](https://git-scm.com/docs/git-revert) or [git reset](https://git-scm.com/docs/git-reset).
+
+A valid branch could be ${wordsList(validBranches.map(({name}) => `\`${name}\``))}.
+
+See the [workflow configuration documentation](${linkify('docs/usage/workflow-configuration.md')}) for more details.`,
+  }),
+  EINVALIDMAINTENANCEMERGE: ({nextRelease, branch}) => ({
+    message: `The release \`${nextRelease.version}\` on branch \`${
+      branch.name
+    }\` cannot be published as it is out of range.`,
+    details: `Only releases within the range \`${branch['merge-range']}\` can be merged into the maintenance branch \`${
+      branch.name
+    }\` and published to the \`${nextRelease.channel}\` distribution channel.
+
+The branch \`${
+      branch.name
+    }\` head should be [reset](https://git-scm.com/docs/git-reset) to a previous commit so the commit with tag \`${
+      nextRelease.gitTag
+    }\` is removed from the branch history.
+
+See the [workflow configuration documentation](${linkify('docs/usage/workflow-configuration.md')}) for more details.`,
   }),
 };

--- a/lib/definitions/plugins.js
+++ b/lib/definitions/plugins.js
@@ -71,8 +71,22 @@ module.exports = {
     pipelineConfig: () => ({
       // Add `nextRelease` and plugin properties to published release
       transform: (release, step, {nextRelease}) => ({
-        ...(isPlainObject(release) ? release : {}),
         ...nextRelease,
+        ...(release || {}),
+        ...step,
+      }),
+    }),
+  },
+  addChannel: {
+    default: ['@semantic-release/npm', '@semantic-release/github'],
+    required: false,
+    dryRun: false,
+    outputValidator: output => !output || isPlainObject(output),
+    pipelineConfig: () => ({
+      // Add `nextRelease` and plugin properties to published release
+      transform: (release, step, {nextRelease}) => ({
+        ...nextRelease,
+        ...(release || {}),
         ...step,
       }),
     }),

--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -1,6 +1,5 @@
-const gitLogParser = require('git-log-parser');
-const getStream = require('get-stream');
 const debug = require('debug')('semantic-release:get-commits');
+const {getCommits} = require('./git');
 
 /**
  * Retrieve the list of commits on the current branch since the commit sha associated with the last release, or all the commits of the current branch if there is no last released version.
@@ -9,21 +8,15 @@ const debug = require('debug')('semantic-release:get-commits');
  *
  * @return {Promise<Array<Object>>} The list of commits on the branch `branch` since the last release.
  */
-module.exports = async ({cwd, env, lastRelease: {gitHead}, logger}) => {
-  if (gitHead) {
-    debug('Use gitHead: %s', gitHead);
+module.exports = async ({cwd, env, lastRelease: {gitHead: from}, nextRelease: {gitHead: to = 'HEAD'} = {}, logger}) => {
+  if (from) {
+    debug('Use from: %s', from);
   } else {
     logger.log('No previous release found, retrieving all commits');
   }
 
-  Object.assign(gitLogParser.fields, {hash: 'H', message: 'B', gitTags: 'd', committerDate: {key: 'ci', type: Date}});
-  const commits = (await getStream.array(
-    gitLogParser.parse({_: `${gitHead ? gitHead + '..' : ''}HEAD`}, {cwd, env: {...process.env, ...env}})
-  )).map(commit => {
-    commit.message = commit.message.trim();
-    commit.gitTags = commit.gitTags.trim();
-    return commit;
-  });
+  const commits = await getCommits(from, to, {cwd, env});
+
   logger.log(`Found ${commits.length} commits since last release`);
   debug('Parsed commits: %o', commits);
   return commits;

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -62,7 +62,14 @@ module.exports = async (context, opts) => {
 
   // Set default options values if not defined yet
   options = {
-    branch: 'master',
+    branches: [
+      '+([1-9])?(.{+([1-9]),x}).x',
+      'master',
+      'next',
+      'next-major',
+      {name: 'beta', prerelease: true},
+      {name: 'alpha', prerelease: true},
+    ],
     repositoryUrl: (await pkgRepoUrl({normalize: false, cwd})) || (await repoUrl({cwd, env})),
     tagFormat: `v\${version}`,
     plugins: [
@@ -73,6 +80,7 @@ module.exports = async (context, opts) => {
     ],
     // Remove `null` and `undefined` options so they can be replaced with default ones
     ...pickBy(options, option => !isNil(option)),
+    ...(options.branches ? {branches: castArray(options.branches)} : {}),
   };
 
   debug('options values: %O', options);

--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -24,7 +24,7 @@ const GIT_TOKENS = {
  *
  * @return {String} The formatted Git repository URL.
  */
-module.exports = async ({cwd, env, options: {repositoryUrl, branch}}) => {
+module.exports = async ({cwd, env, branch, options: {repositoryUrl}}) => {
   const info = hostedGitInfo.fromUrl(repositoryUrl, {noGitPlus: true});
   const {protocol, ...parsed} = parse(repositoryUrl);
 
@@ -38,7 +38,7 @@ module.exports = async ({cwd, env, options: {repositoryUrl, branch}}) => {
 
   // Test if push is allowed without transforming the URL (e.g. is ssh keys are set up)
   try {
-    await verifyAuth(repositoryUrl, branch, {cwd, env});
+    await verifyAuth(repositoryUrl, branch.name, {cwd, env});
   } catch (error) {
     const envVar = Object.keys(GIT_TOKENS).find(envVar => !isNil(env[envVar]));
     const gitCredentials = `${GIT_TOKENS[envVar] || ''}${env[envVar] || ''}`;

--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -1,8 +1,6 @@
-const {escapeRegExp, template} = require('lodash');
+const {isUndefined} = require('lodash');
 const semver = require('semver');
-const pLocate = require('p-locate');
-const debug = require('debug')('semantic-release:get-last-release');
-const {getTags, isRefInHistory, getTagHead} = require('./git');
+const {makeTag} = require('./utils');
 
 /**
  * Last release.
@@ -15,37 +13,27 @@ const {getTags, isRefInHistory, getTagHead} = require('./git');
 /**
  * Determine the Git tag and version of the last tagged release.
  *
- * - Obtain all the tags referencing commits in the current branch history
- * - Filter out the ones that are not valid semantic version or doesn't match the `tagFormat`
+ * - Filter out the branch tags that are not valid semantic version
  * - Sort the versions
  * - Retrive the highest version
  *
  * @param {Object} context semantic-release context.
+ * @param {Object} params Function parameters.
+ * @param {Object} params.before Find only releases with version number lower than this version.
  *
- * @return {Promise<LastRelease>} The last tagged release or `undefined` if none is found.
+ * @return {LastRelease} The last tagged release or empty object if none is found.
  */
-module.exports = async ({cwd, env, options: {tagFormat}, logger}) => {
-  // Generate a regex to parse tags formatted with `tagFormat`
-  // by replacing the `version` variable in the template by `(.+)`.
-  // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
-  // so it's guaranteed to no be present in the `tagFormat`.
-  const tagRegexp = `^${escapeRegExp(template(tagFormat)({version: ' '})).replace(' ', '(.+)')}`;
-  const tags = (await getTags({cwd, env}))
-    .map(tag => ({gitTag: tag, version: (tag.match(tagRegexp) || new Array(2))[1]}))
-    .filter(
-      tag => tag.version && semver.valid(semver.clean(tag.version)) && !semver.prerelease(semver.clean(tag.version))
-    )
+module.exports = ({branch: {name, tags, type}, options: {tagFormat}, logger}, {before} = {}) => {
+  const [{version, gitTag, gitHead, channel} = {}] = tags
+    .filter(tag => type === 'prerelease' || !semver.prerelease(tag.version))
+    .filter(tag => isUndefined(before) || semver.lt(tag.version, before))
     .sort((a, b) => semver.rcompare(a.version, b.version));
 
-  debug('found tags: %o', tags);
-
-  const tag = await pLocate(tags, tag => isRefInHistory(tag.gitTag, {cwd, env}), {preserveOrder: true});
-
-  if (tag) {
-    logger.log(`Found git tag ${tag.gitTag} associated with version ${tag.version}`);
-    return {gitHead: await getTagHead(tag.gitTag, {cwd, env}), ...tag};
+  if (gitTag) {
+    logger.log(`Found git tag ${gitTag} associated with version ${version} on branch ${name}`);
+    return {version, gitTag, gitHead, channel, name: makeTag(tagFormat, version)};
   }
 
-  logger.log('No git tag version found');
+  logger.log(`No git tag version found on branch ${name}`);
   return {};
 };

--- a/lib/get-next-version.js
+++ b/lib/get-next-version.js
@@ -1,13 +1,18 @@
 const semver = require('semver');
-const {FIRST_RELEASE} = require('./definitions/constants');
+const {FIRST_RELEASE, FIRSTPRERELEASE} = require('./definitions/constants');
 
-module.exports = ({nextRelease: {type}, lastRelease, logger}) => {
+module.exports = ({branch, nextRelease: {type}, lastRelease, logger}) => {
   let version;
   if (lastRelease.version) {
-    version = semver.inc(lastRelease.version, type);
-    logger.log(`The next release version is ${version}`);
+    version =
+      branch.type === 'prerelease'
+        ? semver.prerelease(lastRelease.version)
+          ? semver.inc(lastRelease.version, 'prerelease')
+          : `${semver.inc(lastRelease.version, type)}-${branch.prerelease}.${FIRSTPRERELEASE}`
+        : semver.inc(lastRelease.version, type);
+    logger.log('The next release version is %s', version);
   } else {
-    version = FIRST_RELEASE;
+    version = branch.type === 'prerelease' ? `${FIRST_RELEASE}-${branch.prerelease}.${FIRSTPRERELEASE}` : FIRST_RELEASE;
     logger.log(`There is no previous release, the next release version is ${version}`);
   }
 

--- a/lib/get-releases-to-add.js
+++ b/lib/get-releases-to-add.js
@@ -1,0 +1,64 @@
+const {uniq} = require('lodash');
+const semver = require('semver');
+const semverDiff = require('semver-diff');
+const getLastRelease = require('./get-last-release');
+const {makeTag} = require('./utils');
+
+/**
+ * Find releases that have been merged from from a higher branch but not added on the channel of the current branch.
+ *
+ * @param {Object} context semantic-release context.
+ *
+ * @return {Array<Object>} Last release and next release to be added on the channel of the current branch.
+ */
+module.exports = context => {
+  const {
+    branch,
+    branches,
+    options: {tagFormat},
+  } = context;
+
+  return (
+    branches
+      // Consider only releases of higher branches
+      .slice(branches.findIndex(({name}) => name === branch.name) + 1)
+      // Exclude prerelease branches
+      .filter(({type}) => type !== 'prerelease')
+      // Find higher branch releases merged to building branch but not released on associated channel
+      .reduce(
+        (releases, higherBranch) => [
+          ...releases,
+          // For all unique release version of the higher branch merged on current branch
+          ...uniq(branch.tags.filter(({channel}) => channel === higherBranch.channel))
+            // Find ones that are not released on the building branch channel
+            .filter(tag =>
+              branch.tags.every(
+                ({version, channel}) =>
+                  version !== tag.version || channel === higherBranch.channel || channel !== branch.channel
+              )
+            )
+            // Sort in ascending order to add the most recent release last
+            .sort((a, b) => semver.compare(a.version, b.version))
+            // Construct the last and next release to add to the building branch channel
+            .map(({version, gitHead, gitTag}) => {
+              const lastRelease = getLastRelease(context, {before: version});
+              const type = lastRelease.version ? semverDiff(lastRelease.version, version) : 'major';
+              const name = makeTag(tagFormat, version);
+              return {
+                lastRelease,
+                currentRelease: {type, version, channel: higherBranch.channel, gitTag, name, gitHead},
+                nextRelease: {
+                  type,
+                  version,
+                  channel: branch.channel,
+                  gitTag: makeTag(tagFormat, version, branch.channel),
+                  name,
+                  gitHead,
+                },
+              };
+            }),
+        ],
+        []
+      )
+  );
+};

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,5 +1,10 @@
+const {trimStart, matches, pick, memoize} = require('lodash');
+const gitLogParser = require('git-log-parser');
+const getStream = require('get-stream');
 const execa = require('execa');
 const debug = require('debug')('semantic-release:git');
+
+Object.assign(gitLogParser.fields, {hash: 'H', message: 'B', gitTags: 'd', committerDate: {key: 'ci', type: Date}});
 
 /**
  * Get the commit sha for a given tag.
@@ -7,7 +12,7 @@ const debug = require('debug')('semantic-release:git');
  * @param {String} tagName Tag name for which to retrieve the commit sha.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
- * @return {string} The commit sha of the tag in parameter or `null`.
+ * @return {String} The commit sha of the tag in parameter or `null`.
  */
 async function getTagHead(tagName, execaOpts) {
   try {
@@ -33,19 +38,67 @@ async function getTags(execaOpts) {
 }
 
 /**
- * Verify if the `ref` is in the direct history of the current branch.
+ * Retrieve a range of commits.
+ *
+ * @param {String} from to includes all commits made after this sha (does not include this sha).
+ * @param {String} to to includes all commits made before this sha (also include this sha).
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ * @return {Promise<Array<Object>>} The list of commits between `from` and `to`.
+ */
+async function getCommits(from, to, execaOpts) {
+  return (await getStream.array(
+    gitLogParser.parse(
+      {_: `${from ? from + '..' : ''}${to}`},
+      {cwd: execaOpts.cwd, env: {...process.env, ...execaOpts.env}}
+    )
+  )).map(({message, gitTags, ...commit}) => ({...commit, message: message.trim(), gitTags: gitTags.trim()}));
+}
+
+/**
+ * Get all the repository branches.
+ *
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @return {Array<String>} List of git branches.
+ * @throws {Error} If the `git` command fails.
+ */
+async function getBranches(execaOpts) {
+  return (await execa.stdout('git', ['branch', '--list', '--no-color'], execaOpts))
+    .split('\n')
+    .map(branch => trimStart(branch, '*').trim())
+    .filter(Boolean);
+}
+
+const getBranchCommits = memoize((branch, execaOpts) =>
+  getStream.array(gitLogParser.parse({_: branch}, {cwd: execaOpts.cwd, env: {...process.env, ...execaOpts.env}}))
+);
+
+/**
+ * Verify if the `ref` is in the direct history of a given branch.
  *
  * @param {String} ref The reference to look for.
+ * @param {String} branch The branch for which to check if the `ref` is in history.
+ * @param {Boolean} findRebasedTags Weither consider in history tags associated with a commit that was rebased to another branch (i.e. GitHub Rebase and Merge feature).
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
  * @return {Boolean} `true` if the reference is in the history of the current branch, falsy otherwise.
  */
-async function isRefInHistory(ref, execaOpts) {
+async function isRefInHistory(ref, branch, findRebasedTags, execaOpts) {
+  if (!(await isRefExists(branch, execaOpts))) {
+    return false;
+  }
+
   try {
-    await execa('git', ['merge-base', '--is-ancestor', ref, 'HEAD'], execaOpts);
+    await execa('git', ['merge-base', '--is-ancestor', ref, branch], execaOpts);
     return true;
   } catch (error) {
     if (error.code === 1) {
+      if (findRebasedTags) {
+        const [tagCommit] = await getStream.array(
+          gitLogParser.parse({_: ref, n: '1'}, {cwd: execaOpts.cwd, env: {...process.env, ...execaOpts.env}})
+        );
+        return (await getBranchCommits(branch, execaOpts)).some(matches(pick(tagCommit, ['message', 'author'])));
+      }
       return false;
     }
 
@@ -55,16 +108,31 @@ async function isRefInHistory(ref, execaOpts) {
 }
 
 /**
+ * Verify if the `ref` exits
+ *
+ * @param {String} ref The reference to verify.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @return {Boolean} `true` if the reference exists, falsy otherwise.
+ */
+async function isRefExists(ref, execaOpts) {
+  try {
+    return (await execa('git', ['rev-parse', '--verify', ref], execaOpts)).code === 0;
+  } catch (error) {
+    debug(error);
+  }
+}
+
+/**
  * Unshallow the git repository if necessary and fetch all the tags.
  *
- * @param {String} repositoryUrl The remote repository URL.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  */
-async function fetch(repositoryUrl, execaOpts) {
+async function fetch(execaOpts) {
   try {
-    await execa('git', ['fetch', '--unshallow', '--tags', repositoryUrl], execaOpts);
+    await execa('git', ['fetch', '--unshallow', '--tags'], execaOpts);
   } catch (error) {
-    await execa('git', ['fetch', '--tags', repositoryUrl], execaOpts);
+    await execa('git', ['fetch', '--tags'], execaOpts);
   }
 }
 
@@ -131,12 +199,13 @@ async function verifyAuth(repositoryUrl, branch, execaOpts) {
  * Tag the commit head on the local repository.
  *
  * @param {String} tagName The name of the tag.
+ * @param {String} ref The Git reference to tag.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
  * @throws {Error} if the tag creation failed.
  */
-async function tag(tagName, execaOpts) {
-  await execa('git', ['tag', tagName], execaOpts);
+async function tag(tagName, ref, execaOpts) {
+  await execa('git', ['tag', tagName, ref], execaOpts);
 }
 
 /**
@@ -169,6 +238,22 @@ async function verifyTagName(tagName, execaOpts) {
 }
 
 /**
+ * Verify a branch name is a valid Git reference.
+ *
+ * @param {String} branch the branch name to verify.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @return {Boolean} `true` if valid, falsy otherwise.
+ */
+async function verifyBranchName(branch, execaOpts) {
+  try {
+    return (await execa('git', ['check-ref-format', `refs/heads/${branch}`], execaOpts)).code === 0;
+  } catch (error) {
+    debug(error);
+  }
+}
+
+/**
  * Verify the local branch is up to date with the remote one.
  *
  * @param {String} branch The repository branch for which to verify status.
@@ -179,7 +264,7 @@ async function verifyTagName(tagName, execaOpts) {
 async function isBranchUpToDate(branch, execaOpts) {
   const remoteHead = await execa.stdout('git', ['ls-remote', '--heads', 'origin', branch], execaOpts);
   try {
-    return await isRefInHistory(remoteHead.match(/^(\w+)?/)[1], execaOpts);
+    return await isRefInHistory(remoteHead.match(/^(\w+)?/)[1], branch, false, execaOpts);
   } catch (error) {
     debug(error);
   }
@@ -188,7 +273,10 @@ async function isBranchUpToDate(branch, execaOpts) {
 module.exports = {
   getTagHead,
   getTags,
+  getCommits,
+  getBranches,
   isRefInHistory,
+  isRefExists,
   fetch,
   getGitHead,
   repoUrl,
@@ -198,4 +286,5 @@ module.exports = {
   push,
   verifyTagName,
   isBranchUpToDate,
+  verifyBranchName,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
-const {isFunction} = require('lodash');
+const {isFunction, union, template} = require('lodash');
+const semver = require('semver');
 const hideSensitive = require('./hide-sensitive');
 
 function extractErrors(err) {
@@ -17,4 +18,71 @@ function hideSensitiveValues(env, objs) {
   });
 }
 
-module.exports = {extractErrors, hideSensitiveValues};
+function tagsToVersions(tags) {
+  return tags.map(({version}) => version);
+}
+
+function isMajorRange(range) {
+  return /^\d\.x(?:\.x)?$/i.test(range);
+}
+
+function isMaintenanceRange(range) {
+  return /^\d\.[\dx](?:\.x)?$/i.test(range);
+}
+
+function getUpperBound(range) {
+  return semver.valid(range) ? range : ((semver.validRange(range) || '').match(/<(\d\.\d\.\d)$/) || [])[1];
+}
+
+function getLowerBound(range) {
+  return ((semver.validRange(range) || '').match(/(\d\.\d\.\d)/) || [])[1];
+}
+
+function highest(version1, version2) {
+  return version1 && version2 ? (semver.gt(version1, version2) ? version1 : version2) : version1 || version2;
+}
+
+function lowest(version1, version2) {
+  return version1 && version2 ? (semver.lt(version1, version2) ? version1 : version2) : version1 || version2;
+}
+
+function getLatestVersion(versions, {withPrerelease} = {}) {
+  return versions.filter(version => withPrerelease || !semver.prerelease(version)).sort(semver.rcompare)[0];
+}
+
+function getEarliestVersion(versions, {withPrerelease} = {}) {
+  return versions.filter(version => withPrerelease || !semver.prerelease(version)).sort(semver.compare)[0];
+}
+
+function getFirstVersion(versions, lowerBranches) {
+  const lowerVersion = union(...lowerBranches.map(({tags}) => tagsToVersions(tags))).sort(semver.rcompare);
+  if (lowerVersion[0]) {
+    return versions.sort(semver.compare).find(version => semver.gt(version, lowerVersion[0]));
+  }
+  return getEarliestVersion(versions);
+}
+
+function getRange(min, max) {
+  return `>=${min}${max ? ` <${max}` : ''}`;
+}
+
+function makeTag(tagFormat, version, channel) {
+  return template(tagFormat)({version: `${version}${channel ? `@${channel}` : ''}`});
+}
+
+module.exports = {
+  extractErrors,
+  hideSensitiveValues,
+  tagsToVersions,
+  isMajorRange,
+  isMaintenanceRange,
+  getUpperBound,
+  getLowerBound,
+  highest,
+  lowest,
+  getLatestVersion,
+  getEarliestVersion,
+  getFirstVersion,
+  getRange,
+  makeTag,
+};

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,9 +1,9 @@
-const {template} = require('lodash');
+const {template, isString, isPlainObject} = require('lodash');
 const AggregateError = require('aggregate-error');
 const {isGitRepo, verifyTagName} = require('./git');
 const getError = require('./get-error');
 
-module.exports = async ({cwd, env, options: {repositoryUrl, tagFormat}}) => {
+module.exports = async ({cwd, env, options: {repositoryUrl, tagFormat, branches}}) => {
   const errors = [];
 
   if (!(await isGitRepo({cwd, env}))) {
@@ -23,6 +23,14 @@ module.exports = async ({cwd, env, options: {repositoryUrl, tagFormat}}) => {
   if ((template(tagFormat)({version: ' '}).match(/ /g) || []).length !== 1) {
     errors.push(getError('ETAGNOVERSION', {tagFormat}));
   }
+
+  branches.forEach(branch => {
+    if (
+      !((isString(branch) && branch.trim()) || (isPlainObject(branch) && isString(branch.name) && branch.name.trim()))
+    ) {
+      errors.push(getError('EINVALIDBRANCH', {branch}));
+    }
+  });
 
   if (errors.length > 0) {
     throw new AggregateError(errors);

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@semantic-release/commit-analyzer": "^6.1.0",
     "@semantic-release/error": "^2.2.0",
-    "@semantic-release/github": "^5.1.0",
-    "@semantic-release/npm": "^5.0.5",
+    "@semantic-release/github": "^5.3.0-beta.1",
+    "@semantic-release/npm": "^5.2.0-beta.1",
     "@semantic-release/release-notes-generator": "^7.1.2",
     "aggregate-error": "^1.0.0",
     "cosmiconfig": "^5.0.1",
@@ -38,11 +38,13 @@
     "lodash": "^4.17.4",
     "marked": "^0.5.0",
     "marked-terminal": "^3.0.0",
-    "p-locate": "^3.0.0",
+    "micromatch": "3.1.5",
+    "p-each-series": "^1.0.0",
     "p-reduce": "^1.0.0",
     "read-pkg-up": "^4.0.0",
     "resolve-from": "^4.0.0",
     "semver": "^5.4.1",
+    "semver-diff": "^2.1.0",
     "signale": "^1.2.1",
     "yargs": "^12.0.0"
   },
@@ -110,7 +112,7 @@
     "trailingComma": "es5"
   },
   "publishConfig": {
-    "tag": "next"
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "Pierre Vanduynslager (https://twitter.com/@pvdlg_)"
   ],
   "dependencies": {
-    "@semantic-release/commit-analyzer": "^6.1.0",
+    "@semantic-release/commit-analyzer": "^7.0.0-beta.2",
     "@semantic-release/error": "^2.2.0",
     "@semantic-release/github": "^5.3.0-beta.1",
     "@semantic-release/npm": "^5.2.0-beta.1",

--- a/test/branches/branches.test.js
+++ b/test/branches/branches.test.js
@@ -1,0 +1,199 @@
+import test from 'ava';
+import {union} from 'lodash';
+import semver from 'semver';
+import proxyquire from 'proxyquire';
+
+const getBranch = (branches, branch) => branches.find(({name}) => name === branch);
+const release = (branches, name, version) => getBranch(branches, name).tags.push({version});
+const merge = (branches, source, target, tag) => {
+  getBranch(branches, target).tags = union(
+    getBranch(branches, source).tags.filter(({version}) => !tag || semver.cmp(version, '<=', tag)),
+    getBranch(branches, target).tags
+  );
+};
+
+test('Enforce ranges with branching release workflow', async t => {
+  const branches = [
+    {name: '1.x', tags: []},
+    {name: '1.0.x', tags: []},
+    {name: 'master', tags: []},
+    {name: 'next', tags: []},
+    {name: 'next-major', tags: []},
+    {name: 'beta', prerelease: true, tags: []},
+    {name: 'alpha', prerelease: true, tags: []},
+  ];
+  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches});
+
+  let result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, '1.0.x').range, '>=1.0.0 <1.0.0', 'Cannot release on 1.0.x before a releasing on master');
+  t.is(getBranch(result, '1.x').range, '>=1.1.0 <1.0.0', 'Cannot release on 1.x before a releasing on master');
+  t.is(getBranch(result, 'master').range, '>=1.0.0 <1.1.0', 'Can release only patch on master');
+  t.is(getBranch(result, 'next').range, '>=1.1.0 <2.0.0', 'Can release only minor on next');
+  t.is(getBranch(result, 'next-major').range, '>=2.0.0', 'Can release only major on next-major');
+
+  release(branches, 'master', '1.0.0');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, '1.0.x').range, '>=1.0.0 <1.0.0', 'Cannot release on 1.0.x before a releasing on master');
+  t.is(getBranch(result, '1.x').range, '>=1.1.0 <1.0.0', 'Cannot release on 1.x before a releasing on master');
+  t.is(getBranch(result, 'master').range, '>=1.0.0 <1.1.0', 'Can release only patch on master');
+
+  release(branches, 'master', '1.0.1');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=1.0.1 <1.1.0', 'Can release only patch, > than 1.0.1 on master');
+
+  merge(branches, 'master', 'next');
+  merge(branches, 'master', 'next-major');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=1.0.1 <1.1.0', 'Can release only patch, > than 1.0.1 on master');
+  t.is(getBranch(result, 'next').range, '>=1.1.0 <2.0.0', 'Can release only minor on next');
+  t.is(getBranch(result, 'next-major').range, '>=2.0.0', 'Can release only major on next-major');
+
+  release(branches, 'next', '1.1.0');
+  release(branches, 'next', '1.1.1');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'next').range, '>=1.1.1 <2.0.0', 'Can release only patch or minor, > than 1.1.0 on next');
+
+  release(branches, 'next-major', '2.0.0');
+  release(branches, 'next-major', '2.0.1');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'next-major').range, '>=2.0.1', 'Can release any version, > than 2.0.1 on next-major');
+
+  merge(branches, 'next-major', 'beta');
+  release(branches, 'beta', '3.0.0-beta.1');
+  merge(branches, 'beta', 'alpha');
+  release(branches, 'alpha', '4.0.0-alpha.1');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'next-major').range, '>=2.0.1', 'Can release any version, > than 2.0.1 on next-major');
+
+  merge(branches, 'master', '1.0.x');
+  merge(branches, 'master', '1.x');
+  release(branches, 'master', '1.0.1');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=1.0.1 <1.1.0', 'Can release only patch, > than 1.0.1 on master');
+  t.is(
+    getBranch(result, '1.0.x').range,
+    '>=1.0.1 <1.0.1',
+    'Cannot release on 1.0.x before >= 1.1.0 is released on master'
+  );
+  t.is(getBranch(result, '1.x').range, '>=1.1.0 <1.0.1', 'Cannot release on 1.x before >= 1.2.0 is released on master');
+
+  release(branches, 'master', '1.0.2');
+  release(branches, 'master', '1.0.3');
+  release(branches, 'master', '1.0.4');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=1.0.4 <1.1.0', 'Can release only patch, > than 1.0.4 on master');
+  t.is(
+    getBranch(result, '1.0.x').range,
+    '>=1.0.1 <1.0.2',
+    'Cannot release on 1.0.x before >= 1.1.0 is released on master'
+  );
+  t.is(getBranch(result, '1.x').range, '>=1.1.0 <1.0.2', 'Cannot release on 1.x before >= 1.2.0 is released on master');
+
+  merge(branches, 'next', 'master');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=1.1.1 <1.2.0', 'Can release only patch, > than 1.1.1 on master');
+  t.is(getBranch(result, 'next').range, '>=1.2.0 <2.0.0', 'Can release only patch or minor, > than 1.2.0 on next');
+  t.is(getBranch(result, 'next-major').range, '>=2.0.1', 'Can release any version, > than 2.0.1 on next-major');
+  t.is(
+    getBranch(result, '1.0.x').range,
+    '>=1.0.1 <1.0.2',
+    'Cannot release on 1.0.x before 1.0.x version from master are merged'
+  );
+  t.is(getBranch(result, '1.x').range, '>=1.1.0 <1.0.2', 'Cannot release on 1.x before >= 2.0.0 is released on master');
+
+  merge(branches, 'master', '1.0.x', '1.0.4');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=1.1.1 <1.2.0', 'Can release only patch, > than 1.1.1 on master');
+  t.is(getBranch(result, '1.0.x').range, '>=1.0.4 <1.1.0', 'Can release on 1.0.x only within range');
+  t.is(getBranch(result, '1.x').range, '>=1.1.0 <1.1.0', 'Cannot release on 1.x before >= 2.0.0 is released on master');
+
+  merge(branches, 'master', '1.x');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=1.1.1 <1.2.0', 'Can release only patch, > than 1.1.1 on master');
+  t.is(getBranch(result, '1.0.x').range, '>=1.0.4 <1.1.0', 'Can release on 1.0.x only within range');
+  t.is(getBranch(result, '1.x').range, '>=1.1.1 <1.1.1', 'Cannot release on 1.x before >= 2.0.0 is released on master');
+
+  merge(branches, 'next-major', 'next');
+  merge(branches, 'next', 'master');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=2.0.1 <2.1.0', 'Can release only patch, > than 2.0.1 on master');
+  t.is(getBranch(result, 'next').range, '>=2.1.0 <3.0.0', 'Can release only minor on next');
+  t.is(getBranch(result, 'next-major').range, '>=3.0.0', 'Can release only major on next-major');
+  t.is(getBranch(result, '1.x').range, '>=1.1.1 <2.0.0', 'Can release on 1.x only within range');
+
+  merge(branches, 'beta', 'master');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, 'master').range, '>=2.0.1 <2.1.0', 'Can release only patch, > than 2.0.1 on master');
+  t.is(getBranch(result, 'next').range, '>=2.1.0 <3.0.0', 'Can release only minor on next');
+  t.is(getBranch(result, 'next-major').range, '>=3.0.0', 'Can release only major on next-major');
+
+  branches.push({name: '1.1.x', tags: []});
+  merge(branches, '1.x', '1.1.x');
+  result = (await getBranches({options: {branches}})).map(({name, range}) => ({name, range}));
+  t.is(getBranch(result, '1.0.x').range, '>=1.0.4 <1.1.0', 'Can release on 1.0.x only within range');
+  t.is(getBranch(result, '1.1.x').range, '>=1.1.1 <1.2.0', 'Can release on 1.1.x only within range');
+  t.is(getBranch(result, '1.x').range, '>=1.2.0 <2.0.0', 'Can release on 1.x only within range');
+});
+
+test('Throw SemanticReleaseError for invalid configurations', async t => {
+  const branches = [
+    {name: '123', range: '123', tags: []},
+    {name: '1.x', tags: []},
+    {name: 'maintenance-1', range: '1.x', tags: []},
+    {name: '1.x.x', tags: []},
+    {name: 'beta', prerelease: '', tags: []},
+    {name: 'alpha', prerelease: 'alpha', tags: []},
+    {name: 'preview', prerelease: 'alpha', tags: []},
+  ];
+  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches});
+  const errors = [...(await t.throws(getBranches({options: {branches}})))];
+
+  t.is(errors[0].name, 'SemanticReleaseError');
+  t.is(errors[0].code, 'EMAINTENANCEBRANCH');
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+  t.is(errors[1].name, 'SemanticReleaseError');
+  t.is(errors[1].code, 'EMAINTENANCEBRANCHES');
+  t.truthy(errors[1].message);
+  t.truthy(errors[1].details);
+  t.is(errors[2].name, 'SemanticReleaseError');
+  t.is(errors[2].code, 'EPRERELEASEBRANCH');
+  t.truthy(errors[2].message);
+  t.truthy(errors[2].details);
+  t.is(errors[3].name, 'SemanticReleaseError');
+  t.is(errors[3].code, 'EPRERELEASEBRANCHES');
+  t.truthy(errors[3].message);
+  t.truthy(errors[3].details);
+  t.is(errors[4].name, 'SemanticReleaseError');
+  t.is(errors[4].code, 'ERELEASEBRANCHES');
+  t.truthy(errors[4].message);
+  t.truthy(errors[4].details);
+});
+
+test('Throw a SemanticReleaseError if there is duplicate branches', async t => {
+  const branches = [{name: 'master', tags: []}, {name: 'master', tags: []}];
+  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches});
+
+  const errors = [...(await t.throws(getBranches({options: {branches}})))];
+
+  t.is(errors[0].name, 'SemanticReleaseError');
+  t.is(errors[0].code, 'EDUPLICATEBRANCHES');
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+});
+
+test('Throw a SemanticReleaseError for each invalid branch name', async t => {
+  const branches = [{name: '~master', tags: []}, {name: '^master', tags: []}];
+  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches});
+
+  const errors = [...(await t.throws(getBranches({options: {branches}})))];
+
+  t.is(errors[0].name, 'SemanticReleaseError');
+  t.is(errors[0].code, 'EINVALIDBRANCHNAME');
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+  t.is(errors[1].name, 'SemanticReleaseError');
+  t.is(errors[1].code, 'EINVALIDBRANCHNAME');
+  t.truthy(errors[1].message);
+  t.truthy(errors[1].details);
+});

--- a/test/branches/expand.test.js
+++ b/test/branches/expand.test.js
@@ -1,0 +1,46 @@
+import test from 'ava';
+import expand from '../../lib/branches/expand';
+import {gitRepo, gitCommits, gitCheckout} from '../helpers/git-utils';
+
+test('Expand branches defined with globs', async t => {
+  const {cwd} = await gitRepo();
+  await gitCommits(['First'], {cwd});
+  await gitCheckout('1.1.x', true, {cwd});
+  await gitCommits(['Second'], {cwd});
+  await gitCheckout('1.x.x', true, {cwd});
+  await gitCommits(['Third'], {cwd});
+  await gitCheckout('2.x', true, {cwd});
+  await gitCommits(['Fourth'], {cwd});
+  await gitCheckout('next', true, {cwd});
+  await gitCommits(['Fifth'], {cwd});
+  await gitCheckout('pre/foo', true, {cwd});
+  await gitCommits(['Sixth'], {cwd});
+  await gitCheckout('pre/bar', true, {cwd});
+  await gitCommits(['Seventh'], {cwd});
+  await gitCheckout('beta', true, {cwd});
+  await gitCommits(['Eighth'], {cwd});
+
+  const branches = [
+    // Should match all maintenance type branches
+    {name: '+([1-9])?(.{+([1-9]),x}).x'},
+    {name: 'master', channel: 'latest'},
+    {name: 'next'},
+    {name: 'pre/{foo,bar}', channel: `\${name.replace(/^pre\\//g, '')}`, prerelease: true},
+    // Should be ignored as there is no matching branches in the repo
+    {name: 'missing'},
+    // Should be ignored as the matching branch in the repo is already matched by `/^pre\\/(\\w+)$/gi`
+    {name: '*/foo', channel: 'foo', prerelease: 'foo'},
+    {name: 'beta', channel: `channel-\${name}`, prerelease: true},
+  ];
+
+  t.deepEqual(await expand({cwd}, branches), [
+    {name: '1.1.x'},
+    {name: '1.x.x'},
+    {name: '2.x'},
+    {name: 'master', channel: 'latest'},
+    {name: 'next'},
+    {name: 'pre/bar', channel: 'bar', prerelease: true},
+    {name: 'pre/foo', channel: 'foo', prerelease: true},
+    {name: 'beta', channel: 'channel-beta', prerelease: true},
+  ]);
+});

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -1,0 +1,202 @@
+import test from 'ava';
+import getTags from '../../lib/branches/get-tags';
+import {gitRepo, gitCommits, gitTagVersion, gitCheckout, merge, changeAuthor} from '../helpers/git-utils';
+
+test('Get the valid tags', async t => {
+  const {cwd} = await gitRepo();
+  const commits = await gitCommits(['First'], {cwd});
+  await gitTagVersion('foo', undefined, {cwd});
+  await gitTagVersion('v2.0.0', undefined, {cwd});
+  commits.push(...(await gitCommits(['Second'], {cwd})));
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  commits.push(...(await gitCommits(['Third'], {cwd})));
+  await gitTagVersion('v3.0', undefined, {cwd});
+  commits.push(...(await gitCommits(['Fourth'], {cwd})));
+  await gitTagVersion('v3.0.0-beta.1', undefined, {cwd});
+
+  const result = await getTags({cwd, options: {tagFormat: `v\${version}`}}, [{name: 'master'}]);
+
+  t.deepEqual(result, [
+    {
+      name: 'master',
+      tags: [
+        {gitTag: 'v1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[1].hash},
+        {gitTag: 'v2.0.0', version: '2.0.0', channel: undefined, gitHead: commits[0].hash},
+        {gitTag: 'v3.0.0-beta.1', version: '3.0.0-beta.1', channel: undefined, gitHead: commits[3].hash},
+      ],
+    },
+  ]);
+});
+
+test('Get the valid tags from multiple branches', async t => {
+  const {cwd} = await gitRepo();
+  const commits = await gitCommits(['First'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitTagVersion('v1.0.0@1.x', undefined, {cwd});
+  commits.push(...(await gitCommits(['Second'], {cwd})));
+  await gitTagVersion('v1.1.0', undefined, {cwd});
+  await gitTagVersion('v1.1.0@1.x', undefined, {cwd});
+  await gitCheckout('1.x', true, {cwd});
+  await gitCheckout('master', false, {cwd});
+  commits.push(...(await gitCommits(['Third'], {cwd})));
+  await gitTagVersion('v2.0.0', undefined, {cwd});
+  await gitTagVersion('v2.0.0@next', undefined, {cwd});
+  await gitCheckout('next', true, {cwd});
+  commits.push(...(await gitCommits(['Fourth'], {cwd})));
+  await gitTagVersion('v3.0.0@next', undefined, {cwd});
+
+  const result = await getTags({cwd, options: {tagFormat: `v\${version}`}}, [
+    {name: '1.x'},
+    {name: 'master'},
+    {name: 'next'},
+  ]);
+
+  t.deepEqual(result, [
+    {
+      name: '1.x',
+      tags: [
+        {gitTag: 'v1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[0].hash},
+        {gitTag: 'v1.0.0@1.x', version: '1.0.0', channel: '1.x', gitHead: commits[0].hash},
+        {gitTag: 'v1.1.0', version: '1.1.0', channel: undefined, gitHead: commits[1].hash},
+        {gitTag: 'v1.1.0@1.x', version: '1.1.0', channel: '1.x', gitHead: commits[1].hash},
+      ],
+    },
+    {
+      name: 'master',
+      tags: [
+        ...result[0].tags,
+        {gitTag: 'v2.0.0', version: '2.0.0', channel: undefined, gitHead: commits[2].hash},
+        {gitTag: 'v2.0.0@next', version: '2.0.0', channel: 'next', gitHead: commits[2].hash},
+      ],
+    },
+    {
+      name: 'next',
+      tags: [...result[1].tags, {gitTag: 'v3.0.0@next', version: '3.0.0', channel: 'next', gitHead: commits[3].hash}],
+    },
+  ]);
+});
+
+test('Match the tag name from the begining of the string and the channel from the last "@"', async t => {
+  const {cwd} = await gitRepo();
+  const commits = await gitCommits(['First'], {cwd});
+  await gitTagVersion('prefix@v1.0.0', undefined, {cwd});
+  await gitTagVersion('prefix@v1.0.0@next', undefined, {cwd});
+  await gitTagVersion('prefix@v2.0.0', undefined, {cwd});
+  await gitTagVersion('prefix@v2.0.0@next', undefined, {cwd});
+  await gitTagVersion('other-prefix@v3.0.0', undefined, {cwd});
+
+  const result = await getTags({cwd, options: {tagFormat: `prefix@v\${version}`}}, [{name: 'master'}]);
+
+  t.deepEqual(result, [
+    {
+      name: 'master',
+      tags: [
+        {gitTag: 'prefix@v1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[0].hash},
+        {gitTag: 'prefix@v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: commits[0].hash},
+        {gitTag: 'prefix@v2.0.0', version: '2.0.0', channel: undefined, gitHead: commits[0].hash},
+        {gitTag: 'prefix@v2.0.0@next', version: '2.0.0', channel: 'next', gitHead: commits[0].hash},
+      ],
+    },
+  ]);
+});
+
+test('Return branches with and empty tags array if no valid tag is found', async t => {
+  const {cwd} = await gitRepo();
+  await gitCommits(['First'], {cwd});
+  await gitTagVersion('foo', undefined, {cwd});
+  await gitCommits(['Second'], {cwd});
+  await gitTagVersion('v2.0.x', undefined, {cwd});
+  await gitCommits(['Third'], {cwd});
+  await gitTagVersion('v3.0', undefined, {cwd});
+
+  const result = await getTags({cwd, options: {tagFormat: `prefix@v\${version}`}}, [{name: 'master'}, {name: 'next'}]);
+
+  t.deepEqual(result, [{name: 'master', tags: []}, {name: 'next', tags: []}]);
+});
+
+test('Return branches with and empty tags array if no valid tag is found in history of configured branches', async t => {
+  const {cwd} = await gitRepo();
+  await gitCommits(['First'], {cwd});
+  await gitCheckout('other-branch', true, {cwd});
+  await gitCommits(['Second'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitTagVersion('v1.0.0@next', undefined, {cwd});
+  await gitTagVersion('v2.0.0', undefined, {cwd});
+  await gitTagVersion('v2.0.0@next', undefined, {cwd});
+  await gitTagVersion('v3.0.0', undefined, {cwd});
+  await gitTagVersion('v3.0.0@next', undefined, {cwd});
+  await gitCheckout('master', false, {cwd});
+
+  const result = await getTags({cwd, options: {tagFormat: `prefix@v\${version}`}}, [{name: 'master'}, {name: 'next'}]);
+
+  t.deepEqual(result, [{name: 'master', tags: []}, {name: 'next', tags: []}]);
+});
+
+test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
+  const {cwd} = await gitRepo();
+  const commits = await gitCommits(['First'], {cwd});
+
+  await gitTagVersion('1.0.0', undefined, {cwd});
+  t.deepEqual(await getTags({cwd, options: {tagFormat: `\${version}`}}, [{name: 'master'}]), [
+    {name: 'master', tags: [{gitTag: '1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}]},
+  ]);
+
+  await gitTagVersion('foo-1.0.0-bar', undefined, {cwd});
+  t.deepEqual(await getTags({cwd, options: {tagFormat: `foo-\${version}-bar`}}, [{name: 'master'}]), [
+    {name: 'master', tags: [{gitTag: 'foo-1.0.0-bar', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}]},
+  ]);
+
+  await gitTagVersion('foo-v1.0.0-bar', undefined, {cwd});
+  t.deepEqual(await getTags({cwd, options: {tagFormat: `foo-v\${version}-bar`}}, [{name: 'master'}]), [
+    {
+      name: 'master',
+      tags: [{gitTag: 'foo-v1.0.0-bar', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}],
+    },
+  ]);
+
+  await gitTagVersion('(.+)/1.0.0/(a-z)', undefined, {cwd});
+  t.deepEqual(await getTags({cwd, options: {tagFormat: `(.+)/\${version}/(a-z)`}}, [{name: 'master'}]), [
+    {
+      name: 'master',
+      tags: [{gitTag: '(.+)/1.0.0/(a-z)', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}],
+    },
+  ]);
+
+  await gitTagVersion('2.0.0-1.0.0-bar.1', undefined, {cwd});
+  t.deepEqual(await getTags({cwd, options: {tagFormat: `2.0.0-\${version}-bar.1`}}, [{name: 'master'}]), [
+    {
+      name: 'master',
+      tags: [{gitTag: '2.0.0-1.0.0-bar.1', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}],
+    },
+  ]);
+
+  await gitTagVersion('3.0.0-bar.2', undefined, {cwd});
+  t.deepEqual(await getTags({cwd, options: {tagFormat: `\${version}-bar.2`}}, [{name: 'master'}]), [
+    {name: 'master', tags: [{gitTag: '3.0.0-bar.2', version: '3.0.0', channel: undefined, gitHead: commits[0].hash}]},
+  ]);
+});
+
+test('Get the tag on branch where commits have been rebased', async t => {
+  const {cwd} = await gitRepo();
+  const commits = await gitCommits(['First'], {cwd});
+  await gitCheckout('next', true, {cwd});
+  commits.push(...(await gitCommits(['Second/n/n/commit body'], {cwd})));
+  await gitTagVersion('v1.0.0@next', undefined, {cwd});
+  await gitCheckout('master', false, {cwd});
+  await merge('next', {cwd});
+  // Simulate GitHub "Rebase and Merge" by changing the committer info, which will result in a new commit sha and losing the tag
+  await changeAuthor(commits[1].hash, {cwd});
+
+  const result = await getTags({cwd, options: {tagFormat: `v\${version}`}}, [{name: 'master'}, {name: 'next'}]);
+
+  t.deepEqual(result, [
+    {
+      name: 'master',
+      tags: [{gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: commits[1].hash}],
+    },
+    {
+      name: 'next',
+      tags: [{gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: commits[1].hash}],
+    },
+  ]);
+});

--- a/test/branches/normalize.test.js
+++ b/test/branches/normalize.test.js
@@ -1,0 +1,307 @@
+import test from 'ava';
+import normalize from '../../lib/branches/normalize';
+
+const toTags = versions => versions.map(version => ({version}));
+
+test('Maintenance branches - initial state', t => {
+  const maintenance = [{name: '1.x', tags: []}, {name: '1.1.x', tags: []}, {name: '1.2.x', tags: []}];
+  const release = [{name: 'master', tags: []}];
+  t.deepEqual(
+    normalize
+      .maintenance({maintenance, release})
+      .map(({type, name, range, accept, channel, 'merge-range': maintenanceRange}) => ({
+        type,
+        name,
+        range,
+        accept,
+        channel,
+        'merge-range': maintenanceRange,
+      })),
+    [
+      {
+        type: 'maintenance',
+        name: '1.1.x',
+        range: '>=1.1.0 <1.0.0',
+        accept: [],
+        channel: '1.1.x',
+        'merge-range': '>=1.1.0 <1.2.0',
+      },
+      {
+        type: 'maintenance',
+        name: '1.2.x',
+        range: '>=1.2.0 <1.0.0',
+        accept: [],
+        channel: '1.2.x',
+        'merge-range': '>=1.2.0 <1.3.0',
+      },
+      {
+        type: 'maintenance',
+        name: '1.x',
+        range: '>=1.3.0 <1.0.0',
+        accept: [],
+        channel: '1.x',
+        'merge-range': '>=1.3.0 <2.0.0',
+      },
+    ]
+  );
+});
+
+test('Maintenance branches - cap range to first release present on default branch and not in any Maintenance one', t => {
+  const maintenance = [
+    {name: '1.x', tags: toTags(['1.0.0', '1.1.0', '1.1.1', '1.2.0', '1.2.1', '1.3.0', '1.4.0', '1.5.0'])},
+    {name: 'name', range: '1.1.x', tags: toTags(['1.0.0', '1.0.1', '1.1.0', '1.1.1'])},
+    {name: '1.2.x', tags: toTags(['1.0.0', '1.1.0', '1.1.1', '1.2.0', '1.2.1'])},
+    {name: '2.x.x', tags: toTags(['1.0.0', '1.1.0', '1.1.1', '1.2.0', '1.2.1', '1.5.0'])},
+  ];
+  const release = [
+    {
+      name: 'master',
+      tags: toTags(['1.0.0', '1.1.0', '1.1.1', '1.2.0', '1.2.1', '1.3.0', '1.4.0', '1.5.0', '1.6.0', '2.0.0']),
+    },
+  ];
+
+  t.deepEqual(
+    normalize
+      .maintenance({maintenance, release})
+      .map(({type, name, range, accept, channel, 'merge-range': maintenanceRange}) => ({
+        type,
+        name,
+        range,
+        accept,
+        channel,
+        'merge-range': maintenanceRange,
+      })),
+    [
+      {
+        type: 'maintenance',
+        name: 'name',
+        range: '>=1.1.1 <1.2.0',
+        accept: ['patch'],
+        channel: 'name',
+        'merge-range': '>=1.1.0 <1.2.0',
+      },
+      {
+        type: 'maintenance',
+        name: '1.2.x',
+        range: '>=1.2.1 <1.3.0',
+        accept: ['patch'],
+        channel: '1.2.x',
+        'merge-range': '>=1.2.0 <1.3.0',
+      },
+      {
+        type: 'maintenance',
+        name: '1.x',
+        range: '>=1.5.0 <1.6.0',
+        accept: ['patch'],
+        channel: '1.x',
+        'merge-range': '>=1.3.0 <2.0.0',
+      },
+      {
+        type: 'maintenance',
+        name: '2.x.x',
+        range: '>=2.0.0 <1.6.0',
+        accept: [],
+        channel: '2.x.x',
+        'merge-range': '>=2.0.0 <3.0.0',
+      },
+    ]
+  );
+});
+
+test('Maintenance branches - cap range to default branch last release if all release are also present on maintenance branch', t => {
+  const maintenance = [
+    {name: '1.x', tags: toTags(['1.0.0', '1.2.0', '1.3.0'])},
+    {name: '2.x.x', tags: toTags(['1.0.0', '1.2.0', '1.3.0', '2.0.0'])},
+  ];
+  const release = [{name: 'master', tags: toTags(['1.0.0', '1.2.0', '1.3.0', '2.0.0'])}];
+
+  t.deepEqual(
+    normalize
+      .maintenance({maintenance, release})
+      .map(({type, name, range, accept, channel, 'merge-range': maintenanceRange}) => ({
+        type,
+        name,
+        range,
+        accept,
+        channel,
+        'merge-range': maintenanceRange,
+      })),
+    [
+      {
+        type: 'maintenance',
+        name: '1.x',
+        range: '>=1.3.0 <2.0.0',
+        accept: ['patch', 'minor'],
+        channel: '1.x',
+        'merge-range': '>=1.0.0 <2.0.0',
+      },
+      {
+        type: 'maintenance',
+        name: '2.x.x',
+        range: '>=2.0.0 <2.0.0',
+        accept: [],
+        channel: '2.x.x',
+        'merge-range': '>=2.0.0 <3.0.0',
+      },
+    ]
+  );
+});
+
+test('Release branches - initial state', t => {
+  const release = [{name: 'master', tags: []}, {name: 'next', tags: []}, {name: 'next-major', tags: []}];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [
+      {type: 'release', name: 'master', range: '>=1.0.0 <1.1.0', accept: ['patch'], channel: undefined},
+      {type: 'release', name: 'next', range: '>=1.1.0 <2.0.0', accept: ['patch', 'minor'], channel: 'next'},
+      {
+        type: 'release',
+        name: 'next-major',
+        range: '>=2.0.0',
+        accept: ['patch', 'minor', 'major'],
+        channel: 'next-major',
+      },
+    ]
+  );
+});
+
+test('Release branches - 3 release branches', t => {
+  const release = [
+    {name: 'master', tags: toTags(['1.0.0', '1.0.1', '1.0.2'])},
+    {name: 'next', tags: toTags(['1.0.0', '1.0.1', '1.0.2', '1.1.0', '1.2.0'])},
+    {name: 'next-major', tags: toTags(['1.0.0', '1.0.1', '1.0.2', '1.1.0', '1.2.0', '2.0.0', '2.0.1', '2.1.0'])},
+  ];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [
+      {type: 'release', name: 'master', range: '>=1.0.2 <1.1.0', accept: ['patch'], channel: undefined},
+      {type: 'release', name: 'next', range: '>=1.2.0 <2.0.0', accept: ['patch', 'minor'], channel: 'next'},
+      {
+        type: 'release',
+        name: 'next-major',
+        range: '>=2.1.0',
+        accept: ['patch', 'minor', 'major'],
+        channel: 'next-major',
+      },
+    ]
+  );
+});
+
+test('Release branches - 2 release branches', t => {
+  const release = [
+    {name: 'master', tags: toTags(['1.0.0', '1.0.1', '1.1.0', '1.1.1', '1.2.0'])},
+    {name: 'next', tags: toTags(['1.0.0', '1.0.1', '1.1.0', '1.1.1', '1.2.0', '2.0.0', '2.0.1', '2.1.0'])},
+  ];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [
+      {type: 'release', name: 'master', range: '>=1.2.0 <2.0.0', accept: ['patch', 'minor'], channel: undefined},
+      {type: 'release', name: 'next', range: '>=2.1.0', accept: ['patch', 'minor', 'major'], channel: 'next'},
+    ]
+  );
+});
+
+test('Release branches - 1 release branches', t => {
+  const release = [{name: 'master', tags: toTags(['1.0.0', '1.1.0', '1.1.1', '1.2.0'])}];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [{type: 'release', name: 'master', range: '>=1.2.0', accept: ['patch', 'minor', 'major'], channel: undefined}]
+  );
+});
+
+test('Release branches - cap ranges to first release only present on following branch', t => {
+  const release = [
+    {name: 'master', tags: toTags(['1.0.0', '1.1.0', '1.2.0', '2.0.0'])},
+    {name: 'next', tags: toTags(['1.0.0', '1.1.0', '1.2.0', '2.0.0', '2.1.0'])},
+    {name: 'next-major', tags: toTags(['1.0.0', '1.1.0', '1.2.0', '2.0.0', '2.1.0', '2.2.0'])},
+  ];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [
+      {type: 'release', name: 'master', range: '>=2.0.0 <2.1.0', accept: ['patch'], channel: undefined},
+      {type: 'release', name: 'next', range: '>=2.1.0 <2.2.0', accept: ['patch'], channel: 'next'},
+      {
+        type: 'release',
+        name: 'next-major',
+        range: '>=2.2.0',
+        accept: ['patch', 'minor', 'major'],
+        channel: 'next-major',
+      },
+    ]
+  );
+});
+
+test('Release branches - Handle missing previous tags in branch history', t => {
+  const release = [
+    {name: 'master', tags: toTags(['1.0.0', '2.0.0'])},
+    {name: 'next', tags: toTags(['1.0.0', '1.1.0', '1.1.1', '1.2.0', '2.0.0'])},
+  ];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [
+      {type: 'release', name: 'master', range: '>=2.0.0 <3.0.0', accept: ['patch', 'minor'], channel: undefined},
+      {type: 'release', name: 'next', range: '>=3.0.0', accept: ['patch', 'minor', 'major'], channel: 'next'},
+    ]
+  );
+});
+
+test('Release branches - enforce release gaps after downstream merge', t => {
+  const release = [
+    {name: 'master', tags: toTags(['1.0.0', '1.1.0', '2.0.0'])},
+    {name: 'next', tags: toTags(['1.0.0', '1.1.0', '2.0.0'])},
+    {name: 'next-major', tags: toTags(['1.0.0', '1.1.0', '2.0.0'])},
+  ];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [
+      {type: 'release', name: 'master', range: '>=2.0.0 <2.1.0', accept: ['patch'], channel: undefined},
+      {type: 'release', name: 'next', range: '>=2.1.0 <3.0.0', accept: ['patch', 'minor'], channel: 'next'},
+      {
+        type: 'release',
+        name: 'next-major',
+        range: '>=3.0.0',
+        accept: ['patch', 'minor', 'major'],
+        channel: 'next-major',
+      },
+    ]
+  );
+});
+
+test('Release branches - limit releases on 2nd and 3rd branche based on 1st branch last release', t => {
+  const release = [
+    {name: 'master', tags: toTags(['1.0.0', '1.1.0', '2.0.0', '3.0.0'])},
+    {name: 'next', tags: toTags(['1.0.0', '1.1.0'])},
+    {name: 'next-major', tags: toTags(['1.0.0', '1.1.0', '2.0.0'])},
+  ];
+
+  t.deepEqual(
+    normalize.release({release}).map(({type, name, range, accept, channel}) => ({type, name, range, accept, channel})),
+    [
+      {type: 'release', name: 'master', range: '>=3.0.0 <3.1.0', accept: ['patch'], channel: undefined},
+      {type: 'release', name: 'next', range: '>=3.1.0 <4.0.0', accept: ['patch', 'minor'], channel: 'next'},
+      {
+        type: 'release',
+        name: 'next-major',
+        range: '>=4.0.0',
+        accept: ['patch', 'minor', 'major'],
+        channel: 'next-major',
+      },
+    ]
+  );
+});
+
+test('Prerelease branches', t => {
+  const prerelease = [{name: 'beta', prerelease: true, tags: []}, {name: 'alpha', prerelease: 'preview', tags: []}];
+
+  t.deepEqual(normalize.prerelease({prerelease}).map(({type, name, channel}) => ({type, name, channel})), [
+    {type: 'prerelease', name: 'beta', channel: 'beta'},
+    {type: 'prerelease', name: 'alpha', channel: 'alpha'},
+  ]);
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -29,6 +29,7 @@ test.serial('Pass options to semantic-release API', async t => {
     '',
     '-b',
     'master',
+    'next',
     '-r',
     'https://github/com/owner/repo.git',
     '-t',
@@ -68,7 +69,7 @@ test.serial('Pass options to semantic-release API', async t => {
 
   const exitCode = await cli();
 
-  t.is(run.args[0][0].branch, 'master');
+  t.deepEqual(run.args[0][0].branches, ['master', 'next']);
   t.is(run.args[0][0].repositoryUrl, 'https://github/com/owner/repo.git');
   t.is(run.args[0][0].tagFormat, `v\${version}`);
   t.deepEqual(run.args[0][0].plugins, ['plugin1', 'plugin2']);
@@ -92,7 +93,7 @@ test.serial('Pass options to semantic-release API with alias arguments', async t
   const argv = [
     '',
     '',
-    '--branch',
+    '--branches',
     'master',
     '--repository-url',
     'https://github/com/owner/repo.git',
@@ -110,7 +111,7 @@ test.serial('Pass options to semantic-release API with alias arguments', async t
 
   const exitCode = await cli();
 
-  t.is(run.args[0][0].branch, 'master');
+  t.deepEqual(run.args[0][0].branches, ['master']);
   t.is(run.args[0][0].repositoryUrl, 'https://github/com/owner/repo.git');
   t.is(run.args[0][0].tagFormat, `v\${version}`);
   t.deepEqual(run.args[0][0].plugins, ['plugin1', 'plugin2']);

--- a/test/definitions/branches.test.js
+++ b/test/definitions/branches.test.js
@@ -1,0 +1,86 @@
+import test from 'ava';
+import {maintenance, prerelease, release} from '../../lib/definitions/branches';
+
+test('A "maintenance" branch is identified by having a "range" property or a "name" formatted like "N.x", "N.x.x" or "N.N.x"', t => {
+  t.true(maintenance.filter({name: '1.x.x'}));
+  t.true(maintenance.filter({name: '1.0.x'}));
+  t.true(maintenance.filter({name: '1.x'}));
+  t.true(maintenance.filter({name: 'some-name', range: '1.x.x'}));
+  t.true(maintenance.filter({name: 'some-name', range: '1.1.x'}));
+  t.true(maintenance.filter({name: 'some-name', range: ''}));
+  t.true(maintenance.filter({name: 'some-name', range: null}));
+  t.true(maintenance.filter({name: 'some-name', range: false}));
+
+  t.false(maintenance.filter({name: 'some-name'}));
+  t.false(maintenance.filter({name: '1.0.0'}));
+  t.false(maintenance.filter({name: 'x.x.x'}));
+});
+
+test('A "maintenance" branches must have a "range" property formatted like "N.x", "N.x.x" or "N.N.x"', t => {
+  t.true(maintenance.branchValidator({name: 'some-name', range: '1.x.x'}));
+  t.true(maintenance.branchValidator({name: 'some-name', range: '1.1.x'}));
+
+  t.false(maintenance.branchValidator({name: 'some-name', range: '^1.0.0'}));
+  t.false(maintenance.branchValidator({name: 'some-name', range: '>=1.0.0 <2.0.0'}));
+  t.false(maintenance.branchValidator({name: 'some-name', range: '1.0.0'}));
+  t.false(maintenance.branchValidator({name: 'some-name', range: 'wrong-range'}));
+  t.false(maintenance.branchValidator({name: 'some-name', range: ''}));
+  t.false(maintenance.branchValidator({name: 'some-name', range: null}));
+  t.false(maintenance.branchValidator({name: 'some-name', range: false}));
+});
+
+test('The "maintenance" branches must have unique ranges', t => {
+  t.true(maintenance.branchesValidator([{range: '1.x.x'}, {range: '1.0.x'}]));
+
+  t.false(maintenance.branchesValidator([{range: '1.x.x'}, {range: '1.x.x'}]));
+  t.false(maintenance.branchesValidator([{range: '1.x.x'}, {range: '1.x'}]));
+});
+
+test('A "prerelease" branch is identified by having a range "prerelease" property', t => {
+  t.true(prerelease.filter({name: 'some-name', prerelease: true}));
+  t.true(prerelease.filter({name: 'some-name', prerelease: 'beta'}));
+  t.true(prerelease.filter({name: 'some-name', prerelease: ''}));
+  t.true(prerelease.filter({name: 'some-name', prerelease: null}));
+  t.true(prerelease.filter({name: 'some-name', prerelease: false}));
+
+  t.false(prerelease.filter({name: 'some-name'}));
+});
+
+test('A "prerelease" branch must have a valid prerelease detonation in "prerelease" property or in "name" if "prerelease" is "true"', t => {
+  t.true(prerelease.branchValidator({name: 'beta', prerelease: true}));
+  t.true(prerelease.branchValidator({name: 'some-name', prerelease: 'beta'}));
+
+  t.false(prerelease.branchValidator({name: 'some-name', prerelease: ''}));
+  t.false(prerelease.branchValidator({name: 'some-name', prerelease: null}));
+  t.false(prerelease.branchValidator({name: 'some-name', prerelease: false}));
+  t.false(prerelease.branchValidator({name: 'some-name', prerelease: '000'}));
+  t.false(prerelease.branchValidator({name: 'some-name', prerelease: '#beta'}));
+  t.false(prerelease.branchValidator({name: '000', prerelease: true}));
+  t.false(prerelease.branchValidator({name: '#beta', prerelease: true}));
+});
+
+test('The "prerelease" branches must have unique "prerelease" property', t => {
+  t.true(prerelease.branchesValidator([{prerelease: 'beta'}, {prerelease: 'alpha'}]));
+
+  t.false(prerelease.branchesValidator([{range: 'beta'}, {range: 'beta'}, {range: 'alpha'}]));
+});
+
+test('A "release" branch is identified by not havin a "range" or "prerelease" property or a "name" formatted like "N.x", "N.x.x" or "N.N.x"', t => {
+  t.true(release.filter({name: 'some-name'}));
+
+  t.false(release.filter({name: '1.x.x'}));
+  t.false(release.filter({name: '1.0.x'}));
+  t.false(release.filter({name: 'some-name', range: '1.x.x'}));
+  t.false(release.filter({name: 'some-name', range: '1.1.x'}));
+  t.false(release.filter({name: 'some-name', prerelease: true}));
+  t.false(release.filter({name: 'some-name', prerelease: 'beta'}));
+});
+
+test('There must be between 1 and 3 release branches', t => {
+  t.true(release.branchesValidator([{name: 'branch1'}]));
+  t.true(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}]));
+  t.true(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}, {name: 'branch3'}]));
+
+  t.false(release.branchesValidator([]));
+  t.false(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}, {name: 'branch3'}, {name: 'branch4'}]));
+});

--- a/test/definitions/plugins.test.js
+++ b/test/definitions/plugins.test.js
@@ -32,6 +32,16 @@ test('The "publish" plugin output, if defined, must be an object', t => {
   t.true(plugins.publish.outputValidator(''));
 });
 
+test('The "addChannel" plugin output, if defined, must be an object', t => {
+  t.false(plugins.addChannel.outputValidator(1));
+  t.false(plugins.addChannel.outputValidator('string'));
+
+  t.true(plugins.addChannel.outputValidator({}));
+  t.true(plugins.addChannel.outputValidator());
+  t.true(plugins.addChannel.outputValidator(null));
+  t.true(plugins.addChannel.outputValidator(''));
+});
+
 test('The "generateNotes" plugins output are concatenated with separator and sensitive data is hidden', t => {
   const env = {MY_TOKEN: 'secret token'};
   t.is(plugins.generateNotes.postprocess(['note 1', 'note 2'], {env}), `note 1${RELEASE_NOTES_SEPARATOR}note 2`);

--- a/test/get-commits.test.js
+++ b/test/get-commits.test.js
@@ -66,6 +66,25 @@ test('Get all commits since gitHead (from lastRelease) on a detached head repo',
   t.truthy(result[0].committer.name);
 });
 
+test('Get all commits between lastRelease.gitHead and a shas', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  const {cwd} = await gitRepo();
+  // Add commits to the master branch
+  const commits = await gitCommits(['First', 'Second', 'Third'], {cwd});
+
+  // Retrieve the commits with the commits module, between commit 'First' and 'Third'
+  const result = await getCommits({
+    cwd,
+    lastRelease: {gitHead: commits[commits.length - 1].hash},
+    nextRelease: {gitHead: commits[1].hash},
+    logger: t.context.logger,
+  });
+
+  // Verify the commits created and retrieved by the module are identical
+  t.is(result.length, 1);
+  t.deepEqual(result, commits.slice(1, commits.length - 1));
+});
+
 test('Return empty array if lastRelease.gitHead is the last commit', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd} = await gitRepo();

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -8,7 +8,7 @@ test('Return the same "git" formatted URL if "gitCredentials" is not defined', a
   const {cwd} = await gitRepo();
 
   t.is(
-    await getAuthUrl({cwd, env, options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'}}),
+    await getAuthUrl({cwd, env, branch: {name: 'master'}, options: {repositoryUrl: 'git@host.null:owner/repo.git'}}),
     'git@host.null:owner/repo.git'
   );
 });
@@ -17,7 +17,12 @@ test('Return the same "https" formatted URL if "gitCredentials" is not defined',
   const {cwd} = await gitRepo();
 
   t.is(
-    await getAuthUrl({cwd, env, options: {branch: 'master', repositoryUrl: 'https://host.null/owner/repo.git'}}),
+    await getAuthUrl({
+      cwd,
+      env,
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'https://host.null/owner/repo.git'},
+    }),
     'https://host.null/owner/repo.git'
   );
 });
@@ -26,7 +31,12 @@ test('Return the "https" formatted URL if "gitCredentials" is not defined and re
   const {cwd} = await gitRepo();
 
   t.is(
-    await getAuthUrl({cwd, env, options: {branch: 'master', repositoryUrl: 'git+https://host.null/owner/repo.git'}}),
+    await getAuthUrl({
+      cwd,
+      env,
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git+https://host.null/owner/repo.git'},
+    }),
     'https://host.null/owner/repo.git'
   );
 });
@@ -35,7 +45,7 @@ test('Do not add trailing ".git" if not present in the origian URL', async t => 
   const {cwd} = await gitRepo();
 
   t.is(
-    await getAuthUrl({cwd, env, options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo'}}),
+    await getAuthUrl({cwd, env, vranch: {name: 'master'}, options: {repositoryUrl: 'git@host.null:owner/repo'}}),
     'git@host.null:owner/repo'
   );
 });
@@ -47,7 +57,8 @@ test('Handle "https" URL with group and subgroup', async t => {
     await getAuthUrl({
       cwd,
       env,
-      options: {branch: 'master', repositoryUrl: 'https://host.null/group/subgroup/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'https://host.null/group/subgroup/owner/repo.git'},
     }),
     'https://host.null/group/subgroup/owner/repo.git'
   );
@@ -60,7 +71,8 @@ test('Handle "git" URL with group and subgroup', async t => {
     await getAuthUrl({
       cwd,
       env,
-      options: {branch: 'master', repositoryUrl: 'git@host.null:group/subgroup/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:group/subgroup/owner/repo.git'},
     }),
     'git@host.null:group/subgroup/owner/repo.git'
   );
@@ -70,7 +82,12 @@ test('Convert shorthand URL', async t => {
   const {cwd} = await gitRepo();
 
   t.is(
-    await getAuthUrl({cwd, env, options: {repositoryUrl: 'semanitc-release/semanitc-release'}}),
+    await getAuthUrl({
+      cwd,
+      env,
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'semanitc-release/semanitc-release'},
+    }),
     'https://github.com/semanitc-release/semanitc-release.git'
   );
 });
@@ -82,7 +99,8 @@ test('Convert GitLab shorthand URL', async t => {
     await getAuthUrl({
       cwd,
       env,
-      options: {branch: 'master', repositoryUrl: 'gitlab:semanitc-release/semanitc-release'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'gitlab:semanitc-release/semanitc-release'},
     }),
     'https://gitlab.com/semanitc-release/semanitc-release.git'
   );
@@ -95,7 +113,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined and reposi
     await getAuthUrl({
       cwd,
       env: {...env, GIT_CREDENTIALS: 'user:pass'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
     }),
     'https://user:pass@host.null/owner/repo.git'
   );
@@ -121,7 +140,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined and reposi
     await getAuthUrl({
       cwd,
       env: {...env, GIT_CREDENTIALS: 'user:pass'},
-      options: {branch: 'master', repositoryUrl: 'https://host.null/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'https://host.null/owner/repo.git'},
     }),
     'https://user:pass@host.null/owner/repo.git'
   );
@@ -134,7 +154,8 @@ test('Return the "http" formatted URL if "gitCredentials" is defined and reposit
     await getAuthUrl({
       cwd,
       env: {...env, GIT_CREDENTIALS: 'user:pass'},
-      options: {branch: 'master', repositoryUrl: 'http://host.null/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'http://host.null/owner/repo.git'},
     }),
     'http://user:pass@host.null/owner/repo.git'
   );
@@ -147,7 +168,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined and reposi
     await getAuthUrl({
       cwd,
       env: {...env, GIT_CREDENTIALS: 'user:pass'},
-      options: {branch: 'master', repositoryUrl: 'git+https://host.null/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git+https://host.null/owner/repo.git'},
     }),
     'https://user:pass@host.null/owner/repo.git'
   );
@@ -160,7 +182,8 @@ test('Return the "http" formatted URL if "gitCredentials" is defined and reposit
     await getAuthUrl({
       cwd,
       env: {...env, GIT_CREDENTIALS: 'user:pass'},
-      options: {branch: 'master', repositoryUrl: 'git+http://host.null/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git+http://host.null/owner/repo.git'},
     }),
     'http://user:pass@host.null/owner/repo.git'
   );
@@ -173,7 +196,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "GH_T
     await getAuthUrl({
       cwd,
       env: {...env, GH_TOKEN: 'token'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
     }),
     'https://token@host.null/owner/repo.git'
   );
@@ -186,7 +210,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "GITH
     await getAuthUrl({
       cwd,
       env: {...env, GITHUB_TOKEN: 'token'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
     }),
     'https://token@host.null/owner/repo.git'
   );
@@ -199,7 +224,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "GL_T
     await getAuthUrl({
       cwd,
       env: {...env, GL_TOKEN: 'token'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
     }),
     'https://gitlab-ci-token:token@host.null/owner/repo.git'
   );
@@ -212,7 +238,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "GITL
     await getAuthUrl({
       cwd,
       env: {...env, GITLAB_TOKEN: 'token'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
     }),
     'https://gitlab-ci-token:token@host.null/owner/repo.git'
   );
@@ -225,7 +252,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "BB_T
     await getAuthUrl({
       cwd,
       env: {...env, BB_TOKEN: 'token'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
     }),
     'https://x-token-auth:token@host.null/owner/repo.git'
   );
@@ -238,7 +266,8 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "BITB
     await getAuthUrl({
       cwd,
       env: {...env, BITBUCKET_TOKEN: 'token'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
     }),
     'https://x-token-auth:token@host.null/owner/repo.git'
   );
@@ -251,7 +280,8 @@ test('Handle "https" URL with group and subgroup, with "GIT_CREDENTIALS"', async
     await getAuthUrl({
       cwd,
       env: {...env, GIT_CREDENTIALS: 'user:pass'},
-      options: {branch: 'master', repositoryUrl: 'https://host.null/group/subgroup/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'https://host.null/group/subgroup/owner/repo.git'},
     }),
     'https://user:pass@host.null/group/subgroup/owner/repo.git'
   );
@@ -264,7 +294,8 @@ test('Handle "git" URL with group and subgroup, with "GIT_CREDENTIALS', async t 
     await getAuthUrl({
       cwd,
       env: {...env, GIT_CREDENTIALS: 'user:pass'},
-      options: {branch: 'master', repositoryUrl: 'git@host.null:group/subgroup/owner/repo.git'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:group/subgroup/owner/repo.git'},
     }),
     'https://user:pass@host.null/group/subgroup/owner/repo.git'
   );
@@ -274,7 +305,12 @@ test('Do not add git credential to repositoryUrl if push is allowed', async t =>
   const {cwd, repositoryUrl} = await gitRepo(true);
 
   t.is(
-    await getAuthUrl({cwd, env: {...env, GIT_CREDENTIALS: 'user:pass'}, options: {branch: 'master', repositoryUrl}}),
+    await getAuthUrl({
+      cwd,
+      env: {...env, GIT_CREDENTIALS: 'user:pass'},
+      branch: {name: 'master'},
+      options: {repositoryUrl},
+    }),
     repositoryUrl
   );
 });

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -1,7 +1,6 @@
 import test from 'ava';
 import {stub} from 'sinon';
 import getLastRelease from '../lib/get-last-release';
-import {gitRepo, gitCommits, gitTagVersion, gitCheckout} from './helpers/git-utils';
 
 test.beforeEach(t => {
   // Stub the logger functions
@@ -9,143 +8,61 @@ test.beforeEach(t => {
   t.context.logger = {log: t.context.log};
 });
 
-test('Get the highest non-prerelease valid tag', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  const {cwd} = await gitRepo();
-  // Create some commits and tags
-  await gitCommits(['First'], {cwd});
-  await gitTagVersion('foo', undefined, {cwd});
-  const commits = await gitCommits(['Second'], {cwd});
-  await gitTagVersion('v2.0.0', undefined, {cwd});
-  await gitCommits(['Third'], {cwd});
-  await gitTagVersion('v1.0.0', undefined, {cwd});
-  await gitCommits(['Fourth'], {cwd});
-  await gitTagVersion('v3.0', undefined, {cwd});
-  await gitCommits(['Fifth'], {cwd});
-  await gitTagVersion('v3.0.0-beta.1', undefined, {cwd});
+test('Get the highest non-prerelease valid tag', t => {
+  const result = getLastRelease({
+    branch: {
+      name: 'master',
+      tags: [
+        {version: '2.0.0', gitTag: 'v2.0.0', gitHead: '222'},
+        {version: '1.0.0', gitTag: 'v1.0.0', gitHead: '111'},
+        {version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: '333'},
+      ],
+      type: 'release',
+    },
+    options: {tagFormat: `v\${version}`},
+    logger: t.context.logger,
+  });
 
-  const result = await getLastRelease({cwd, options: {tagFormat: `v\${version}`}, logger: t.context.logger});
-
-  t.deepEqual(result, {gitHead: commits[0].hash, gitTag: 'v2.0.0', version: '2.0.0'});
-  t.deepEqual(t.context.log.args[0], ['Found git tag v2.0.0 associated with version 2.0.0']);
+  t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: '222', channel: undefined});
+  t.deepEqual(t.context.log.args[0][0], 'Found git tag v2.0.0 associated with version 2.0.0 on branch master');
 });
 
-test('Get the highest tag in the history of the current branch', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  const {cwd} = await gitRepo();
-  // Add commit to the master branch
-  await gitCommits(['First'], {cwd});
-  // Create the tag corresponding to version 1.0.0
-  // Create the new branch 'other-branch' from master
-  await gitCheckout('other-branch', true, {cwd});
-  // Add commit to the 'other-branch' branch
-  await gitCommits(['Second'], {cwd});
-  // Create the tag corresponding to version 3.0.0
-  await gitTagVersion('v3.0.0', undefined, {cwd});
-  // Checkout master
-  await gitCheckout('master', false, {cwd});
-  // Add another commit to the master branch
-  const commits = await gitCommits(['Third'], {cwd});
-  // Create the tag corresponding to version 2.0.0
-  await gitTagVersion('v2.0.0', undefined, {cwd});
-
-  const result = await getLastRelease({cwd, options: {tagFormat: `v\${version}`}, logger: t.context.logger});
-
-  t.deepEqual(result, {gitHead: commits[0].hash, gitTag: 'v2.0.0', version: '2.0.0'});
-});
-
-test('Match the tag name from the begining of the string', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  const {cwd} = await gitRepo();
-  const commits = await gitCommits(['First'], {cwd});
-  await gitTagVersion('prefix/v1.0.0', undefined, {cwd});
-  await gitTagVersion('prefix/v2.0.0', undefined, {cwd});
-  await gitTagVersion('other-prefix/v3.0.0', undefined, {cwd});
-
-  const result = await getLastRelease({cwd, options: {tagFormat: `prefix/v\${version}`}, logger: t.context.logger});
-
-  t.deepEqual(result, {gitHead: commits[0].hash, gitTag: 'prefix/v2.0.0', version: '2.0.0'});
-});
-
-test('Return empty object if no valid tag is found', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  const {cwd} = await gitRepo();
-  // Create some commits and tags
-  await gitCommits(['First'], {cwd});
-  await gitTagVersion('foo', undefined, {cwd});
-  await gitCommits(['Second'], {cwd});
-  await gitTagVersion('v2.0.x', undefined, {cwd});
-  await gitCommits(['Third'], {cwd});
-  await gitTagVersion('v3.0', undefined, {cwd});
-
-  const result = await getLastRelease({cwd, options: {tagFormat: `v\${version}`}, logger: t.context.logger});
+test('Return empty object if no valid tag is found', t => {
+  const result = getLastRelease({
+    branch: {
+      name: 'master',
+      tags: [{version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: '111'}],
+      type: 'release',
+    },
+    options: {tagFormat: `v\${version}`},
+    logger: t.context.logger,
+  });
 
   t.deepEqual(result, {});
-  t.is(t.context.log.args[0][0], 'No git tag version found');
+  t.deepEqual(t.context.log.args[0][0], 'No git tag version found on branch master');
 });
 
-test('Return empty object if no valid tag is found in history', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  const {cwd} = await gitRepo();
-  await gitCommits(['First'], {cwd});
-  await gitCheckout('other-branch', true, {cwd});
-  await gitCommits(['Second'], {cwd});
-  await gitTagVersion('v1.0.0', undefined, {cwd});
-  await gitTagVersion('v2.0.0', undefined, {cwd});
-  await gitTagVersion('v3.0.0', undefined, {cwd});
-  await gitCheckout('master', false, {cwd});
+test('Get the highest non-prerelease valid tag before a certain version', t => {
+  const result = getLastRelease(
+    {
+      branch: {
+        name: 'master',
+        channel: undefined,
+        tags: [
+          {version: '2.0.0', gitTag: 'v2.0.0', gitHead: '333'},
+          {version: '1.0.0', gitTag: 'v1.0.0', gitHead: '111'},
+          {version: '2.0.0-beta.1', gitTag: 'v2.0.0-beta.1@beta', gitHead: '222'},
+          {version: '2.1.0', gitTag: 'v2.1.0', gitHead: '444'},
+          {version: '2.1.1', gitTag: 'v2.1.1', gitHead: '555'},
+        ],
+        type: 'release',
+      },
+      options: {tagFormat: `v\${version}`},
+      logger: t.context.logger,
+    },
+    {before: '2.1.0'}
+  );
 
-  const result = await getLastRelease({cwd, options: {tagFormat: `v\${version}`}, logger: t.context.logger});
-
-  t.deepEqual(result, {});
-  t.is(t.context.log.args[0][0], 'No git tag version found');
-});
-
-test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  const {cwd} = await gitRepo();
-  // Create some commits and tags
-  const [{hash: gitHead}] = await gitCommits(['First'], {cwd});
-
-  await gitTagVersion('1.0.0', undefined, {cwd});
-  t.deepEqual(await getLastRelease({cwd, options: {tagFormat: `\${version}`}, logger: t.context.logger}), {
-    gitHead,
-    gitTag: '1.0.0',
-    version: '1.0.0',
-  });
-
-  await gitTagVersion('foo-1.0.0-bar', undefined, {cwd});
-  t.deepEqual(await getLastRelease({cwd, options: {tagFormat: `foo-\${version}-bar`}, logger: t.context.logger}), {
-    gitHead,
-    gitTag: 'foo-1.0.0-bar',
-    version: '1.0.0',
-  });
-
-  await gitTagVersion('foo-v1.0.0-bar', undefined, {cwd});
-  t.deepEqual(await getLastRelease({cwd, options: {tagFormat: `foo-v\${version}-bar`}, logger: t.context.logger}), {
-    gitHead,
-    gitTag: 'foo-v1.0.0-bar',
-    version: '1.0.0',
-  });
-
-  await gitTagVersion('(.+)/1.0.0/(a-z)', undefined, {cwd});
-  t.deepEqual(await getLastRelease({cwd, options: {tagFormat: `(.+)/\${version}/(a-z)`}, logger: t.context.logger}), {
-    gitHead,
-    gitTag: '(.+)/1.0.0/(a-z)',
-    version: '1.0.0',
-  });
-
-  await gitTagVersion('2.0.0-1.0.0-bar.1', undefined, {cwd});
-  t.deepEqual(await getLastRelease({cwd, options: {tagFormat: `2.0.0-\${version}-bar.1`}, logger: t.context.logger}), {
-    gitHead,
-    gitTag: '2.0.0-1.0.0-bar.1',
-    version: '1.0.0',
-  });
-
-  await gitTagVersion('3.0.0-bar.1', undefined, {cwd});
-  t.deepEqual(await getLastRelease({cwd, options: {tagFormat: `\${version}-bar.1`}, logger: t.context.logger}), {
-    gitHead,
-    gitTag: '3.0.0-bar.1',
-    version: '3.0.0',
-  });
+  t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: '333', channel: undefined});
+  t.deepEqual(t.context.log.args[0][0], 'Found git tag v2.0.0 associated with version 2.0.0 on branch master');
 });

--- a/test/get-next-version.test.js
+++ b/test/get-next-version.test.js
@@ -9,33 +9,127 @@ test.beforeEach(t => {
 });
 
 test('Increase version for patch release', t => {
-  const version = getNextVersion({
-    nextRelease: {type: 'patch'},
-    lastRelease: {version: '1.0.0'},
-    logger: t.context.logger,
-  });
-  t.is(version, '1.0.1');
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release'},
+      nextRelease: {type: 'patch'},
+      lastRelease: {version: '1.0.0'},
+      logger: t.context.logger,
+    }),
+    '1.0.1'
+  );
 });
 
 test('Increase version for minor release', t => {
-  const version = getNextVersion({
-    nextRelease: {type: 'minor'},
-    lastRelease: {version: '1.0.0'},
-    logger: t.context.logger,
-  });
-  t.is(version, '1.1.0');
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release'},
+      nextRelease: {type: 'minor'},
+      lastRelease: {version: '1.0.0'},
+      logger: t.context.logger,
+    }),
+    '1.1.0'
+  );
 });
 
 test('Increase version for major release', t => {
-  const version = getNextVersion({
-    nextRelease: {type: 'major'},
-    lastRelease: {version: '1.0.0'},
-    logger: t.context.logger,
-  });
-  t.is(version, '2.0.0');
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release'},
+      nextRelease: {type: 'major'},
+      lastRelease: {version: '1.0.0'},
+      logger: t.context.logger,
+    }),
+    '2.0.0'
+  );
 });
 
 test('Return 1.0.0 if there is no previous release', t => {
-  const version = getNextVersion({nextRelease: {type: 'minor'}, lastRelease: {}, logger: t.context.logger});
-  t.is(version, '1.0.0');
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release'},
+      nextRelease: {type: 'minor'},
+      lastRelease: {},
+      logger: t.context.logger,
+    }),
+    '1.0.0'
+  );
+});
+
+test('Increase version for patch release on prerelease branch', t => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'beta', type: 'prerelease', prerelease: 'beta'},
+      nextRelease: {type: 'patch'},
+      lastRelease: {version: '1.0.0'},
+      logger: t.context.logger,
+    }),
+    '1.0.1-beta.1'
+  );
+
+  t.is(
+    getNextVersion({
+      branch: {name: 'beta', type: 'prerelease', prerelease: 'beta'},
+      nextRelease: {type: 'patch'},
+      lastRelease: {version: '1.0.0-beta.1'},
+      logger: t.context.logger,
+    }),
+    '1.0.0-beta.2'
+  );
+});
+
+test('Increase version for minor release on prerelease branch', t => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'beta', type: 'prerelease', prerelease: 'beta'},
+      nextRelease: {type: 'minor'},
+      lastRelease: {version: '1.0.0'},
+      logger: t.context.logger,
+    }),
+    '1.1.0-beta.1'
+  );
+
+  t.is(
+    getNextVersion({
+      branch: {name: 'beta', type: 'prerelease', prerelease: 'beta'},
+      nextRelease: {type: 'minor'},
+      lastRelease: {version: '1.0.0-beta.1'},
+      logger: t.context.logger,
+    }),
+    '1.0.0-beta.2'
+  );
+});
+
+test('Increase version for major release on prerelease branch', t => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'beta', type: 'prerelease', prerelease: 'beta'},
+      nextRelease: {type: 'major'},
+      lastRelease: {version: '1.0.0'},
+      logger: t.context.logger,
+    }),
+    '2.0.0-beta.1'
+  );
+
+  t.is(
+    getNextVersion({
+      branch: {name: 'beta', type: 'prerelease', prerelease: 'beta'},
+      nextRelease: {type: 'major'},
+      lastRelease: {version: '1.0.0-beta.1'},
+      logger: t.context.logger,
+    }),
+    '1.0.0-beta.2'
+  );
+});
+
+test('Return 1.0.0 if there is no previous release on prerelease branch', t => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'beta', type: 'prerelease', prerelease: 'beta'},
+      nextRelease: {type: 'minor'},
+      lastRelease: {},
+      logger: t.context.logger,
+    }),
+    '1.0.0-beta.1'
+  );
 });

--- a/test/get-releases-to-add.test.js
+++ b/test/get-releases-to-add.test.js
@@ -1,0 +1,258 @@
+import test from 'ava';
+import {stub} from 'sinon';
+import getReleasesToAdd from '../lib/get-releases-to-add';
+
+test.beforeEach(t => {
+  // Stub the logger functions
+  t.context.log = stub();
+  t.context.logger = {log: t.context.log};
+});
+
+test('Return versions merged from release to maintenance branch', t => {
+  const result = getReleasesToAdd({
+    branch: {
+      name: '1.x',
+      channel: '1.x',
+      tags: [
+        {gitTag: 'v1.0.0@1.x', version: '1.0.0', channel: '1.x', gitHead: '111'},
+        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
+        {gitTag: 'v1.1.0', version: '1.1.0', gitHead: '222'},
+        {gitTag: 'v1.1.1', version: '1.1.1', gitHead: '333'},
+      ],
+    },
+    branches: [{name: '1.x', channel: '1.x'}, {name: 'master'}],
+    options: {tagFormat: `v\${version}`},
+    logger: t.context.logger,
+  });
+
+  t.deepEqual(result, [
+    {
+      lastRelease: {version: '1.0.0', channel: '1.x', gitTag: 'v1.0.0@1.x', name: 'v1.0.0', gitHead: '111'},
+      currentRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: undefined,
+        gitTag: 'v1.1.0',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+      nextRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: '1.x',
+        gitTag: 'v1.1.0@1.x',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+    },
+    {
+      lastRelease: {version: '1.1.0', channel: undefined, gitTag: 'v1.1.0', name: 'v1.1.0', gitHead: '222'},
+      currentRelease: {
+        type: 'patch',
+        version: '1.1.1',
+        channel: undefined,
+        gitTag: 'v1.1.1',
+        name: 'v1.1.1',
+        gitHead: '333',
+      },
+      nextRelease: {
+        type: 'patch',
+        version: '1.1.1',
+        channel: '1.x',
+        gitTag: 'v1.1.1@1.x',
+        name: 'v1.1.1',
+        gitHead: '333',
+      },
+    },
+  ]);
+});
+
+test('Return versions merged from future branch to release branch', t => {
+  const result = getReleasesToAdd({
+    branch: {
+      name: 'master',
+      tags: [
+        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
+        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'},
+        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next', gitHead: '222'},
+        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channel: 'next-major', gitHead: '333'},
+      ],
+    },
+    branches: [{name: 'master'}, {name: 'next', channel: 'next'}, {name: 'next-major', channel: 'next-major'}],
+    options: {tagFormat: `v\${version}`},
+    logger: t.context.logger,
+  });
+
+  t.deepEqual(result, [
+    {
+      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: '111'},
+      currentRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: 'next',
+        gitTag: 'v1.1.0@next',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+      nextRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: undefined,
+        gitTag: 'v1.1.0',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+    },
+    {
+      lastRelease: {version: '1.1.0', gitTag: 'v1.1.0@next', name: 'v1.1.0', gitHead: '222', channel: 'next'},
+      currentRelease: {
+        type: 'major',
+        version: '2.0.0',
+        channel: 'next-major',
+        gitTag: 'v2.0.0@next-major',
+        name: 'v2.0.0',
+        gitHead: '333',
+      },
+      nextRelease: {
+        type: 'major',
+        version: '2.0.0',
+        channel: undefined,
+        gitTag: 'v2.0.0',
+        name: 'v2.0.0',
+        gitHead: '333',
+      },
+    },
+  ]);
+});
+
+test('Return releases sorted by ascending order', t => {
+  const result = getReleasesToAdd({
+    branch: {
+      name: 'master',
+      tags: [
+        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channel: 'next-major', gitHead: '333'},
+        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next', gitHead: '222'},
+        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
+        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'},
+      ],
+    },
+    branches: [{name: 'master'}, {name: 'next', channel: 'next'}, {name: 'next-major', channel: 'next-major'}],
+    options: {tagFormat: `v\${version}`},
+    logger: t.context.logger,
+  });
+
+  t.deepEqual(result, [
+    {
+      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: '111'},
+      currentRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: 'next',
+        gitTag: 'v1.1.0@next',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+      nextRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: undefined,
+        gitTag: 'v1.1.0',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+    },
+    {
+      lastRelease: {version: '1.1.0', gitTag: 'v1.1.0@next', name: 'v1.1.0', gitHead: '222', channel: 'next'},
+      currentRelease: {
+        type: 'major',
+        version: '2.0.0',
+        channel: 'next-major',
+        gitTag: 'v2.0.0@next-major',
+        name: 'v2.0.0',
+        gitHead: '333',
+      },
+      nextRelease: {
+        type: 'major',
+        version: '2.0.0',
+        channel: undefined,
+        gitTag: 'v2.0.0',
+        name: 'v2.0.0',
+        gitHead: '333',
+      },
+    },
+  ]);
+});
+
+test('no lastRelease', t => {
+  const result = getReleasesToAdd({
+    branch: {name: 'master', tags: [{gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'}]},
+    branches: [{name: 'master'}, {name: 'next', channel: 'next'}],
+    options: {tagFormat: `v\${version}`},
+    logger: t.context.logger,
+  });
+
+  t.deepEqual(result, [
+    {
+      lastRelease: {},
+      currentRelease: {
+        type: 'major',
+        version: '1.0.0',
+        channel: 'next',
+        gitTag: 'v1.0.0@next',
+        name: 'v1.0.0',
+        gitHead: '111',
+      },
+      nextRelease: {
+        type: 'major',
+        version: '1.0.0',
+        channel: undefined,
+        gitTag: 'v1.0.0',
+        name: 'v1.0.0',
+        gitHead: '111',
+      },
+    },
+  ]);
+});
+
+test('Ignore pre-release versions', t => {
+  const result = getReleasesToAdd({
+    branch: {
+      name: 'master',
+      tags: [
+        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
+        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'},
+        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next', gitHead: '222'},
+        {gitTag: 'v2.0.0-alpha.1@alpha', version: '2.0.0', channel: 'alpha', gitHead: '333'},
+      ],
+    },
+    branches: [
+      {name: 'master'},
+      {name: 'next', channel: 'next'},
+      {name: 'alpha', type: 'prerelease', channel: 'alpha'},
+    ],
+    options: {tagFormat: `v\${version}`},
+    logger: t.context.logger,
+  });
+
+  t.deepEqual(result, [
+    {
+      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: '111'},
+      currentRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: 'next',
+        gitTag: 'v1.1.0@next',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+      nextRelease: {
+        type: 'minor',
+        version: '1.1.0',
+        channel: undefined,
+        gitTag: 'v1.1.0',
+        name: 'v1.1.0',
+        gitHead: '222',
+      },
+    },
+  ]);
+});

--- a/test/helpers/npm-utils.js
+++ b/test/helpers/npm-utils.js
@@ -1,0 +1,5 @@
+import execa from 'execa';
+
+export async function npmView(packageName, env) {
+  return JSON.parse(await execa.stdout('npm', ['view', packageName, '--json'], {env}));
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,7 @@ import SemanticReleaseError from '@semantic-release/error';
 import {COMMIT_NAME, COMMIT_EMAIL, SECRET_REPLACEMENT} from '../lib/definitions/constants';
 import {
   gitHead as getGitHead,
+  gitCheckout,
   gitTagHead,
   gitRepo,
   gitCommits,
@@ -15,6 +16,9 @@ import {
   gitRemoteTagHead,
   gitPush,
   gitShallowClone,
+  merge,
+  mergeFf,
+  rebase,
 } from './helpers/git-utils';
 
 const requireNoCache = proxyquire.noPreserveCache();
@@ -41,13 +45,28 @@ test('Plugins are called with expected values', async t => {
   // Add commits to the master branch
   let commits = await gitCommits(['First'], {cwd});
   // Create the tag corresponding to version 1.0.0
-  await gitTagVersion('v1.0.0', undefined, {cwd});
-  // Add new commits to the master branch
+  await gitTagVersion('v1.0.0@next', undefined, {cwd});
   commits = (await gitCommits(['Second'], {cwd})).concat(commits);
+  await gitCheckout('next', true, {cwd});
+  await gitPush(repositoryUrl, 'next', {cwd});
+  await gitCheckout('master', false, {cwd});
   await gitPush(repositoryUrl, 'master', {cwd});
 
-  const lastRelease = {version: '1.0.0', gitHead: commits[commits.length - 1].hash, gitTag: 'v1.0.0'};
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
+  const lastRelease = {
+    version: '1.0.0',
+    gitHead: commits[commits.length - 1].hash,
+    gitTag: 'v1.0.0@next',
+    name: 'v1.0.0',
+    channel: 'next',
+  };
+  const nextRelease = {
+    name: 'v1.1.0',
+    type: 'minor',
+    version: '1.1.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'v1.1.0',
+    channel: undefined,
+  };
   const notes1 = 'Release notes 1';
   const notes2 = 'Release notes 2';
   const notes3 = 'Release notes 3';
@@ -59,22 +78,64 @@ test('Plugins are called with expected values', async t => {
   const generateNotes2 = stub().resolves(notes2);
   const generateNotes3 = stub().resolves(notes3);
   const release1 = {name: 'Release 1', url: 'https://release1.com'};
+  const release2 = {name: 'Release 2', url: 'https://release2.com'};
+  const addChannel = stub().resolves(release1);
   const prepare = stub().resolves();
-  const publish1 = stub().resolves(release1);
+  const publish = stub().resolves(release2);
   const success = stub().resolves();
   const env = {...process.env};
-  const config = {branch: 'master', repositoryUrl, globalOpt: 'global', tagFormat: `v\${version}`};
+  const config = {
+    branches: [{name: 'master'}, {name: 'next'}],
+    repositoryUrl,
+    globalOpt: 'global',
+    tagFormat: `v\${version}`,
+  };
+  const branches = [
+    {
+      channel: undefined,
+      name: 'master',
+      range: '>=1.0.0 <2.0.0',
+      accept: ['patch', 'minor'],
+      tags: [{channel: 'next', gitTag: 'v1.0.0@next', version: '1.0.0', gitHead: commits[commits.length - 1].hash}],
+      type: 'release',
+    },
+    {
+      channel: 'next',
+      name: 'next',
+      range: '>=2.0.0',
+      accept: ['patch', 'minor', 'major'],
+      tags: [{channel: 'next', gitHead: commits[commits.length - 1].hash, gitTag: 'v1.0.0@next', version: '1.0.0'}],
+      type: 'release',
+    },
+  ];
+  const branch = branches[0];
   const options = {
     ...config,
     plugins: false,
     verifyConditions: [verifyConditions1, verifyConditions2],
     analyzeCommits,
     verifyRelease,
+    addChannel,
     generateNotes: [generateNotes1, generateNotes2, generateNotes3],
     prepare,
-    publish: [publish1, pluginNoop],
+    publish: [publish, pluginNoop],
     success,
   };
+
+  const releases = [
+    {
+      ...lastRelease,
+      ...release1,
+      type: 'major',
+      version: '1.0.0',
+      channel: undefined,
+      gitTag: 'v1.0.0',
+      notes: `${notes1}\n\n${notes2}\n\n${notes3}`,
+      pluginName: '[Function: proxy]',
+    },
+    {...nextRelease, ...release2, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: '[Function: proxy]'},
+    {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: pluginNoop},
+  ];
 
   const semanticRelease = requireNoCache('..', {
     './lib/get-logger': () => t.context.logger,
@@ -91,16 +152,106 @@ test('Plugins are called with expected values', async t => {
   t.deepEqual(verifyConditions1.args[0][0], config);
   t.deepEqual(verifyConditions1.args[0][1].cwd, cwd);
   t.deepEqual(verifyConditions1.args[0][1].options, options);
+  t.deepEqual(verifyConditions1.args[0][1].branch, branch);
+  t.deepEqual(verifyConditions1.args[0][1].branches, branches);
   t.deepEqual(verifyConditions1.args[0][1].logger, t.context.logger);
   t.is(verifyConditions2.callCount, 1);
   t.deepEqual(verifyConditions2.args[0][0], config);
   t.deepEqual(verifyConditions2.args[0][1].cwd, cwd);
   t.deepEqual(verifyConditions2.args[0][1].options, options);
+  t.deepEqual(verifyConditions2.args[0][1].branch, branch);
+  t.deepEqual(verifyConditions2.args[0][1].branches, branches);
   t.deepEqual(verifyConditions2.args[0][1].logger, t.context.logger);
+
+  t.is(generateNotes1.callCount, 2);
+  t.is(generateNotes2.callCount, 2);
+  t.is(generateNotes3.callCount, 2);
+
+  t.deepEqual(generateNotes1.args[0][0], config);
+  t.deepEqual(generateNotes1.args[0][1].options, options);
+  t.deepEqual(generateNotes1.args[0][1].branch, branch);
+  t.deepEqual(generateNotes1.args[0][1].branches, branches);
+  t.deepEqual(generateNotes1.args[0][1].logger, t.context.logger);
+  t.deepEqual(generateNotes1.args[0][1].lastRelease, {});
+  t.deepEqual(generateNotes1.args[0][1].commits[0].hash, commits[1].hash);
+  t.deepEqual(generateNotes1.args[0][1].commits[0].message, commits[1].message);
+  t.deepEqual(generateNotes1.args[0][1].nextRelease, {
+    ...lastRelease,
+    type: 'major',
+    version: '1.0.0',
+    channel: undefined,
+    gitTag: 'v1.0.0',
+    name: 'v1.0.0',
+  });
+
+  t.deepEqual(generateNotes2.args[0][0], config);
+  t.deepEqual(generateNotes2.args[0][1].options, options);
+  t.deepEqual(generateNotes2.args[0][1].branch, branch);
+  t.deepEqual(generateNotes2.args[0][1].branches, branches);
+  t.deepEqual(generateNotes2.args[0][1].logger, t.context.logger);
+  t.deepEqual(generateNotes2.args[0][1].lastRelease, {});
+  t.deepEqual(generateNotes2.args[0][1].commits[0].hash, commits[1].hash);
+  t.deepEqual(generateNotes2.args[0][1].commits[0].message, commits[1].message);
+  t.deepEqual(generateNotes2.args[0][1].nextRelease, {
+    ...lastRelease,
+    type: 'major',
+    version: '1.0.0',
+    channel: undefined,
+    gitTag: 'v1.0.0',
+    name: 'v1.0.0',
+    notes: notes1,
+  });
+
+  t.deepEqual(generateNotes3.args[0][0], config);
+  t.deepEqual(generateNotes3.args[0][1].options, options);
+  t.deepEqual(generateNotes3.args[0][1].branch, branch);
+  t.deepEqual(generateNotes3.args[0][1].branches, branches);
+  t.deepEqual(generateNotes3.args[0][1].logger, t.context.logger);
+  t.deepEqual(generateNotes3.args[0][1].lastRelease, {});
+  t.deepEqual(generateNotes3.args[0][1].commits[0].hash, commits[1].hash);
+  t.deepEqual(generateNotes3.args[0][1].commits[0].message, commits[1].message);
+  t.deepEqual(generateNotes3.args[0][1].nextRelease, {
+    ...lastRelease,
+    type: 'major',
+    version: '1.0.0',
+    channel: undefined,
+    gitTag: 'v1.0.0',
+    name: 'v1.0.0',
+    notes: `${notes1}\n\n${notes2}`,
+  });
+
+  branch.tags.push({
+    version: '1.0.0',
+    channel: undefined,
+    gitTag: 'v1.0.0',
+    gitHead: commits[commits.length - 1].hash,
+  });
+
+  t.is(addChannel.callCount, 1);
+  t.deepEqual(addChannel.args[0][0], config);
+  t.deepEqual(addChannel.args[0][1].options, options);
+  t.deepEqual(addChannel.args[0][1].branch, branch);
+  t.deepEqual(addChannel.args[0][1].branches, branches);
+  t.deepEqual(addChannel.args[0][1].logger, t.context.logger);
+  t.deepEqual(addChannel.args[0][1].lastRelease, {});
+  t.deepEqual(addChannel.args[0][1].currentRelease, {...lastRelease, type: 'major'});
+  t.deepEqual(addChannel.args[0][1].nextRelease, {
+    ...lastRelease,
+    type: 'major',
+    version: '1.0.0',
+    channel: undefined,
+    gitTag: 'v1.0.0',
+    name: 'v1.0.0',
+    notes: `${notes1}\n\n${notes2}\n\n${notes3}`,
+  });
+  t.deepEqual(addChannel.args[0][1].commits[0].hash, commits[1].hash);
+  t.deepEqual(addChannel.args[0][1].commits[0].message, commits[1].message);
 
   t.is(analyzeCommits.callCount, 1);
   t.deepEqual(analyzeCommits.args[0][0], config);
   t.deepEqual(analyzeCommits.args[0][1].options, options);
+  t.deepEqual(analyzeCommits.args[0][1].branch, branch);
+  t.deepEqual(analyzeCommits.args[0][1].branches, branches);
   t.deepEqual(analyzeCommits.args[0][1].logger, t.context.logger);
   t.deepEqual(analyzeCommits.args[0][1].lastRelease, lastRelease);
   t.deepEqual(analyzeCommits.args[0][1].commits[0].hash, commits[0].hash);
@@ -109,78 +260,102 @@ test('Plugins are called with expected values', async t => {
   t.is(verifyRelease.callCount, 1);
   t.deepEqual(verifyRelease.args[0][0], config);
   t.deepEqual(verifyRelease.args[0][1].options, options);
+  t.deepEqual(verifyRelease.args[0][1].branch, branch);
+  t.deepEqual(verifyRelease.args[0][1].branches, branches);
   t.deepEqual(verifyRelease.args[0][1].logger, t.context.logger);
   t.deepEqual(verifyRelease.args[0][1].lastRelease, lastRelease);
   t.deepEqual(verifyRelease.args[0][1].commits[0].hash, commits[0].hash);
   t.deepEqual(verifyRelease.args[0][1].commits[0].message, commits[0].message);
   t.deepEqual(verifyRelease.args[0][1].nextRelease, nextRelease);
 
-  t.is(generateNotes1.callCount, 1);
-  t.deepEqual(generateNotes1.args[0][0], config);
-  t.deepEqual(generateNotes1.args[0][1].options, options);
-  t.deepEqual(generateNotes1.args[0][1].logger, t.context.logger);
-  t.deepEqual(generateNotes1.args[0][1].lastRelease, lastRelease);
-  t.deepEqual(generateNotes1.args[0][1].commits[0].hash, commits[0].hash);
-  t.deepEqual(generateNotes1.args[0][1].commits[0].message, commits[0].message);
-  t.deepEqual(generateNotes1.args[0][1].nextRelease, nextRelease);
+  t.deepEqual(generateNotes1.args[1][0], config);
+  t.deepEqual(generateNotes1.args[1][1].options, options);
+  t.deepEqual(generateNotes1.args[1][1].branch, branch);
+  t.deepEqual(generateNotes1.args[1][1].branches, branches);
+  t.deepEqual(generateNotes1.args[1][1].logger, t.context.logger);
+  t.deepEqual(generateNotes1.args[1][1].lastRelease, lastRelease);
+  t.deepEqual(generateNotes1.args[1][1].commits[0].hash, commits[0].hash);
+  t.deepEqual(generateNotes1.args[1][1].commits[0].message, commits[0].message);
+  t.deepEqual(generateNotes1.args[1][1].nextRelease, nextRelease);
 
-  t.is(generateNotes2.callCount, 1);
-  t.deepEqual(generateNotes2.args[0][0], config);
-  t.deepEqual(generateNotes2.args[0][1].options, options);
-  t.deepEqual(generateNotes2.args[0][1].logger, t.context.logger);
-  t.deepEqual(generateNotes2.args[0][1].lastRelease, lastRelease);
-  t.deepEqual(generateNotes2.args[0][1].commits[0].hash, commits[0].hash);
-  t.deepEqual(generateNotes2.args[0][1].commits[0].message, commits[0].message);
-  t.deepEqual(generateNotes2.args[0][1].nextRelease, {...nextRelease, notes: notes1});
+  t.deepEqual(generateNotes2.args[1][0], config);
+  t.deepEqual(generateNotes2.args[1][1].options, options);
+  t.deepEqual(generateNotes2.args[1][1].branch, branch);
+  t.deepEqual(generateNotes2.args[1][1].branches, branches);
+  t.deepEqual(generateNotes2.args[1][1].logger, t.context.logger);
+  t.deepEqual(generateNotes2.args[1][1].lastRelease, lastRelease);
+  t.deepEqual(generateNotes2.args[1][1].commits[0].hash, commits[0].hash);
+  t.deepEqual(generateNotes2.args[1][1].commits[0].message, commits[0].message);
+  t.deepEqual(generateNotes2.args[1][1].nextRelease, {...nextRelease, notes: notes1});
 
-  t.is(generateNotes3.callCount, 1);
-  t.deepEqual(generateNotes3.args[0][0], config);
-  t.deepEqual(generateNotes3.args[0][1].options, options);
-  t.deepEqual(generateNotes3.args[0][1].logger, t.context.logger);
-  t.deepEqual(generateNotes3.args[0][1].lastRelease, lastRelease);
-  t.deepEqual(generateNotes3.args[0][1].commits[0].hash, commits[0].hash);
-  t.deepEqual(generateNotes3.args[0][1].commits[0].message, commits[0].message);
-  t.deepEqual(generateNotes3.args[0][1].nextRelease, {...nextRelease, notes: `${notes1}\n\n${notes2}`});
+  t.deepEqual(generateNotes3.args[1][0], config);
+  t.deepEqual(generateNotes3.args[1][1].options, options);
+  t.deepEqual(generateNotes3.args[1][1].branch, branch);
+  t.deepEqual(generateNotes3.args[1][1].branches, branches);
+  t.deepEqual(generateNotes3.args[1][1].logger, t.context.logger);
+  t.deepEqual(generateNotes3.args[1][1].lastRelease, lastRelease);
+  t.deepEqual(generateNotes3.args[1][1].commits[0].hash, commits[0].hash);
+  t.deepEqual(generateNotes3.args[1][1].commits[0].message, commits[0].message);
+  t.deepEqual(generateNotes3.args[1][1].nextRelease, {...nextRelease, notes: `${notes1}\n\n${notes2}`});
 
   t.is(prepare.callCount, 1);
   t.deepEqual(prepare.args[0][0], config);
   t.deepEqual(prepare.args[0][1].options, options);
+  t.deepEqual(prepare.args[0][1].branch, branch);
+  t.deepEqual(prepare.args[0][1].branches, branches);
   t.deepEqual(prepare.args[0][1].logger, t.context.logger);
   t.deepEqual(prepare.args[0][1].lastRelease, lastRelease);
   t.deepEqual(prepare.args[0][1].commits[0].hash, commits[0].hash);
   t.deepEqual(prepare.args[0][1].commits[0].message, commits[0].message);
   t.deepEqual(prepare.args[0][1].nextRelease, {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`});
 
-  t.is(publish1.callCount, 1);
-  t.deepEqual(publish1.args[0][0], config);
-  t.deepEqual(publish1.args[0][1].options, options);
-  t.deepEqual(publish1.args[0][1].logger, t.context.logger);
-  t.deepEqual(publish1.args[0][1].lastRelease, lastRelease);
-  t.deepEqual(publish1.args[0][1].commits[0].hash, commits[0].hash);
-  t.deepEqual(publish1.args[0][1].commits[0].message, commits[0].message);
-  t.deepEqual(publish1.args[0][1].nextRelease, {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`});
+  t.is(publish.callCount, 1);
+  t.deepEqual(publish.args[0][0], config);
+  t.deepEqual(publish.args[0][1].options, options);
+  t.deepEqual(publish.args[0][1].branch, branch);
+  t.deepEqual(publish.args[0][1].branches, branches);
+  t.deepEqual(publish.args[0][1].logger, t.context.logger);
+  t.deepEqual(publish.args[0][1].lastRelease, lastRelease);
+  t.deepEqual(publish.args[0][1].commits[0].hash, commits[0].hash);
+  t.deepEqual(publish.args[0][1].commits[0].message, commits[0].message);
+  t.deepEqual(publish.args[0][1].nextRelease, {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`});
 
-  t.is(success.callCount, 1);
+  t.is(success.callCount, 2);
   t.deepEqual(success.args[0][0], config);
   t.deepEqual(success.args[0][1].options, options);
+  t.deepEqual(success.args[0][1].branch, branch);
+  t.deepEqual(success.args[0][1].branches, branches);
   t.deepEqual(success.args[0][1].logger, t.context.logger);
-  t.deepEqual(success.args[0][1].lastRelease, lastRelease);
-  t.deepEqual(success.args[0][1].commits[0].hash, commits[0].hash);
-  t.deepEqual(success.args[0][1].commits[0].message, commits[0].message);
-  t.deepEqual(success.args[0][1].nextRelease, {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`});
-  t.deepEqual(success.args[0][1].releases, [
-    {...release1, ...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: '[Function: proxy]'},
-    {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: pluginNoop},
-  ]);
+  t.deepEqual(success.args[0][1].lastRelease, {});
+  t.deepEqual(success.args[0][1].commits[0].hash, commits[1].hash);
+  t.deepEqual(success.args[0][1].commits[0].message, commits[1].message);
+  t.deepEqual(success.args[0][1].nextRelease, {
+    ...lastRelease,
+    type: 'major',
+    version: '1.0.0',
+    channel: undefined,
+    gitTag: 'v1.0.0',
+    name: 'v1.0.0',
+    notes: `${notes1}\n\n${notes2}\n\n${notes3}`,
+  });
+  t.deepEqual(success.args[0][1].releases, [releases[0]]);
+
+  t.deepEqual(success.args[1][0], config);
+  t.deepEqual(success.args[1][1].options, options);
+  t.deepEqual(success.args[0][1].branch, branch);
+  t.deepEqual(success.args[0][1].branches, branches);
+  t.deepEqual(success.args[1][1].logger, t.context.logger);
+  t.deepEqual(success.args[1][1].lastRelease, lastRelease);
+  t.deepEqual(success.args[1][1].commits[0].hash, commits[0].hash);
+  t.deepEqual(success.args[1][1].commits[0].message, commits[0].message);
+  t.deepEqual(success.args[1][1].nextRelease, {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`});
+  t.deepEqual(success.args[1][1].releases, releases);
 
   t.deepEqual(result, {
     lastRelease,
-    commits: [commits[0]],
+    commits: [{...commits[0], gitTags: '(HEAD -> master, origin/master, origin/HEAD, next)'}],
     nextRelease: {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`},
-    releases: [
-      {...release1, ...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: '[Function: proxy]'},
-      {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: pluginNoop},
-    ],
+    releases,
   });
 
   // Verify the tag has been created on the local and remote repo and reference the gitHead
@@ -201,15 +376,22 @@ test('Use custom tag format', async t => {
   await gitCommits(['Second'], {cwd});
   await gitPush(repositoryUrl, 'master', {cwd});
 
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'test-2.0.0'};
+  const nextRelease = {
+    name: 'test-2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'test-2.0.0',
+  };
   const notes = 'Release notes';
-  const config = {branch: 'master', repositoryUrl, globalOpt: 'global', tagFormat: `test-\${version}`};
+  const config = {branches: 'master', repositoryUrl, globalOpt: 'global', tagFormat: `test-\${version}`};
   const options = {
     ...config,
     verifyConditions: stub().resolves(),
     analyzeCommits: stub().resolves(nextRelease.type),
     verifyRelease: stub().resolves(),
     generateNotes: stub().resolves(notes),
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish: stub().resolves(),
     success: stub().resolves(),
@@ -245,7 +427,14 @@ test('Use new gitHead, and recreate release notes if a prepare plugin create a c
   commits = (await gitCommits(['Second'], {cwd})).concat(commits);
   await gitPush(repositoryUrl, 'master', {cwd});
 
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
+  const nextRelease = {
+    name: 'v2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'v2.0.0',
+    channel: undefined,
+  };
   const notes = 'Release notes';
 
   const generateNotes = stub().resolves(notes);
@@ -255,12 +444,13 @@ test('Use new gitHead, and recreate release notes if a prepare plugin create a c
   const prepare2 = stub().resolves();
   const publish = stub().resolves();
   const options = {
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: stub().resolves(),
     analyzeCommits: stub().resolves(nextRelease.type),
     verifyRelease: stub().resolves(),
     generateNotes,
+    addChannel: stub().resolves(),
     prepare: [prepare1, prepare2],
     publish,
     success: stub().resolves(),
@@ -300,6 +490,229 @@ test('Use new gitHead, and recreate release notes if a prepare plugin create a c
   t.is(await gitRemoteTagHead(repositoryUrl, nextRelease.gitTag, {cwd}), commits[0].hash);
 });
 
+test('Make a new release when a commit is forward-ported to an upper branch', async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const commits = await gitCommits(['feat: initial release'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitTagVersion('v1.0.0@1.0.x', undefined, {cwd});
+  await gitCheckout('1.0.x', true, {cwd});
+  commits.push(...(await gitCommits(['fix: fix on maintenance version 1.0.x'], {cwd})));
+  await gitTagVersion('v1.0.1@1.0.x', undefined, {cwd});
+  await gitPush('origin', '1.0.x', {cwd});
+  await gitCheckout('master', false, {cwd});
+  commits.push(...(await gitCommits(['feat: new feature on master'], {cwd})));
+  await gitTagVersion('v1.1.0', undefined, {cwd});
+  await merge('1.0.x', {cwd});
+  await gitPush('origin', 'master', {cwd});
+
+  const verifyConditions = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const addChannel = stub().resolves();
+  const prepare = stub().resolves();
+  const publish = stub().resolves();
+  const success = stub().resolves();
+
+  const config = {branches: [{name: '1.0.x'}, {name: 'master'}], repositoryUrl, tagFormat: `v\${version}`};
+  const options = {
+    ...config,
+    verifyConditions,
+    verifyRelease,
+    addChannel,
+    prepare,
+    publish,
+    success,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  t.truthy(await semanticRelease(options, {cwd, env: {}, stdout: {write: () => {}}, stderr: {write: () => {}}}));
+
+  t.is(addChannel.callCount, 0);
+  t.is(publish.callCount, 1);
+  // The release 1.1.1, triggered by the forward-port of "fix: fix on maintenance version 1.0.x" has been published from master
+  t.is(publish.args[0][1].nextRelease.version, '1.1.1');
+  t.is(success.callCount, 1);
+});
+
+test('Publish a pre-release version', async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  await gitCommits(['feat: initial commit'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitPush(repositoryUrl, 'master', {cwd});
+  await gitCheckout('beta', true, {cwd});
+  await gitCommits(['feat: a feature'], {cwd});
+  await gitPush(repositoryUrl, 'beta', {cwd});
+
+  const config = {branches: ['master', {name: 'beta', prerelease: true}], repositoryUrl};
+  const options = {
+    ...config,
+    verifyConditions: stub().resolves(),
+    verifyRelease: stub().resolves(),
+    generateNotes: stub().resolves(''),
+    addChannel: false,
+    prepare: stub().resolves(),
+    publish: stub().resolves(),
+    success: stub().resolves(),
+    fail: stub().resolves(),
+  };
+
+  const semanticRelease = requireNoCache('..', {
+    './lib/get-logger': () => t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'beta', isPr: false}),
+  });
+  let {releases} = await semanticRelease(options, {cwd, stdout: {write: () => {}}, stderr: {write: () => {}}});
+
+  t.is(releases.length, 1);
+  t.is(releases[0].version, '1.1.0-beta.1');
+  t.is(releases[0].gitTag, 'v1.1.0-beta.1@beta');
+
+  await gitCommits(['fix: a fix'], {cwd});
+  ({releases} = await semanticRelease(options, {
+    cwd,
+    stdout: {write: () => {}},
+    stderr: {write: () => {}},
+  }));
+
+  t.is(releases.length, 1);
+  t.is(releases[0].version, '1.1.0-beta.2');
+  t.is(releases[0].gitTag, 'v1.1.0-beta.2@beta');
+});
+
+test('Do not add pre-releases to a different channel', async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const commits = await gitCommits(['feat: initial release'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitTagVersion('v1.0.0@beta', undefined, {cwd});
+  await gitCheckout('beta', true, {cwd});
+  commits.push(...(await gitCommits(['feat: breaking change/n/nBREAKING CHANGE: break something'], {cwd})));
+  await gitTagVersion('v2.0.0-beta.1@beta', undefined, {cwd});
+  commits.push(...(await gitCommits(['fix: a fix'], {cwd})));
+  await gitTagVersion('v2.0.0-beta.2@beta', undefined, {cwd});
+  await gitPush('origin', 'beta', {cwd});
+  await gitCheckout('master', false, {cwd});
+  await merge('beta', {cwd});
+  await gitPush('origin', 'master', {cwd});
+
+  const verifyConditions = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const generateNotes = stub().resolves('Release notes');
+  const release1 = {name: 'Release 1', url: 'https://release1.com'};
+  const addChannel = stub().resolves(release1);
+  const prepare = stub().resolves();
+  const publish = stub().resolves();
+  const success = stub().resolves();
+
+  const config = {
+    branches: [{name: 'master'}, {name: 'beta', prerelease: 'beta'}],
+    repositoryUrl,
+    tagFormat: `v\${version}`,
+  };
+
+  const options = {
+    ...config,
+    verifyConditions,
+    verifyRelease,
+    addChannel,
+    generateNotes,
+    prepare,
+    publish,
+    success,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  t.truthy(await semanticRelease(options, {cwd, env: {}, stdout: {write: () => {}}, stderr: {write: () => {}}}));
+
+  t.is(addChannel.callCount, 0);
+});
+
+async function addChannelMacro(t, mergeFunction) {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const commits = await gitCommits(['feat: initial release'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitTagVersion('v1.0.0@next', undefined, {cwd});
+  await gitCheckout('next', true, {cwd});
+  commits.push(...(await gitCommits(['feat: breaking change/n/nBREAKING CHANGE: break something'], {cwd})));
+  await gitTagVersion('v2.0.0@next', undefined, {cwd});
+  commits.push(...(await gitCommits(['fix: a fix'], {cwd})));
+  await gitTagVersion('v2.0.1@next', undefined, {cwd});
+  commits.push(...(await gitCommits(['feat: a feature'], {cwd})));
+  await gitTagVersion('v2.1.0@next', undefined, {cwd});
+  await gitPush('origin', 'next', {cwd});
+  await gitCheckout('master', false, {cwd});
+  // Merge all commits but last one from next to master
+  await mergeFunction('next~1', {cwd});
+  await gitPush('origin', 'master', {cwd});
+
+  const notes = 'Release notes';
+  const verifyConditions = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const generateNotes = stub().resolves(notes);
+  const release1 = {name: 'Release 1', url: 'https://release1.com'};
+  const addChannel1 = stub().resolves(release1);
+  const addChannel2 = stub().resolves();
+  const prepare = stub().resolves();
+  const publish = stub().resolves();
+  const success = stub().resolves();
+
+  const config = {branches: [{name: 'master'}, {name: 'next'}], repositoryUrl, tagFormat: `v\${version}`};
+  const options = {
+    ...config,
+    verifyConditions,
+    verifyRelease,
+    addChannel: [addChannel1, addChannel2],
+    generateNotes,
+    prepare,
+    publish,
+    success,
+  };
+  const nextRelease1 = {
+    name: 'v2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    channel: undefined,
+    gitTag: 'v2.0.0',
+    gitHead: commits[1].hash,
+  };
+  const nextRelease2 = {
+    name: 'v2.0.1',
+    type: 'patch',
+    version: '2.0.1',
+    channel: undefined,
+    gitTag: 'v2.0.1',
+    gitHead: commits[2].hash,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+  const result = await semanticRelease(options, {cwd, env: {}, stdout: {write: () => {}}, stderr: {write: () => {}}});
+
+  t.deepEqual(result.releases, [
+    {...nextRelease1, ...release1, notes, pluginName: '[Function: proxy]'},
+    {...nextRelease1, notes, pluginName: '[Function: proxy]'},
+    {...nextRelease2, ...release1, notes, pluginName: '[Function: proxy]'},
+    {...nextRelease2, notes, pluginName: '[Function: proxy]'},
+  ]);
+
+  // Verify the tag has been created on the local and remote repo and reference
+  t.is(await gitTagHead(nextRelease1.gitTag, {cwd}), nextRelease1.gitHead);
+  t.is(await gitRemoteTagHead(repositoryUrl, nextRelease1.gitTag, {cwd}), nextRelease1.gitHead);
+  t.is(await gitTagHead(nextRelease2.gitTag, {cwd}), nextRelease2.gitHead);
+  t.is(await gitRemoteTagHead(repositoryUrl, nextRelease2.gitTag, {cwd}), nextRelease2.gitHead);
+}
+
+addChannelMacro.title = providedTitle => `Add version to a channel after a merge (${providedTitle})`;
+
+test('fast-forward', addChannelMacro, mergeFf);
+test('non fast-forward', addChannelMacro, merge);
+test('rebase', addChannelMacro, rebase);
+
 test('Call all "success" plugins even if one errors out', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd, repositoryUrl} = await gitRepo(true);
@@ -311,7 +724,14 @@ test('Call all "success" plugins even if one errors out', async t => {
   await gitCommits(['Second'], {cwd});
   await gitPush(repositoryUrl, 'master', {cwd});
 
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
+  const nextRelease = {
+    name: 'v2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'v2.0.0',
+    channel: undefined,
+  };
   const notes = 'Release notes';
   const verifyConditions1 = stub().resolves();
   const verifyConditions2 = stub().resolves();
@@ -321,12 +741,18 @@ test('Call all "success" plugins even if one errors out', async t => {
   const publish = stub().resolves(release);
   const success1 = stub().rejects();
   const success2 = stub().resolves();
-  const config = {branch: 'master', repositoryUrl, globalOpt: 'global', tagFormat: `v\${version}`};
+  const config = {
+    branches: [{name: 'master'}],
+    repositoryUrl,
+    globalOpt: 'global',
+    tagFormat: `v\${version}`,
+  };
   const options = {
     ...config,
     verifyConditions: [verifyConditions1, verifyConditions2],
     analyzeCommits,
     generateNotes,
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish,
     success: [success1, success2],
@@ -342,10 +768,11 @@ test('Call all "success" plugins even if one errors out', async t => {
   );
 
   t.is(success1.callCount, 1);
-  t.deepEqual(success1.args[0][1].releases, [{...release, ...nextRelease, notes, pluginName: '[Function: proxy]'}]);
+  t.deepEqual(success1.args[0][0], config);
+  t.deepEqual(success1.args[0][1].releases, [{...nextRelease, ...release, notes, pluginName: '[Function: proxy]'}]);
 
   t.is(success2.callCount, 1);
-  t.deepEqual(success2.args[0][1].releases, [{...release, ...nextRelease, notes, pluginName: '[Function: proxy]'}]);
+  t.deepEqual(success2.args[0][1].releases, [{...nextRelease, ...release, notes, pluginName: '[Function: proxy]'}]);
 });
 
 test('Log all "verifyConditions" errors', async t => {
@@ -359,7 +786,7 @@ test('Log all "verifyConditions" errors', async t => {
   const error2 = new SemanticReleaseError('error 2', 'ERR2');
   const error3 = new SemanticReleaseError('error 3', 'ERR3');
   const fail = stub().resolves();
-  const config = {branch: 'master', repositoryUrl, tagFormat: `v\${version}`};
+  const config = {branches: [{name: 'master'}], repositoryUrl, tagFormat: `v\${version}`};
   const options = {
     ...config,
     plugins: false,
@@ -403,7 +830,7 @@ test('Log all "verifyRelease" errors', async t => {
   const error1 = new SemanticReleaseError('error 1', 'ERR1');
   const error2 = new SemanticReleaseError('error 2', 'ERR2');
   const fail = stub().resolves();
-  const config = {branch: 'master', repositoryUrl, tagFormat: `v\${version}`};
+  const config = {branches: [{name: 'master'}], repositoryUrl, tagFormat: `v\${version}`};
   const options = {
     ...config,
     verifyConditions: stub().resolves(),
@@ -430,36 +857,35 @@ test('Log all "verifyRelease" errors', async t => {
   t.deepEqual(fail.args[0][1].errors, [error1, error2]);
 });
 
-test('Dry-run skips prepare, publish and success', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
+test('Dry-run skips addChannel, prepare, publish and success', async t => {
   const {cwd, repositoryUrl} = await gitRepo(true);
-  // Add commits to the master branch
   await gitCommits(['First'], {cwd});
-  // Create the tag corresponding to version 1.0.0
   await gitTagVersion('v1.0.0', undefined, {cwd});
-  // Add new commits to the master branch
+  await gitTagVersion('v1.0.0@next', undefined, {cwd});
+  await gitTagVersion('v1.1.0@next', undefined, {cwd});
   await gitCommits(['Second'], {cwd});
   await gitPush(repositoryUrl, 'master', {cwd});
-
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
-  const notes = 'Release notes';
+  await gitCheckout('next', true, {cwd});
+  await gitPush('origin', 'next', {cwd});
 
   const verifyConditions = stub().resolves();
-  const analyzeCommits = stub().resolves(nextRelease.type);
+  const analyzeCommits = stub().resolves('minor');
   const verifyRelease = stub().resolves();
-  const generateNotes = stub().resolves(notes);
+  const generateNotes = stub().resolves();
+  const addChannel = stub().resolves();
   const prepare = stub().resolves();
   const publish = stub().resolves();
   const success = stub().resolves();
 
   const options = {
     dryRun: true,
-    branch: 'master',
+    branches: ['master', 'next'],
     repositoryUrl,
     verifyConditions,
     analyzeCommits,
     verifyRelease,
     generateNotes,
+    addChannel,
     prepare,
     publish,
     success,
@@ -482,7 +908,11 @@ test('Dry-run skips prepare, publish and success', async t => {
   t.is(verifyConditions.callCount, 1);
   t.is(analyzeCommits.callCount, 1);
   t.is(verifyRelease.callCount, 1);
-  t.is(generateNotes.callCount, 1);
+  t.is(generateNotes.callCount, 2);
+  t.is(addChannel.callCount, 0);
+  t.true(
+    t.context.warn.calledWith(`Skip step "addChannel" of plugin "[Function: ${addChannel.name}]" in dry-run mode`)
+  );
   t.is(prepare.callCount, 0);
   t.true(t.context.warn.calledWith(`Skip step "prepare" of plugin "[Function: ${prepare.name}]" in dry-run mode`));
   t.is(publish.callCount, 0);
@@ -508,7 +938,7 @@ test('Dry-run skips fail', async t => {
 
   const options = {
     dryRun: true,
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: [stub().rejects(error1), stub().rejects(error2)],
     fail,
@@ -542,7 +972,14 @@ test('Force a dry-run if not on a CI and "noCi" is not explicitly set', async t 
   await gitCommits(['Second'], {cwd});
   await gitPush(repositoryUrl, 'master', {cwd});
 
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
+  const nextRelease = {
+    name: 'v2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'v2.0.0',
+    channel: undefined,
+  };
   const notes = 'Release notes';
 
   const verifyConditions = stub().resolves();
@@ -554,12 +991,13 @@ test('Force a dry-run if not on a CI and "noCi" is not explicitly set', async t 
 
   const options = {
     dryRun: false,
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions,
     analyzeCommits,
     verifyRelease,
     generateNotes,
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish,
     success,
@@ -605,7 +1043,7 @@ test('Dry-run does not print changelog if "generateNotes" return "undefined"', a
 
   const options = {
     dryRun: true,
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: false,
     analyzeCommits,
@@ -643,7 +1081,14 @@ test('Allow local releases with "noCi" option', async t => {
   await gitCommits(['Second'], {cwd});
   await gitPush(repositoryUrl, 'master', {cwd});
 
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
+  const nextRelease = {
+    name: 'v2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'v2.0.0',
+    channel: undefined,
+  };
   const notes = 'Release notes';
 
   const verifyConditions = stub().resolves();
@@ -655,12 +1100,13 @@ test('Allow local releases with "noCi" option', async t => {
 
   const options = {
     noCi: true,
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions,
     analyzeCommits,
     verifyRelease,
     generateNotes,
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish,
     success,
@@ -704,8 +1150,21 @@ test('Accept "undefined" value returned by the "generateNotes" plugins', async t
   commits = (await gitCommits(['Second'], {cwd})).concat(commits);
   await gitPush(repositoryUrl, 'master', {cwd});
 
-  const lastRelease = {version: '1.0.0', gitHead: commits[commits.length - 1].hash, gitTag: 'v1.0.0'};
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
+  const lastRelease = {
+    name: 'v1.0.0',
+    version: '1.0.0',
+    gitHead: commits[commits.length - 1].hash,
+    gitTag: 'v1.0.0',
+    channel: undefined,
+  };
+  const nextRelease = {
+    name: 'v2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'v2.0.0',
+    channel: undefined,
+  };
   const analyzeCommits = stub().resolves(nextRelease.type);
   const verifyRelease = stub().resolves();
   const generateNotes1 = stub().resolves();
@@ -714,12 +1173,13 @@ test('Accept "undefined" value returned by the "generateNotes" plugins', async t
   const publish = stub().resolves();
 
   const options = {
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: stub().resolves(),
     analyzeCommits,
     verifyRelease,
     generateNotes: [generateNotes1, generateNotes2],
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish,
     success: stub().resolves(),
@@ -777,7 +1237,188 @@ test('Returns false if triggered by a PR', async t => {
   );
 });
 
-test('Returns false if triggered on an outdated clone', async t => {
+test('Throws "EINVALIDNEXTVERSION" if next release is out of range of the current maintenance branch', async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const commits = await gitCommits(['feat: initial commit'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitTagVersion('v1.0.0@1.x', undefined, {cwd});
+  await gitCheckout('1.x', true, {cwd});
+  await gitPush('origin', '1.x', {cwd});
+  await gitCheckout('master', false, {cwd});
+  commits.push(...(await gitCommits(['feat: new feature on master'], {cwd})));
+  await gitTagVersion('v1.1.0', undefined, {cwd});
+  await gitCheckout('1.x', false, {cwd});
+  commits.push(...(await gitCommits(['feat: feature on maintenance version 1.x'], {cwd})));
+  await gitPush('origin', 'master', {cwd});
+
+  const verifyConditions = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const addChannel = stub().resolves();
+  const prepare = stub().resolves();
+  const publish = stub().resolves();
+  const success = stub().resolves();
+
+  const config = {
+    branches: [{name: '1.x'}, {name: 'master'}],
+    repositoryUrl,
+    tagFormat: `v\${version}`,
+  };
+  const options = {
+    ...config,
+    verifyConditions,
+    verifyRelease,
+    addChannel,
+    prepare,
+    publish,
+    success,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: '1.x', isPr: false}),
+  });
+
+  const error = await t.throws(
+    semanticRelease(options, {cwd, env: {}, stdout: {write: () => {}}, stderr: {write: () => {}}})
+  );
+
+  t.is(error.code, 'EINVALIDNEXTVERSION');
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.message, 'The release `1.1.0` on branch `1.x` cannot be published as it is out of range.');
+  t.regex(error.details, /A valid branch could be `master`./);
+});
+
+test('Throws "EINVALIDNEXTVERSION" if next release is out of range of the current release branch', async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const commits = await gitCommits(['feat: initial commit'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitCheckout('next', true, {cwd});
+  commits.push(...(await gitCommits(['feat: new feature on next'], {cwd})));
+  await gitTagVersion('v1.1.0@next', undefined, {cwd});
+  await gitPush('origin', 'next', {cwd});
+  await gitCheckout('next-major', true, {cwd});
+  await gitPush('origin', 'next-major', {cwd});
+  await gitCheckout('master', false, {cwd});
+  commits.push(...(await gitCommits(['feat: new feature on master', 'fix: new fix on master'], {cwd})));
+  await gitPush('origin', 'master', {cwd});
+
+  const verifyConditions = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const addChannel = stub().resolves();
+  const prepare = stub().resolves();
+  const publish = stub().resolves();
+  const success = stub().resolves();
+
+  const config = {
+    branches: [{name: 'master'}, {name: 'next'}, {name: 'next-major'}],
+    repositoryUrl,
+    tagFormat: `v\${version}`,
+  };
+  const options = {
+    ...config,
+    verifyConditions,
+    verifyRelease,
+    addChannel,
+    prepare,
+    publish,
+    success,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+
+  const error = await t.throws(
+    semanticRelease(options, {cwd, env: {}, stdout: {write: () => {}}, stderr: {write: () => {}}})
+  );
+
+  t.is(error.code, 'EINVALIDNEXTVERSION');
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.message, 'The release `1.1.0` on branch `master` cannot be published as it is out of range.');
+  t.regex(error.details, /A valid branch could be `next` or `next-major`./);
+});
+
+test('Throws "EINVALIDMAINTENANCEMERGE" if merge an out of range release in a maintenance branch', async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const commits = await gitCommits(['First'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await gitTagVersion('v1.0.0@1.1.x', undefined, {cwd});
+  commits.push(...(await gitCommits(['Second'], {cwd})));
+  await gitTagVersion('v1.1.0', undefined, {cwd});
+  await gitTagVersion('v1.1.0@1.1.x', undefined, {cwd});
+  await gitCheckout('1.1.x', 'master', {cwd});
+  await gitPush('origin', '1.1.x', {cwd});
+  await gitCheckout('master', false, {cwd});
+  commits.push(...(await gitCommits(['Third'], {cwd})));
+  await gitTagVersion('v1.1.1', undefined, {cwd});
+  commits.push(...(await gitCommits(['Fourth'], {cwd})));
+  await gitTagVersion('v1.2.0', undefined, {cwd});
+  await gitPush('origin', 'master', {cwd});
+  await gitCheckout('1.1.x', false, {cwd});
+  await merge('master', {cwd});
+  await gitPush('origin', '1.1.x', {cwd});
+
+  const notes = 'Release notes';
+  const verifyConditions = stub().resolves();
+  const analyzeCommits = stub().resolves();
+  const verifyRelease = stub().resolves();
+  const generateNotes = stub().resolves(notes);
+  const addChannel = stub().resolves();
+  const prepare = stub().resolves();
+  const publish = stub().resolves();
+  const success = stub().resolves();
+  const fail = stub().resolves();
+
+  const config = {branches: [{name: 'master'}, {name: '1.1.x'}], repositoryUrl, tagFormat: `v\${version}`};
+  const options = {
+    ...config,
+    verifyConditions,
+    analyzeCommits,
+    verifyRelease,
+    addChannel,
+    generateNotes,
+    prepare,
+    publish,
+    success,
+    fail,
+  };
+
+  const nextRelease = {
+    type: 'patch',
+    version: '1.1.1',
+    channel: '1.1.x',
+    gitTag: 'v1.1.1@1.1.x',
+    name: 'v1.1.1',
+    gitHead: commits[2].hash,
+  };
+
+  const semanticRelease = proxyquire('..', {
+    './lib/logger': t.context.logger,
+    'env-ci': () => ({isCi: true, branch: '1.1.x', isPr: false}),
+  });
+  const errors = [
+    ...(await t.throws(semanticRelease(options, {cwd, env: {}, stdout: {write: () => {}}, stderr: {write: () => {}}}))),
+  ];
+
+  t.is(addChannel.callCount, 1);
+  t.deepEqual(addChannel.args[0][1].nextRelease, {...nextRelease, notes});
+
+  t.is(publish.callCount, 0);
+
+  t.is(success.callCount, 1);
+  t.deepEqual(success.args[0][1].releases, [{...nextRelease, notes, pluginName: '[Function: proxy]'}]);
+
+  t.is(fail.callCount, 1);
+  t.deepEqual(fail.args[0][1].errors, errors);
+
+  t.is(errors[0].code, 'EINVALIDMAINTENANCEMERGE');
+  t.is(errors[0].name, 'SemanticReleaseError');
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+});
+
+test('Returns false value if triggered on an outdated clone', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   let {cwd, repositoryUrl} = await gitRepo(true);
   const repoDir = cwd;
@@ -809,12 +1450,13 @@ test('Returns false if not running from the configured branch', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd, repositoryUrl} = await gitRepo(true);
   const options = {
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: stub().resolves(),
     analyzeCommits: stub().resolves(),
     verifyRelease: stub().resolves(),
     generateNotes: stub().resolves(),
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish: stub().resolves(),
     success: stub().resolves(),
@@ -853,12 +1495,13 @@ test('Returns false if there is no relevant changes', async t => {
   const publish = stub().resolves();
 
   const options = {
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: [stub().resolves()],
     analyzeCommits,
     verifyRelease,
     generateNotes,
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish,
     success: stub().resolves(),
@@ -907,13 +1550,14 @@ test('Exclude commits with [skip release] or [release skip] from analysis', asyn
   );
   await gitPush(repositoryUrl, 'master', {cwd});
   const analyzeCommits = stub().resolves();
-  const config = {branch: 'master', repositoryUrl, globalOpt: 'global'};
+  const config = {branches: ['master'], repositoryUrl, globalOpt: 'global'};
   const options = {
     ...config,
     verifyConditions: [stub().resolves(), stub().resolves()],
     analyzeCommits,
     verifyRelease: stub().resolves(),
     generateNotes: stub().resolves(),
+    addChannel: stub().resolves(),
     prepare: stub().resolves(),
     publish: stub().resolves(),
     success: stub().resolves(),
@@ -943,7 +1587,7 @@ test('Log both plugins errors and errors thrown by "fail" plugin', async t => {
   const failError2 = new Error('Fail error 2');
 
   const options = {
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: stub().rejects(pluginError),
     fail: [stub().rejects(failError1), stub().rejects(failError2)],
@@ -968,7 +1612,7 @@ test('Call "fail" only if a plugin returns a SemanticReleaseError', async t => {
   const fail = stub().resolves();
 
   const options = {
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: stub().rejects(pluginError),
     fail,
@@ -1003,6 +1647,8 @@ test('Throw SemanticReleaseError if repositoryUrl is not set and cannot be found
   // Verify error code and type
   t.is(errors[0].code, 'ENOREPOURL');
   t.is(errors[0].name, 'SemanticReleaseError');
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
 });
 
 test('Throw an Error if plugin returns an unexpected value', async t => {
@@ -1020,7 +1666,7 @@ test('Throw an Error if plugin returns an unexpected value', async t => {
   const analyzeCommits = stub().resolves('string');
 
   const options = {
-    branch: 'master',
+    branches: ['master'],
     repositoryUrl,
     verifyConditions: [verifyConditions],
     analyzeCommits,
@@ -1099,6 +1745,7 @@ test('Hide sensitive information passed to "success" plugin', async t => {
       name: `Name: Exposing token ${env.MY_TOKEN}`,
       url: `URL: Exposing token ${env.MY_TOKEN}`,
     }),
+    addChannel: false,
     success,
     fail: stub().resolves(),
   };
@@ -1129,11 +1776,18 @@ test('Get all commits including the ones not in the shallow clone', async t => {
 
   cwd = await gitShallowClone(repositoryUrl);
 
-  const nextRelease = {type: 'major', version: '2.0.0', gitHead: await getGitHead({cwd}), gitTag: 'v2.0.0'};
+  const nextRelease = {
+    name: 'v2.0.0',
+    type: 'major',
+    version: '2.0.0',
+    gitHead: await getGitHead({cwd}),
+    gitTag: 'v2.0.0',
+    channel: undefined,
+  };
   const notes = 'Release notes';
   const analyzeCommits = stub().resolves(nextRelease.type);
 
-  const config = {branch: 'master', repositoryUrl, globalOpt: 'global'};
+  const config = {branches: ['master'], repositoryUrl, globalOpt: 'global'};
   const options = {
     ...config,
     verifyConditions: stub().resolves(),

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -5,8 +5,19 @@ import {escapeRegExp} from 'lodash';
 import {writeJson, readJson} from 'fs-extra';
 import execa from 'execa';
 import {WritableStreamBuffer} from 'stream-buffers';
+import delay from 'delay';
 import {SECRET_REPLACEMENT} from '../lib/definitions/constants';
-import {gitHead, gitTagHead, gitRepo, gitCommits, gitRemoteTagHead, gitPush} from './helpers/git-utils';
+import {
+  gitHead,
+  gitTagHead,
+  gitRepo,
+  gitCommits,
+  gitRemoteTagHead,
+  gitPush,
+  gitCheckout,
+  merge,
+} from './helpers/git-utils';
+import {npmView} from './helpers/npm-utils';
 import gitbox from './helpers/gitbox';
 import mockServer from './helpers/mockserver';
 import npmRegistry from './helpers/npm-registry';
@@ -58,7 +69,7 @@ test('Release patch, minor and major versions', async t => {
     version: '0.0.0-dev',
     repository: {url: repositoryUrl},
     publishConfig: {registry: npmRegistry.url},
-    release: {success: false, fail: false},
+    release: {branches: ['master', 'next'], success: false, fail: false},
   });
   // Create a npm-shrinkwrap.json file
   await execa('npm', ['shrinkwrap'], {env: testEnv, cwd});
@@ -86,7 +97,7 @@ test('Release patch, minor and major versions', async t => {
   let createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
     {
-      body: {tag_name: `v${version}`, target_commitish: 'master', name: `v${version}`},
+      body: {tag_name: `v${version}`, name: `v${version}`},
       headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}],
     },
     {body: {html_url: `release-url/${version}`}}
@@ -105,15 +116,14 @@ test('Release patch, minor and major versions', async t => {
   t.is((await readJson(path.resolve(cwd, 'npm-shrinkwrap.json'))).version, version);
 
   // Retrieve the published package from the registry and check version and gitHead
-  let [, releasedVersion, releasedGitHead] = /^version = '(.+)'\s+gitHead = '(.+)'$/.exec(
-    (await execa('npm', ['show', packageName, 'version', 'gitHead'], {env: testEnv, cwd})).stdout
-  );
+  let {
+    'dist-tags': {latest: releasedVersion},
+  } = await npmView(packageName, testEnv);
   let head = await gitHead({cwd});
   t.is(releasedVersion, version);
-  t.is(releasedGitHead, head);
   t.is(await gitTagHead(`v${version}`, {cwd}), head);
   t.is(await gitRemoteTagHead(authUrl, `v${version}`, {cwd}), head);
-  t.log(`+ released ${releasedVersion} with head ${releasedGitHead}`);
+  t.log(`+ released ${releasedVersion}`);
 
   await mockServer.verify(verifyMock);
   await mockServer.verify(createReleaseMock);
@@ -128,7 +138,7 @@ test('Release patch, minor and major versions', async t => {
   createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
     {
-      body: {tag_name: `v${version}`, target_commitish: 'master', name: `v${version}`},
+      body: {tag_name: `v${version}`, name: `v${version}`},
       headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}],
     },
     {body: {html_url: `release-url/${version}`}}
@@ -147,15 +157,14 @@ test('Release patch, minor and major versions', async t => {
   t.is((await readJson(path.resolve(cwd, 'npm-shrinkwrap.json'))).version, version);
 
   // Retrieve the published package from the registry and check version and gitHead
-  [, releasedVersion, releasedGitHead] = /^version = '(.+)'\s+gitHead = '(.+)'$/.exec(
-    (await execa('npm', ['show', packageName, 'version', 'gitHead'], {env: testEnv, cwd})).stdout
-  );
+  ({
+    'dist-tags': {latest: releasedVersion},
+  } = await npmView(packageName, testEnv));
   head = await gitHead({cwd});
   t.is(releasedVersion, version);
-  t.is(releasedGitHead, head);
   t.is(await gitTagHead(`v${version}`, {cwd}), head);
   t.is(await gitRemoteTagHead(authUrl, `v${version}`, {cwd}), head);
-  t.log(`+ released ${releasedVersion} with head ${releasedGitHead}`);
+  t.log(`+ released ${releasedVersion}`);
 
   await mockServer.verify(verifyMock);
   await mockServer.verify(createReleaseMock);
@@ -170,7 +179,7 @@ test('Release patch, minor and major versions', async t => {
   createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
     {
-      body: {tag_name: `v${version}`, target_commitish: 'master', name: `v${version}`},
+      body: {tag_name: `v${version}`, name: `v${version}`},
       headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}],
     },
     {body: {html_url: `release-url/${version}`}}
@@ -189,20 +198,19 @@ test('Release patch, minor and major versions', async t => {
   t.is((await readJson(path.resolve(cwd, 'npm-shrinkwrap.json'))).version, version);
 
   // Retrieve the published package from the registry and check version and gitHead
-  [, releasedVersion, releasedGitHead] = /^version = '(.+)'\s+gitHead = '(.+)'$/.exec(
-    (await execa('npm', ['show', packageName, 'version', 'gitHead'], {env: testEnv, cwd})).stdout
-  );
+  ({
+    'dist-tags': {latest: releasedVersion},
+  } = await npmView(packageName, testEnv));
   head = await gitHead({cwd});
   t.is(releasedVersion, version);
-  t.is(releasedGitHead, head);
   t.is(await gitTagHead(`v${version}`, {cwd}), head);
   t.is(await gitRemoteTagHead(authUrl, `v${version}`, {cwd}), head);
-  t.log(`+ released ${releasedVersion} with head ${releasedGitHead}`);
+  t.log(`+ released ${releasedVersion}`);
 
   await mockServer.verify(verifyMock);
   await mockServer.verify(createReleaseMock);
 
-  /* Major release */
+  /* Major release on next */
   version = '2.0.0';
   verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
@@ -212,16 +220,18 @@ test('Release patch, minor and major versions', async t => {
   createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
     {
-      body: {tag_name: `v${version}`, target_commitish: 'master', name: `v${version}`},
+      body: {tag_name: `v${version}@next`, name: `v${version}`},
       headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}],
     },
     {body: {html_url: `release-url/${version}`}}
   );
 
-  t.log('Commit a breaking change');
+  t.log('Commit a breaking change on next');
+  await gitCheckout('next', true, {cwd});
+  await gitPush('origin', 'next', {cwd});
   await gitCommits(['feat: foo\n\n BREAKING CHANGE: bar'], {cwd});
   t.log('$ semantic-release');
-  ({stdout, code} = await execa(cli, [], {env, cwd}));
+  ({stdout, code} = await execa(cli, [], {env: {...env, TRAVIS_BRANCH: 'next'}, cwd}));
   t.regex(stdout, new RegExp(`Published GitHub release: release-url/${version}`));
   t.regex(stdout, new RegExp(`Publishing version ${version} to npm registry`));
   t.is(code, 0);
@@ -231,18 +241,67 @@ test('Release patch, minor and major versions', async t => {
   t.is((await readJson(path.resolve(cwd, 'npm-shrinkwrap.json'))).version, version);
 
   // Retrieve the published package from the registry and check version and gitHead
-  [, releasedVersion, releasedGitHead] = /^version = '(.+)'\s+gitHead = '(.+)'$/.exec(
-    (await execa('npm', ['show', packageName, 'version', 'gitHead'], {env: testEnv, cwd})).stdout
-  );
+  ({
+    'dist-tags': {next: releasedVersion},
+  } = await npmView(packageName, testEnv));
   head = await gitHead({cwd});
   t.is(releasedVersion, version);
-  t.is(releasedGitHead, head);
-  t.is(await gitTagHead(`v${version}`, {cwd}), head);
-  t.is(await gitRemoteTagHead(authUrl, `v${version}`, {cwd}), head);
-  t.log(`+ released ${releasedVersion} with head ${releasedGitHead}`);
+  t.is(await gitTagHead(`v${version}@next`, {cwd}), head);
+  t.is(await gitRemoteTagHead(authUrl, `v${version}@next`, {cwd}), head);
+  t.log(`+ released ${releasedVersion} on @next`);
 
   await mockServer.verify(verifyMock);
   await mockServer.verify(createReleaseMock);
+
+  /* Merge next into master */
+  version = '2.0.0';
+  const releaseId = 1;
+  verifyMock = await mockServer.mock(
+    `/repos/${owner}/${packageName}`,
+    {headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}]},
+    {body: {permissions: {push: true}}, method: 'GET'}
+  );
+  const getReleaseMock = await mockServer.mock(
+    `/repos/${owner}/${packageName}/releases/tags/v2.0.0@next`,
+    {headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}]},
+    {body: {id: releaseId}, method: 'GET'}
+  );
+  const updateReleaseMock = await mockServer.mock(
+    `/repos/${owner}/${packageName}/releases/${releaseId}`,
+    {
+      body: {tag_name: `v${version}`, name: `v${version}`, prerelease: false},
+      headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}],
+    },
+    {body: {html_url: `release-url/${version}`}, method: 'PATCH'}
+  );
+
+  t.log('Merge next into master');
+  await gitCheckout('master', false, {cwd});
+  await merge('next', {cwd});
+  await gitPush('origin', 'master', {cwd});
+  t.log('$ semantic-release');
+  ({stdout, code} = await execa(cli, [], {env, cwd}));
+  t.regex(stdout, new RegExp(`Updated GitHub release: release-url/${version}`));
+  t.regex(stdout, new RegExp(`Adding version ${version} to npm registry on dist-tag latest`));
+  t.is(code, 0);
+
+  // Wait for 3s as the change of dist-tag takes time to be reflected in the registry
+  await delay(3000);
+  // Retrieve the published package from the registry and check version and gitHead
+  ({
+    'dist-tags': {latest: releasedVersion},
+  } = await npmView(packageName, testEnv));
+  t.is(releasedVersion, version);
+  t.is(await gitTagHead(`v${version}`, {cwd}), await gitTagHead(`v${version}@next`, {cwd}));
+  t.is(
+    await gitRemoteTagHead(authUrl, `v${version}`, {cwd}),
+    await gitRemoteTagHead(authUrl, `v${version}@next`, {cwd})
+  );
+  t.log(`+ added ${releasedVersion}`);
+
+  await mockServer.verify(verifyMock);
+  await mockServer.verify(getReleaseMock);
+  await mockServer.verify(updateReleaseMock);
 });
 
 test('Exit with 1 if a plugin is not found', async t => {
@@ -366,7 +425,7 @@ test('Allow local releases with "noCi" option', async t => {
   const createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
     {
-      body: {tag_name: `v${version}`, target_commitish: 'master', name: `v${version}`},
+      body: {tag_name: `v${version}`, name: `v${version}`},
       headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}],
     },
     {body: {html_url: `release-url/${version}`}}
@@ -384,9 +443,7 @@ test('Allow local releases with "noCi" option', async t => {
   t.is((await readJson(path.resolve(cwd, 'package.json'))).version, version);
 
   // Retrieve the published package from the registry and check version and gitHead
-  const [, releasedVersion, releasedGitHead] = /^version = '(.+)'\s+gitHead = '(.+)'$/.exec(
-    (await execa('npm', ['show', packageName, 'version', 'gitHead'], {env: testEnv, cwd})).stdout
-  );
+  const {version: releasedVersion, gitHead: releasedGitHead} = await npmView(packageName, testEnv);
 
   const head = await gitHead({cwd});
   t.is(releasedVersion, version);
@@ -439,9 +496,7 @@ test('Pass options via CLI arguments', async t => {
   t.is((await readJson(path.resolve(cwd, 'package.json'))).version, version);
 
   // Retrieve the published package from the registry and check version and gitHead
-  const [, releasedVersion, releasedGitHead] = /^version = '(.+)'\s+gitHead = '(.+)'$/.exec(
-    (await execa('npm', ['show', packageName, 'version', 'gitHead'], {env: testEnv, cwd})).stdout
-  );
+  const {version: releasedVersion, gitHead: releasedGitHead} = await npmView(packageName, testEnv);
   const head = await gitHead({cwd});
   t.is(releasedVersion, version);
   t.is(releasedGitHead, head);
@@ -482,7 +537,7 @@ test('Run via JS API', async t => {
   const createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
     {
-      body: {tag_name: `v${version}`, target_commitish: 'master', name: `v${version}`},
+      body: {tag_name: `v${version}`, name: `v${version}`},
       headers: [{name: 'Authorization', values: [`token ${env.GH_TOKEN}`]}],
     },
     {body: {html_url: `release-url/${version}`}}
@@ -497,9 +552,7 @@ test('Run via JS API', async t => {
   t.is((await readJson(path.resolve(cwd, 'package.json'))).version, version);
 
   // Retrieve the published package from the registry and check version and gitHead
-  const [, releasedVersion, releasedGitHead] = /^version = '(.+)'\s+gitHead = '(.+)'$/.exec(
-    (await execa('npm', ['show', packageName, 'version', 'gitHead'], {env: testEnv, cwd})).stdout
-  );
+  const {version: releasedVersion, gitHead: releasedGitHead} = await npmView(packageName, testEnv);
   const head = await gitHead({cwd});
   t.is(releasedVersion, version);
   t.is(releasedGitHead, head);

--- a/test/plugins/normalize.test.js
+++ b/test/plugins/normalize.test.js
@@ -152,6 +152,24 @@ test('Wrap "publish" plugin in a function that validate the output of the plugin
   t.regex(error.details, /2/);
 });
 
+test('Wrap "addChannel" plugin in a function that validate the output of the plugin', async t => {
+  const addChannel = stub().resolves(2);
+  const plugin = normalize(
+    {cwd, options: {}, stderr: t.context.stderr, logger: t.context.logger},
+    'addChannel',
+    addChannel,
+    {}
+  );
+
+  const error = await t.throws(plugin({options: {}}));
+
+  t.is(error.code, 'EADDCHANNELOUTPUT');
+  t.is(error.name, 'SemanticReleaseError');
+  t.truthy(error.message);
+  t.truthy(error.details);
+  t.regex(error.details, /2/);
+});
+
 test('Plugin is called with "pluginConfig" (with object definition) and input', async t => {
   const pluginFunction = stub().resolves();
   const pluginConf = {path: pluginFunction, conf: 'confValue'};

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,153 @@
+import test from 'ava';
+import AggregateError from 'aggregate-error';
+import {
+  extractErrors,
+  tagsToVersions,
+  isMajorRange,
+  isMaintenanceRange,
+  getUpperBound,
+  getLowerBound,
+  highest,
+  lowest,
+  getLatestVersion,
+  getEarliestVersion,
+  getFirstVersion,
+  getRange,
+  makeTag,
+} from '../lib/utils';
+
+test('extractErrors', t => {
+  const errors = [new Error('Error 1'), new Error('Error 2')];
+
+  t.deepEqual(extractErrors(new AggregateError(errors)), errors);
+  t.deepEqual(extractErrors(errors[0]), [errors[0]]);
+});
+
+test('tagsToVersions', t => {
+  t.deepEqual(tagsToVersions([{version: '1.0.0'}, {version: '1.1.0'}, {version: '1.2.0'}]), [
+    '1.0.0',
+    '1.1.0',
+    '1.2.0',
+  ]);
+});
+
+test('isMajorRange', t => {
+  t.false(isMajorRange('1.1.x'));
+  t.false(isMajorRange('1.1.X'));
+  t.false(isMajorRange('1.1.0'));
+
+  t.true(isMajorRange('1.x.x'));
+  t.true(isMajorRange('1.X.X'));
+  t.true(isMajorRange('1.x'));
+  t.true(isMajorRange('1.X'));
+});
+
+test('isMaintenanceRange', t => {
+  t.true(isMaintenanceRange('1.1.x'));
+  t.true(isMaintenanceRange('1.x.x'));
+  t.true(isMaintenanceRange('1.x'));
+  t.true(isMaintenanceRange('1.1.X'));
+  t.true(isMaintenanceRange('1.X.X'));
+  t.true(isMaintenanceRange('1.X'));
+
+  t.false(isMaintenanceRange('1.1.0'));
+  t.false(isMaintenanceRange('~1.0.0'));
+  t.false(isMaintenanceRange('^1.0.0'));
+});
+
+test('getUpperBound', t => {
+  t.is(getUpperBound('1.x.x'), '2.0.0');
+  t.is(getUpperBound('1.x'), '2.0.0');
+  t.is(getUpperBound('1.0.x'), '1.1.0');
+  t.is(getUpperBound('1.0.0'), '1.0.0');
+
+  t.is(getUpperBound('foo'), undefined);
+});
+
+test('getLowerBound', t => {
+  t.is(getLowerBound('1.x.x'), '1.0.0');
+  t.is(getLowerBound('1.x'), '1.0.0');
+  t.is(getLowerBound('1.0.x'), '1.0.0');
+  t.is(getLowerBound('1.0.0'), '1.0.0');
+
+  t.is(getLowerBound('foo'), undefined);
+});
+
+test('highest', t => {
+  t.is(highest('1.0.0', '2.0.0'), '2.0.0');
+  t.is(highest('1.1.1', '1.1.0'), '1.1.1');
+  t.is(highest(null, '1.0.0'), '1.0.0');
+  t.is(highest('1.0.0'), '1.0.0');
+  t.is(highest(), undefined);
+});
+
+test('lowest', t => {
+  t.is(lowest('1.0.0', '2.0.0'), '1.0.0');
+  t.is(lowest('1.1.1', '1.1.0'), '1.1.0');
+  t.is(lowest(null, '1.0.0'), '1.0.0');
+  t.is(lowest(), undefined);
+});
+
+test.serial('getLatestVersion', t => {
+  t.is(getLatestVersion(['1.2.3-alpha.3', '1.2.0', '1.0.1', '1.0.0-alpha.1']), '1.2.0');
+  t.is(getLatestVersion(['1.2.3-alpha.3', '1.2.3-alpha.2']), undefined);
+
+  t.is(getLatestVersion(['1.2.3-alpha.3', '1.2.0', '1.0.1', '1.0.0-alpha.1']), '1.2.0');
+  t.is(getLatestVersion(['1.2.3-alpha.3', '1.2.3-alpha.2']), undefined);
+
+  t.is(getLatestVersion(['1.2.3-alpha.3', '1.2.0', '1.0.1', '1.0.0-alpha.1'], {withPrerelease: true}), '1.2.3-alpha.3');
+  t.is(getLatestVersion(['1.2.3-alpha.3', '1.2.3-alpha.2'], {withPrerelease: true}), '1.2.3-alpha.3');
+
+  t.is(getLatestVersion([]), undefined);
+});
+
+test.serial('getEarliestVersion', t => {
+  t.is(getEarliestVersion(['1.2.3-alpha.3', '1.2.0', '1.0.0', '1.0.1-alpha.1']), '1.0.0');
+  t.is(getEarliestVersion(['1.2.3-alpha.3', '1.2.3-alpha.2']), undefined);
+
+  t.is(getEarliestVersion(['1.2.3-alpha.3', '1.2.0', '1.0.0', '1.0.1-alpha.1']), '1.0.0');
+  t.is(getEarliestVersion(['1.2.3-alpha.3', '1.2.3-alpha.2']), undefined);
+
+  t.is(
+    getEarliestVersion(['1.2.3-alpha.3', '1.2.0', '1.0.1', '1.0.0-alpha.1'], {withPrerelease: true}),
+    '1.0.0-alpha.1'
+  );
+  t.is(getEarliestVersion(['1.2.3-alpha.3', '1.2.3-alpha.2'], {withPrerelease: true}), '1.2.3-alpha.2');
+
+  t.is(getEarliestVersion([]), undefined);
+});
+
+test('getFirstVersion', t => {
+  t.is(getFirstVersion(['1.2.0', '1.0.0', '1.3.0', '1.1.0', '1.4.0'], []), '1.0.0');
+  t.is(
+    getFirstVersion(
+      ['1.2.0', '1.0.0', '1.3.0', '1.1.0', '1.4.0'],
+      [
+        {name: 'master', tags: [{version: '1.0.0'}, {version: '1.1.0'}]},
+        {name: 'next', tags: [{version: '1.0.0'}, {version: '1.1.0'}, {version: '1.2.0'}]},
+      ]
+    ),
+    '1.3.0'
+  );
+  t.is(
+    getFirstVersion(
+      ['1.2.0', '1.0.0', '1.1.0'],
+      [
+        {name: 'master', tags: [{version: '1.0.0'}, {version: '1.1.0'}]},
+        {name: 'next', tags: [{version: '1.0.0'}, {version: '1.1.0'}, {version: '1.2.0'}]},
+      ]
+    ),
+    undefined
+  );
+});
+
+test('getRange', t => {
+  t.is(getRange('1.0.0', '1.1.0'), '>=1.0.0 <1.1.0');
+  t.is(getRange('1.0.0'), '>=1.0.0');
+});
+
+test('makeTag', t => {
+  t.is(makeTag(`v\${version}`, '1.0.0'), 'v1.0.0');
+  t.is(makeTag(`v\${version}`, '1.0.0', 'next'), 'v1.0.0@next');
+  t.is(makeTag(`v\${version}@test`, '1.0.0', 'next'), 'v1.0.0@next@test');
+});

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -5,7 +5,7 @@ import {gitRepo} from './helpers/git-utils';
 
 test('Throw a AggregateError', async t => {
   const {cwd} = await gitRepo();
-  const options = {};
+  const options = {branches: [{name: 'master'}, {name: ''}]};
 
   const errors = [...(await t.throws(verify({cwd, options})))];
 
@@ -21,11 +21,15 @@ test('Throw a AggregateError', async t => {
   t.is(errors[2].code, 'ETAGNOVERSION');
   t.truthy(errors[2].message);
   t.truthy(errors[2].details);
+  t.is(errors[3].name, 'SemanticReleaseError');
+  t.is(errors[3].code, 'EINVALIDBRANCH');
+  t.truthy(errors[3].message);
+  t.truthy(errors[3].details);
 });
 
 test('Throw a SemanticReleaseError if does not run on a git repository', async t => {
   const cwd = tempy.directory();
-  const options = {};
+  const options = {branches: []};
 
   const errors = [...(await t.throws(verify({cwd, options})))];
 
@@ -37,7 +41,7 @@ test('Throw a SemanticReleaseError if does not run on a git repository', async t
 
 test('Throw a SemanticReleaseError if the "tagFormat" is not valid', async t => {
   const {cwd, repositoryUrl} = await gitRepo(true);
-  const options = {repositoryUrl, tagFormat: `?\${version}`};
+  const options = {repositoryUrl, tagFormat: `?\${version}`, branches: []};
 
   const errors = [...(await t.throws(verify({cwd, options})))];
 
@@ -49,7 +53,7 @@ test('Throw a SemanticReleaseError if the "tagFormat" is not valid', async t => 
 
 test('Throw a SemanticReleaseError if the "tagFormat" does not contains the "version" variable', async t => {
   const {cwd, repositoryUrl} = await gitRepo(true);
-  const options = {repositoryUrl, tagFormat: 'test'};
+  const options = {repositoryUrl, tagFormat: 'test', branches: []};
 
   const errors = [...(await t.throws(verify({cwd, options})))];
 
@@ -61,7 +65,7 @@ test('Throw a SemanticReleaseError if the "tagFormat" does not contains the "ver
 
 test('Throw a SemanticReleaseError if the "tagFormat" contains multiple "version" variables', async t => {
   const {cwd, repositoryUrl} = await gitRepo(true);
-  const options = {repositoryUrl, tagFormat: `\${version}v\${version}`};
+  const options = {repositoryUrl, tagFormat: `\${version}v\${version}`, branches: []};
 
   const errors = [...(await t.throws(verify({cwd, options})))];
 
@@ -71,9 +75,43 @@ test('Throw a SemanticReleaseError if the "tagFormat" contains multiple "version
   t.truthy(errors[0].details);
 });
 
+test('Throw a SemanticReleaseError for each invalid branch', async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const options = {
+    repositoryUrl,
+    tagFormat: `v\${version}`,
+    branches: [{name: ''}, {name: '  '}, {name: 1}, {}, {name: ''}, 1, 'master'],
+  };
+
+  const errors = [...(await t.throws(verify({cwd, options})))];
+
+  t.is(errors[0].name, 'SemanticReleaseError');
+  t.is(errors[0].code, 'EINVALIDBRANCH');
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+  t.is(errors[1].name, 'SemanticReleaseError');
+  t.is(errors[1].code, 'EINVALIDBRANCH');
+  t.truthy(errors[1].message);
+  t.truthy(errors[1].details);
+  t.is(errors[2].name, 'SemanticReleaseError');
+  t.is(errors[2].code, 'EINVALIDBRANCH');
+  t.truthy(errors[2].message);
+  t.truthy(errors[2].details);
+  t.is(errors[3].name, 'SemanticReleaseError');
+  t.is(errors[3].code, 'EINVALIDBRANCH');
+  t.truthy(errors[3].message);
+  t.truthy(errors[3].details);
+  t.is(errors[4].code, 'EINVALIDBRANCH');
+  t.truthy(errors[4].message);
+  t.truthy(errors[4].details);
+  t.is(errors[5].code, 'EINVALIDBRANCH');
+  t.truthy(errors[5].message);
+  t.truthy(errors[5].details);
+});
+
 test('Return "true" if all verification pass', async t => {
   const {cwd, repositoryUrl} = await gitRepo(true);
-  const options = {repositoryUrl, tagFormat: `v\${version}`};
+  const options = {repositoryUrl, tagFormat: `v\${version}`, branches: [{name: 'master'}]};
 
   await t.notThrows(verify({cwd, options}));
 });


### PR DESCRIPTION
Fix #563. Connected to semantic-release/evolution#1.

- Allow to configure multiple branches to release from
- Allow to define a distribution channel associated with each branch
- Manage the availability on distribution channels based on git merges
- Support regular releases, maintenance releases and pre-releases
- Add the `addChannel` plugin step to make an existing release available on a different distribution channel

It differs from semantic-release/evolution#1 in two points:
- Adding a release to a distribution channel is done with a the new plugin hook `addChannel` rather than using the existing `publish`. Publishing and adding to a channel do not share much and adding a new hook avoid forcing existing plugins to update their `publish` function to handle the case where no new release is created but only moved to a different distribution channel.
- When a release is publish on a given distribution channel, the associated tag has the format `v<version>@<channel>`. That allow semantic-release to keep a state of what is available where and avoid continuously adding the same version on a distribution channel  on every run.

To release this feature I propose to:
- Rename the branch `caribou` to `master` for consistency. That also allows us to use the default config.
- Create a `beta` branch and merge this PR in it, so we would release `v16.0.0-beta.1` for people to test. This way if we find issues that are solved by a breaking change we can do it on the `beta` branch and we don't have to release a `v17.0.0`, `v18.0.0` etc... for fixes on this feature.
- Create the branch `next` for working on next major release in the future.