### PR TITLE
docs: limit list of suggested tools for commit linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This removes the immediate connection between human emotions and version numbers
 
 By default **semantic-release** uses [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines). The commit message format can be changed with the [`preset` or `config` options](docs/usage/configuration.md#options) of the [@semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer#options) and [@semantic-release/release-notes-generator](https://github.com/semantic-release/release-notes-generator#options) plugins.
 
-Tools such as [commitizen](https://github.com/commitizen/cz-cli), [commitlint](https://github.com/conventional-changelog/commitlint) or [semantic-git-commit-cli](https://github.com/JPeer264/node-semantic-git-commit-cli) can be used to help contributors and enforce valid commit messages.
+Tools such as [commitizen](https://github.com/commitizen/cz-cli) or [commitlint](https://github.com/conventional-changelog/commitlint) can be used to help contributors and enforce valid commit messages.
 
 Here is an example of the release type that will be done based on a commit messages:
 


### PR DESCRIPTION
The goal here is to give a few example of the most popular tools (with a lot of GitHub stars) not to be exhaustive nor to endorse any tool, nor being used to promote a tool.

Fix #1184