### PR TITLE
feat(publish): add flag to enable git tag signing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,7 @@ Usage:
     .option('success', {...stringList, group: 'Plugins'})
     .option('fail', {...stringList, group: 'Plugins'})
     .option('debug', {describe: 'Output debugging information', type: 'boolean', group: 'Options'})
+    .option('sign', {alias: 's', describe: 'Enable GPG signing of the tag', type: 'boolean', group: 'Options'})
     .option('d', {alias: 'dry-run', describe: 'Skip publishing', type: 'boolean', group: 'Options'})
     .option('h', {alias: 'help', group: 'Options'})
     .option('v', {alias: 'version', group: 'Options'})

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -135,6 +135,14 @@ Output debugging information. This can also be enabled by setting the `DEBUG` en
 
 **Note**: The `debug` is used only supported via CLI argument. To enable debug mode from the [JS API](../developer-guide/js-api.md#javascript-api) use `require('debug').enable('semantic-release:*')`.
 
+### sign
+
+Type: `Boolean`<br>
+Default: `false`<br>
+CLI argument: `--sign` / `-s`
+
+Set to `true` to enable [git tag signatures](https://git-scm.com/book/id/v2/Git-Tools-Signing-Your-Work).
+
 ## Git environment variables
 
 | Variable              | Description                                                                                                                                                                                                                    | Default                              |

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ async function run(context, plugins) {
     logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
   } else {
     // Create the tag before calling the publish plugins as some require the tag to exists
-    await tag(nextRelease.gitTag, {cwd, env});
+    await tag(nextRelease.gitTag, {cwd, env}, options.sign);
     await push(options.repositoryUrl, {cwd, env});
     logger.success(`Created tag ${nextRelease.gitTag}`);
   }

--- a/lib/git.js
+++ b/lib/git.js
@@ -132,11 +132,17 @@ async function verifyAuth(repositoryUrl, branch, execaOpts) {
  *
  * @param {String} tagName The name of the tag.
  * @param {Object} [execaOpts] Options to pass to `execa`.
+ * @param {Boolean} [sign] Indicates if the git tag should be signed with -S.
  *
  * @throws {Error} if the tag creation failed.
  */
-async function tag(tagName, execaOpts) {
-  await execa('git', ['tag', tagName], execaOpts);
+async function tag(tagName, execaOpts, sign) {
+  const defaultArgs = ['tag', tagName];
+  if (sign) {
+    defaultArgs.splice(1, 0, '-s');
+  }
+
+  await execa('git', defaultArgs, execaOpts);
 }
 
 /**


### PR DESCRIPTION
Hello! I noticed it was impossible to sign tags (even using `git config tag.forceSignAnnotated` or `commit.gpgsign`). So I digged into the code and added the option to do so.

I hope this is okay and should be completely backwards-compatible 😄 

[Related Issue semantic-release/semantic-release#214]