### PR TITLE
chore: document that plugins config is an override

### DIFF
--- a/docs/usage/plugins.md
+++ b/docs/usage/plugins.md
@@ -44,6 +44,8 @@ Each plugin must be configured with the [`plugins` options](./configuration.md#p
 }
 ```
 
+**Note:** If the `plugins` option is defined, it overrides the default plugin list, rather than merging with it.
+
 ## Plugin ordering
 
 For each [release step](../../README.md#release-steps) the plugins that implement that step will be executed in the order in which the are defined.


### PR DESCRIPTION
This patch documents that the `plugin` config option is an override, not a merge with the default. This is significant, for example, if you customise the github plugin as it will then prevent npm publishing by default unless the npm plugin is also defined manually.