### PR TITLE
docs: note publishing on distribution channels in beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here is an example of the release type that will be done based on a commit messa
 For each new commits added to the release branch (i.e. `master`) with `git push` or by merging a pull request or merging from another branch, a CI build is triggered and runs the `semantic-release` command to make a release if there are codebase changes since the last release that affect the package functionalities.
 
 If you need more control over the timing of releases you have a couple of options:
-- Publish releases on a distribution channel (for example npm’s [dist-tags](https://docs.npmjs.com/cli/dist-tag)). This way you can keep control over what your users end up using by default, and you can decide when to make an automatically released version available to the stable channel, and promote it.
+- Publish releases on a distribution channel (for example npm’s [dist-tags](https://docs.npmjs.com/cli/dist-tag)). This way you can keep control over what your users end up using by default, and you can decide when to make an automatically released version available to the stable channel, and promote it. **NOTE**: `16.0.0-beta` of semantic-release, includes new features to automate the release of different branches to different npm distribution tags. The corresponding documentation can be found [on the beta branch of this repo](https://github.com/semantic-release/semantic-release/blob/beta/docs/recipes/distribution-channels.md#publishing-on-distribution-channels).
 - Develop on a `dev` branch and merge it to the release branch (i.e. `master`) once you are ready to publish. **semantic-release** will run only on pushes to the release branch.
 
 ### Release steps


### PR DESCRIPTION
Since the readme hints at doing this, note that features to automate this are in beta. Also discussed at https://spectrum.chat/semantic-release/general/im-trying-to-configure-a-next-release~5bb8e692-a0cd-49be-8379-9fb6b25261fe