### PR TITLE
Update dependency lodash (patch version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "git-log-parser": "^1.2.0",
     "hook-std": "^2.0.0",
     "hosted-git-info": "^2.7.1",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.15",
     "marked": "^0.7.0",
     "marked-terminal": "^3.2.0",
     "p-locate": "^4.0.0",


### PR DESCRIPTION
Recently, the lodash package had a couple of patch version updates due to reported security vulnerabilites. This PR updates lodash to the last version. I reckon that similar updates are in order in the various other repositories related to semantic-release.

That said, it would be helpful to be able to run `npm audit` against this repository. Alas, that’s not possible because it has no package-lock.json.