### PR TITLE
fix: prefix git auth url with "x-access-token:" when run in a GitHub Action

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -3,16 +3,6 @@ const {isNil} = require('lodash');
 const hostedGitInfo = require('hosted-git-info');
 const {verifyAuth} = require('./git');
 
-const GIT_TOKENS = {
-  GIT_CREDENTIALS: undefined,
-  GH_TOKEN: undefined,
-  GITHUB_TOKEN: undefined,
-  GL_TOKEN: 'gitlab-ci-token:',
-  GITLAB_TOKEN: 'gitlab-ci-token:',
-  BB_TOKEN: 'x-token-auth:',
-  BITBUCKET_TOKEN: 'x-token-auth:',
-};
-
 /**
  * Determine the the git repository URL to use to push, either:
  * - The `repositoryUrl` as is if allowed to push
@@ -25,6 +15,18 @@ const GIT_TOKENS = {
  * @return {String} The formatted Git repository URL.
  */
 module.exports = async ({cwd, env, branch, options: {repositoryUrl}}) => {
+  const GIT_TOKENS = {
+    GIT_CREDENTIALS: undefined,
+    GH_TOKEN: undefined,
+    // GitHub Actions require the "x-access-token:" prefix for git access
+    // https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#http-based-git-access-by-an-installation
+    GITHUB_TOKEN: isNil(env.GITHUB_ACTION) ? undefined : 'x-access-token:',
+    GL_TOKEN: 'gitlab-ci-token:',
+    GITLAB_TOKEN: 'gitlab-ci-token:',
+    BB_TOKEN: 'x-token-auth:',
+    BITBUCKET_TOKEN: 'x-token-auth:',
+  };
+
   const info = hostedGitInfo.fromUrl(repositoryUrl, {noGitPlus: true});
   const {protocol, ...parsed} = parse(repositoryUrl);
 

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -273,6 +273,19 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "BITB
   );
 });
 
+test('Return the "https" formatted URL if "GITHUB_ACTION" is set', async t => {
+  const {cwd} = await gitRepo();
+
+  t.is(
+    await getAuthUrl({
+      cwd,
+      env: {...env, GITHUB_ACTION: 'foo', GITHUB_TOKEN: 'token'},
+      options: {branch: 'master', repositoryUrl: 'git@host.null:owner/repo.git'},
+    }),
+    'https://x-access-token:token@host.null/owner/repo.git'
+  );
+});
+
 test('Handle "https" URL with group and subgroup, with "GIT_CREDENTIALS"', async t => {
   const {cwd} = await gitRepo();
 


### PR DESCRIPTION
As mentioned in a comment at https://github.com/semantic-release/github/issues/182#issuecomment-523257373, the fix for GitHub Actions support (semantic-release/semantic-release#1194) that was made in master as part of semantic-release/semantic-release#1197 hasn't yet made it to the `beta` branch as of v16.0.0-beta.22. This PR adds the fix to the `beta` branch with the necessary minor changes since these files have slightly diverged.

I tested this and demonstrated the fix working at https://github.com/activescott/agentmarkdown/runs/198973327#step:7:61 which is directly pulling it's semantic-release dependency from this PR's branch.