### PR TITLE
docs: add leiningen-semantic-release to list

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -91,3 +91,7 @@
 - [semantic-release-github-pages](https://github.com/qiwi/semantic-release-gh-pages-plugin)
   - `verifyConditions`: Verify the presence of the auth token set via environment variables.
   - `publish`: Pushes commit to the documentation branch.
+- [leiningen-semantic-release](https://github.com/NoxHarmonium/leiningen-semantic-release)
+  - `verifyConditions`: Checks the project.clj is syntactically valid.
+  - `prepare`: Update the project.clj version and package the output jar file.
+  - `publish`: Publish the jar (and generated Maven metadata) to a maven repository (or clojars).


### PR DESCRIPTION
I was recently looking for a plugin for [leiningen](https://leiningen.org/) projects.

I couldn't find one so I've put one together at https://github.com/NoxHarmonium/leiningen-semantic-release

It's fully tested using the https://github.com/NoxHarmonium/leiningen-semantic-release-test-clojars sample project.

I thought adding it to the community plugins list might save people some time!

Let me know if there is anything else I need to do, or any suggestions for improvements to the plugin that need to be done to get added here.

Thanks!