### PR TITLE
fix: correctly resolve plugins installed globally with `npx`

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -6,6 +6,7 @@ const debug = require('debug')('semantic-release:config');
 const {repoUrl} = require('./git');
 const PLUGINS_DEFINITIONS = require('./definitions/plugins');
 const plugins = require('./plugins');
+const {validatePlugin, parseConfig} = require('./plugins/utils');
 
 const CONFIG_NAME = 'release';
 const CONFIG_FILES = [
@@ -37,17 +38,21 @@ module.exports = async (context, opts) => {
 
         // For each plugin defined in a shareable config, save in `pluginsPath` the extendable config path,
         // so those plugin will be loaded relatively to the config file
-        Object.entries(extendsOpts).reduce((pluginsPath, [option, value]) => {
-          if (PLUGINS_DEFINITIONS[option] || option === 'plugins') {
-            castArray(value)
-              .filter(plugin => isString(plugin) || (isPlainObject(plugin) && isString(plugin.path)))
-              .map(plugin => (isString(plugin) ? plugin : plugin.path))
-              .forEach(plugin => {
-                pluginsPath[plugin] = extendPath;
-              });
-          }
-          return pluginsPath;
-        }, pluginsPath);
+        Object.entries(extendsOpts)
+          .filter(([, value]) => Boolean(value))
+          .reduce((pluginsPath, [option, value]) => {
+            castArray(value).forEach(plugin => {
+              if (option === 'plugins' && validatePlugin(plugin)) {
+                pluginsPath[parseConfig(plugin)[0]] = extendPath;
+              } else if (
+                PLUGINS_DEFINITIONS[option] &&
+                (isString(plugin) || (isPlainObject(plugin) && isString(plugin.path)))
+              ) {
+                pluginsPath[isString(plugin) ? plugin : plugin.path] = extendPath;
+              }
+            });
+            return pluginsPath;
+          }, pluginsPath);
 
         return {...result, ...extendsOpts};
       }, {}),

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -212,7 +212,7 @@ test('Read configuration from file path in "extends"', async t => {
     branch: 'test_branch',
     repositoryUrl: 'https://host.null/owner/module.git',
     tagFormat: `v\${version}`,
-    plugins: false,
+    plugins: ['plugin-1', ['plugin-2', {plugin2Opt: 'value'}]],
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, 'package.json'), {release: pkgOptions});
@@ -227,6 +227,8 @@ test('Read configuration from file path in "extends"', async t => {
   t.deepEqual(t.context.plugins.args[0][1], {
     analyzeCommits: './shareable.json',
     generateNotes: './shareable.json',
+    'plugin-1': './shareable.json',
+    'plugin-2': './shareable.json',
   });
 });
 


### PR DESCRIPTION
This bug affects only plugins defined with the `plugins` option and wrapped in an Array to add a configuration

Fix #999