### PR TITLE
feat: added '--skip-tag', '--skip-pr-check' and `--branch=*`

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -115,6 +115,20 @@ CLI arguments: `-d`, `--dry-run`
 
 Dry-run mode, skip publishing, print next version and release notes.
 
+### skipTag
+Type: `Boolean`<br>
+Default: `false`
+CLI arguments: `--skip-tag`
+
+Prevent tagging of the git commit on release.
+
+### skipPrCheck
+Type: `Boolean`<br>
+Default: `false`
+CLI arguments: `--skip-pr-check`
+
+Do not verify that execution is not triggered by a pull request.
+
 ### ci
 
 Type: `Boolean`<br>


### PR DESCRIPTION
This pr is not final. I'm putting this up since it solves my use case nicely. I do want to add more tests once we have agreed on changes here.

There are different reasons why options are added:

### skipTag
See discussion here: https://github.com/semantic-release/semantic-release/issues/753#issuecomment-455241656
Basically we can disable all plugin execution, however there is no way to prevent the tagging. So if we just want to output the version to a file without changing anything in the repo, this option is necessary.

### skipPrCheck
See discussion here: https://github.com/semantic-release/semantic-release/issues/1074
Basically CircleCI has weird behaviour. I can provide show case of the behaviour if that is desired.