### PR TITLE
fix: ignore lasst release only if pre-release on the same channel as current branch

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -23,9 +23,9 @@ const {makeTag} = require('./utils');
  *
  * @return {LastRelease} The last tagged release or empty object if none is found.
  */
-module.exports = ({branch: {tags, type}, options: {tagFormat}}, {before} = {}) => {
-  const [{version, gitTag, gitHead, channel} = {}] = tags
-    .filter(tag => type === 'prerelease' || !semver.prerelease(tag.version))
+module.exports = ({branch, options: {tagFormat}}, {before} = {}) => {
+  const [{version, gitTag, gitHead, channel} = {}] = branch.tags
+    .filter(tag => (branch.type === 'prerelease' && branch.channel === tag.channel) || !semver.prerelease(tag.version))
     .filter(tag => isUndefined(before) || semver.lt(tag.version, before))
     .sort((a, b) => semver.rcompare(a.version, b.version));
 

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -18,6 +18,31 @@ test('Get the highest non-prerelease valid tag', t => {
   t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: '222', channel: undefined});
 });
 
+test('Get the highest prerelease valid tag, ignoring other tags from other prerelease channels', t => {
+  const result = getLastRelease({
+    branch: {
+      name: 'beta',
+      prerelease: 'beta',
+      channel: 'beta',
+      tags: [
+        {version: '1.0.0-beta.1', gitTag: 'v1.0.0-beta.1@beta', gitHead: '111', channel: 'beta'},
+        {version: '1.0.0-beta.2', gitTag: 'v1.0.0-beta.2@beta', gitHead: '222', channel: 'beta'},
+        {version: '1.0.0-alpha.1', gitTag: 'v1.0.0-alpha.1@alpha', gitHead: '333', channel: 'alpha'},
+      ],
+      type: 'prerelease',
+    },
+    options: {tagFormat: `v\${version}`},
+  });
+
+  t.deepEqual(result, {
+    version: '1.0.0-beta.2',
+    gitTag: 'v1.0.0-beta.2@beta',
+    name: 'v1.0.0-beta.2',
+    gitHead: '222',
+    channel: 'beta',
+  });
+});
+
 test('Return empty object if no valid tag is found', t => {
   const result = getLastRelease({
     branch: {


### PR DESCRIPTION
Fix #1071