### PR TITLE
Add a reference to semantic-release-ado on the plugins list

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -71,3 +71,5 @@
   - `verifyRelease`: Checks and warns (does not error by default) if the version numbers found on maven central and within the Git project differ by quite a bit
   - `prepare`: Changes the version number in the `pom.xml` (or all `pom.xml` files in maven projects with multiple `pom.xml` files) and optionally creates a commit with this version number and pushes it to `master`
   - `publish`: Runs `mvn deploy` to deploy to maven central and optionally will update to next snapshot version and merge changes to development branch
+- [semantic-release-ado](https://github.com/lluchmk/semantic-release-ado)
+  - `prepare`: Stores the version number as an Azure DevOps pipeline variable availabe to downstream steps on the job


### PR DESCRIPTION
Adds a reference to the semantic-release-ado plugin on docs/extending/plugins-list.md.