### PR TITLE
Doc : correct way to print release plugin name

### DIFF
--- a/docs/developer-guide/js-api.md
+++ b/docs/developer-guide/js-api.md
@@ -39,7 +39,7 @@ try {
     }
 
     for (const release of releases) {
-      console.log(`The release was published with plugin "${pluginName}".`);
+      console.log(`The release was published with plugin "${release.pluginName}".`);
     }
   } else {
     console.log('No release published.');


### PR DESCRIPTION
There is an error in the JavaScript API documentation page. Copy/pasting the snippet as this makes the script fail with : 

```
The automated release failed with ReferenceError: pluginName is not defined
```