### PR TITLE
feat: add optional support for prereleases

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,11 @@ Usage:
     .option('p', {alias: 'plugins', describe: 'Plugins', ...stringList, group: 'Options'})
     .option('e', {alias: 'extends', describe: 'Shareable configurations', ...stringList, group: 'Options'})
     .option('ci', {describe: 'Toggle CI verifications', type: 'boolean', group: 'Options'})
-    .option('prereleases', { describe: 'Enable support for "pre[type]" release types', type: 'boolean', group: 'Options'})
+    .option('prereleases', {
+      describe: 'Enable support for "pre[type]" release types',
+      type: 'boolean',
+      group: 'Options',
+    })
     .option('verify-conditions', {...stringList, group: 'Plugins'})
     .option('analyze-commits', {type: 'string', group: 'Plugins'})
     .option('verify-release', {...stringList, group: 'Plugins'})

--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,7 @@ Usage:
     .option('p', {alias: 'plugins', describe: 'Plugins', ...stringList, group: 'Options'})
     .option('e', {alias: 'extends', describe: 'Shareable configurations', ...stringList, group: 'Options'})
     .option('ci', {describe: 'Toggle CI verifications', type: 'boolean', group: 'Options'})
+    .option('prereleases', { describe: 'Enable support for "pre[type]" release types', type: 'boolean', group: 'Options'})
     .option('verify-conditions', {...stringList, group: 'Plugins'})
     .option('analyze-commits', {type: 'string', group: 'Plugins'})
     .option('verify-release', {...stringList, group: 'Plugins'})

--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -33,7 +33,10 @@ module.exports = async ({cwd, env, options: {tagFormat, prereleases}, logger}) =
   const tags = (await getTags({cwd, env}))
     .map(tag => ({gitTag: tag, version: (tag.match(tagRegexp) || new Array(2))[1]}))
     .filter(
-      tag => tag.version && semver.valid(semver.clean(tag.version)) && (prereleases || !semver.prerelease(semver.clean(tag.version)))
+      tag =>
+        tag.version &&
+        semver.valid(semver.clean(tag.version)) &&
+        (prereleases || !semver.prerelease(semver.clean(tag.version)))
     )
     .sort((a, b) => semver.rcompare(a.version, b.version));
 

--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -24,7 +24,7 @@ const {getTags, isRefInHistory, getTagHead} = require('./git');
  *
  * @return {Promise<LastRelease>} The last tagged release or `undefined` if none is found.
  */
-module.exports = async ({cwd, env, options: {tagFormat}, logger}) => {
+module.exports = async ({cwd, env, options: {tagFormat, prereleases}, logger}) => {
   // Generate a regex to parse tags formatted with `tagFormat`
   // by replacing the `version` variable in the template by `(.+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
@@ -33,7 +33,7 @@ module.exports = async ({cwd, env, options: {tagFormat}, logger}) => {
   const tags = (await getTags({cwd, env}))
     .map(tag => ({gitTag: tag, version: (tag.match(tagRegexp) || new Array(2))[1]}))
     .filter(
-      tag => tag.version && semver.valid(semver.clean(tag.version)) && !semver.prerelease(semver.clean(tag.version))
+      tag => tag.version && semver.valid(semver.clean(tag.version)) && (prereleases || !semver.prerelease(semver.clean(tag.version)))
     )
     .sort((a, b) => semver.rcompare(a.version, b.version));
 


### PR DESCRIPTION
# Feature proposal
The fix for #691 was to exclude pre-releases when determining the last release version. However, this breaks support for using semantic-release to also manage pre-releases.

The suggestion solution is to optionally allow inclusion of pre-releases when determining the last release version by adding a `--prereleases` flag to the cli.