### PR TITLE
feat: allow `publish` plugins to return `false` in order to signify no release was done

### DIFF
--- a/lib/definitions/plugins.js
+++ b/lib/definitions/plugins.js
@@ -73,7 +73,7 @@ module.exports = {
       transform: (release, step, {nextRelease}) => ({
         ...(isPlainObject(release) ? release : {}),
         ...nextRelease,
-        ...step,
+        ...(release === false ? {} : step),
       }),
     }),
   },

--- a/test/definitions/plugins.test.js
+++ b/test/definitions/plugins.test.js
@@ -22,7 +22,7 @@ test('The "generateNotes" plugin output, if defined, must be a string', t => {
   t.true(plugins.generateNotes.outputValidator('string'));
 });
 
-test('The "publish" plugin output, if defined, must be an object', t => {
+test('The "publish" plugin output, if defined, must be an object or "false"', t => {
   t.false(plugins.publish.outputValidator(1));
   t.false(plugins.publish.outputValidator('string'));
 
@@ -30,6 +30,7 @@ test('The "publish" plugin output, if defined, must be an object', t => {
   t.true(plugins.publish.outputValidator());
   t.true(plugins.publish.outputValidator(null));
   t.true(plugins.publish.outputValidator(''));
+  t.true(plugins.publish.outputValidator(false));
 });
 
 test('The "generateNotes" plugins output are concatenated with separator and sensitive data is hidden', t => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -693,7 +693,7 @@ test('Allow local releases with "noCi" option', async t => {
   t.is(success.callCount, 1);
 });
 
-test('Accept "undefined" value returned by the "generateNotes" plugins', async t => {
+test('Accept "undefined" value returned by "generateNotes" and "false" by "publish"', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd, repositoryUrl} = await gitRepo(true);
   // Add commits to the master branch
@@ -711,7 +711,7 @@ test('Accept "undefined" value returned by the "generateNotes" plugins', async t
   const generateNotes1 = stub().resolves();
   const notes2 = 'Release notes 2';
   const generateNotes2 = stub().resolves(notes2);
-  const publish = stub().resolves();
+  const publish = stub().resolves(false);
 
   const options = {
     branch: 'master',


### PR DESCRIPTION
Ref https://github.com/semantic-release/github/issues/138