### PR TITLE
Doc cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Jetbrains IDEs
+.idea
 
 # Created by https://www.gitignore.io/api/macos,windows,linux,node
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ After running the tests, the command `semantic-release` will execute the followi
 ## Documentation
 
 - Usage
-  - [Getting started](docs/usage/getting-started.md#getting-started)
+  - [Getting started](docs/usage/getting-started.md)
   - [Installation](docs/usage/installation.md#installation)
   - [CI Configuration](docs/usage/ci-configuration.md#ci-configuration)
   - [Configuration](docs/usage/configuration.md#configuration)
@@ -103,12 +103,17 @@ After running the tests, the command `semantic-release` will execute the followi
   - [Plugins](docs/extending/plugins-list.md)
   - [Shareable configuration](docs/extending/shareable-configurations-list.md)
 - Recipes
-  - [CI configurations](docs/recipes/README.md)
-  - [Package managers and languages](docs/recipes/README.md)
+  - [CI configurations](docs/recipes/ci-configurations.md)
+	- [CircleCI 2.0 workflows](docs/recipes/circleci-workflows.md)
+	- [Travis CI](docs/recipes/travis.md)
+	- [GitLab CI](docs/recipes/gitlab-ci.md)
+  - [Git hosted services](docs/recipes/git-hosted-services.md)
+	- [Git authentication with SSH keys](docs/recipes/git-auth-ssh-keys.md)
+  - [Package managers and languages](docs/recipes/package-managers-and-languages.md)
 - Developer guide
   - [JavaScript API](docs/developer-guide/js-api.md)
-  - [Plugins](docs/developer-guide/plugin.md)
-  - [Shareable configuration](docs/developer-guide/shareable-configuration.md)
+  - [Plugin development](docs/developer-guide/plugin.md)
+  - [Shareable configuration development](docs/developer-guide/shareable-configuration.md)
 - Support
   - [Resources](docs/support/resources.md)
   - [Frequently Asked Questions](docs/support/FAQ.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,14 +12,13 @@
 - [Shareable configuration](docs/extending/shareable-configurations-list.md)
 
 ## Recipes
-- [CI configurations](docs/recipes/README.md)
+- [CI configurations](docs/recipes/ci-configurations.md)
 	- [CircleCI 2.0 workflows](docs/recipes/circleci-workflows.md)
 	- [Travis CI](docs/recipes/travis.md)
-	- [Travis CI with build stages](docs/recipes/travis-build-stages.md)
 	- [GitLab CI](docs/recipes/gitlab-ci.md)
-- [Git hosted services](docs/recipes/README.md)
+- [Git hosted services](docs/recipes/git-hosted-services.md)
 	- [Git authentication with SSH keys](docs/recipes/git-auth-ssh-keys.md)
-- [Package managers and languages](docs/recipes/README.md)
+- [Package managers and languages](docs/recipes/package-managers-and-languages.md)
 
 ## Developer guide
 - [JavaScript API](docs/developer-guide/js-api.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 ## Usage
+- [Getting started](docs/usage/getting-started.md)
 - [Installation](docs/usage/installation.md#installation)
 - [CI Configuration](docs/usage/ci-configuration.md#ci-configuration)
 - [Configuration](docs/usage/configuration.md#configuration)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -22,8 +22,8 @@
 
 ## Developer guide
 - [JavaScript API](docs/developer-guide/js-api.md)
-- [Plugin](docs/developer-guide/plugin.md)
-- [Shareable configuration](docs/developer-guide/shareable-configuration.md)
+- [Plugin development](docs/developer-guide/plugin.md)
+- [Shareable configuration development](docs/developer-guide/shareable-configuration.md)
 
 ## Support
 - [Resources](docs/support/resources.md)

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,11 +1,3 @@
-# Recipes
-
-## CI configurations
-- [CircleCI 2.0 workflows](circleci-workflows.md)
-- [Travis CI](travis.md)
-- [GitLab CI](gitlab-ci.md)
-
-## Git hosted services
+# Git hosted services
 - [Git authentication with SSH keys](git-auth-ssh-keys.md)
 
-## Package managers and languages

--- a/docs/recipes/ci-configurations.md
+++ b/docs/recipes/ci-configurations.md
@@ -1,0 +1,4 @@
+# CI configurations
+- [CircleCI 2.0 workflows](circleci-workflows.md)
+- [Travis CI](travis.md)
+- [GitLab CI](gitlab-ci.md)

--- a/docs/recipes/git-hosted-services.md
+++ b/docs/recipes/git-hosted-services.md
@@ -1,0 +1,12 @@
+# Recipes
+
+## CI configurations
+- [CircleCI 2.0 workflows](circleci-workflows.md)
+- [Travis CI](travis.md)
+- [GitLab CI](gitlab-ci.md)
+
+## Git hosted services
+- [Git authentication with SSH keys](git-auth-ssh-keys.md)
+
+## Package managers and languages (to be completed)
+

--- a/docs/recipes/package-managers-and-languages.md
+++ b/docs/recipes/package-managers-and-languages.md
@@ -1,0 +1,2 @@
+# Package managers and languages (to be completed)
+

--- a/docs/support/FAQ.md
+++ b/docs/support/FAQ.md
@@ -56,7 +56,7 @@ If your CI environment provides [nvm](https://github.com/creationix/nvm) you can
 $ nvm install 8 && yarn global add semantic-release && semantic-release
 ```
 
-See the [CI configuration recipes](../recipes/README.md#ci-configurations) for more details on specific CI environments.
+See the [CI configuration recipes](../recipes/ci-configurations.md) for more details on specific CI environments.
 
 As `semantic-release` is recommended to be executed with [`npx`](https://www.npmjs.com/package/npx) an alternative is required for usage with Yarn. Even though it is possible to install npx with Yarn, it's not recommended. Yarn and npx would be using different cache locations.
 
@@ -75,7 +75,7 @@ To publish a non-Node package (without a `package.json`) you would need to:
 - Set **semantic-release** [options](../usage/configuration.md#options) via [CLI arguments or rc file](../usage/configuration.md#configuration)
 - Make sure your CI job executing the `semantic-release` command has access to [Node >= 8](#why-does-semantic-release-require-node-version--83) to execute the `semantic-release` command
 
-See the [CI configuration recipes](../recipes/README.md#ci-configurations) for more details on specific CI environments.
+See the [CI configuration recipes](../recipes/ci-configurations.md) for more details on specific CI environments.
 
 In addition you will need to configure the **semantic-release** [plugins](../usage/plugins.md#plugins) to disable the [`@semantic-release/npm`](https://github.com/semantic-release/npm) plugin which is used by default and use a plugin for your project type.
 
@@ -107,7 +107,7 @@ Yes, **semantic-release** can be used with any CI service, as long as it provide
 - A way to set [authentication](../usage/ci-configuration.md#authentication) via environment variables
 - A way to guarantee that the `semantic-release` command is [executed only after all the tests of all the jobs in the CI build pass](../usage/ci-configuration.md#run-semantic-release-only-after-all-tests-succeeded)
 
-See the [CI configuration recipes](../recipes/README.md#ci-configurations) for more details on specific CI environments.
+See the [CI configuration recipes](../recipes/ci-configurations.md) for more details on specific CI environments.
 
 ## Can I run semantic-release on my local machine rather than on a CI server?
 

--- a/docs/support/node-version.md
+++ b/docs/support/node-version.md
@@ -12,7 +12,7 @@ See our [Node Support Policy](node-support-policy.md) for our long-term promise 
 
 The recommended approach is to run the `semantic-release` command from a CI job running on Node 8.3 or higher. This can either be a job used by your project to test on Node >= 8.3 or a dedicated job for the release steps.
 
-See [CI configuration](../usage/ci-configuration.md) and [CI configuration recipes](../recipes/README.md#ci-configurations) for more details.
+See [CI configuration](../usage/ci-configuration.md) and [CI configuration recipes](../recipes/ci-configurations.md) for more details.
 
 ## Alternative solutions
 

--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -4,7 +4,7 @@
 
 The `semantic-release` command must be executed only after all the tests in the CI build pass. If the build runs multiple jobs (for example to test on multiple Operating Systems or Node versions) the CI has to be configured to guarantee that the `semantic-release` command is executed only after all jobs are successful. This can be achieved with [Travis Build Stages](https://docs.travis-ci.com/user/build-stages), [CircleCI Workflows](https://circleci.com/docs/2.0/workflows), [Codeship Deployment Pipelines](https://documentation.codeship.com/basic/builds-and-configuration/deployment-pipelines), [GitLab Pipelines](https://docs.gitlab.com/ee/ci/pipelines.html#introduction-to-pipelines-and-jobs), [Codefresh Pipelines](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/introduction-to-codefresh-pipelines), [Wercker Workflows](http://devcenter.wercker.com/docs/workflows) or [GoCD Pipelines](https://docs.gocd.org/current/introduction/concepts_in_go.html#pipeline).
 
-See [CI configuration recipes](../recipes/README.md#ci-configurations) for more details.
+See [CI configuration recipes](../recipes/ci-configurations.md) for more details.
 
 ## Authentication
 
@@ -30,4 +30,4 @@ See each plugin's documentation for the environment variables required.
 
 The authentication token/credentials have to be made available in the CI service via environment variables.
 
-See [CI configuration recipes](../recipes/README.md#ci-configurations) for more details on how to configure environment variables in your CI service.
+See [CI configuration recipes](../recipes/ci-configurations.md) for more details on how to configure environment variables in your CI service.


### PR DESCRIPTION
Includes:

- docs(recipes): cleaned doc and navigation
  - Corrected inconsistancies between the sidebar and the actual pages. Remove non existing pages. 
  - Clarified status of "Package managers and languages" to "to be completed".
- docs: repared broken links to "CI configuration recipes"
- docs: cleaned "Developer guide" section navigation
- docs: synched README.md and SUMMARY.md

Also added my (Jetbrains) IDE files to `.gitignore`.