### PR TITLE
Docs/Improve `ERELEASEBRANCHES` error flow

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -81,6 +81,8 @@ The branches on which releases should happen. By default **semantic-release** wi
 - prereleases to the `beta` distribution channel from the branch `beta` if it exists
 - prereleases to the `alpha` distribution channel from the branch `alpha` if it exists
 
+**Note**: If your repository does not have a release branch, then **semantic-release** will fail with an `ERELEASEBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `master` branch.
+
 **Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://help.github.com/articles/about-protected-branches).
 
 See [Plugins configuration](plugins.md#plugins) for more details.

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -183,6 +183,8 @@ Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
     details: `A minimum of 1 and a maximum of 3 release branches are required in the [branches configuration](${linkify(
       'docs/usage/configuration.md#branches'
     )}).
+    
+This may occur if your repository does not have a release branch, such as \`master\`.
 
 Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
   }),


### PR DESCRIPTION
We're migrating some old repositories that had been using a `develop` branch, and `semantic-release@beta` failed out of the box because we didn't have a `master` branch.

This PR adds a bit more detail to the error message and documentation to help the next person in my shoes.