### PR TITLE
docs: remove unnecessary apostrophe

### DIFF
--- a/docs/support/FAQ.md
+++ b/docs/support/FAQ.md
@@ -141,11 +141,11 @@ See the [`@semantic-release/npm`](https://github.com/semantic-release/npm#semant
 
 If you have introduced a breaking bug in a release you have 2 options:
 - If you have a fix immediately ready, commit and push it (or merge it via a pull request) to the release branch
-- Otherwise [revert the commit](https://git-scm.com/docs/git-revert) that introduced the bug and push the revert commit (or merge it via a pull request) to the release branch
+- Otherwise, [revert the commit](https://git-scm.com/docs/git-revert) that introduced the bug and push the revert commit (or merge it via a pull request) to the release branch
 
-In both cases **semantic-release** will publish a new release, so your package users' will get the fixed/reverted version.
+In both cases **semantic-release** will publish a new release, so your package users will get the fixed/reverted version.
 
-Depending on the package manager you are using, you might be able to un-publish or deprecate a release, in order to prevent users from downloading it by accident. For example npm allows you to [un-publish](https://docs.npmjs.com/cli/unpublish) [within 72 hours](https://www.npmjs.com/policies/unpublish) after releasing. You may also [deprecate](https://docs.npmjs.com/cli/deprecate) a release if you would rather avoid un-publishing.
+Depending on the package manager you are using, you might be able to un-publish or deprecate a release, in order to prevent users from downloading it by accident. For example, npm allows you to [un-publish](https://docs.npmjs.com/cli/unpublish) [within 72 hours](https://www.npmjs.com/policies/unpublish) after release. You may also [deprecate](https://docs.npmjs.com/cli/deprecate) a release if you would rather avoid un-publishing.
 
 In any case **do not remove the Git tag associated with the buggy version**, otherwise **semantic-release** will later try to republish that version. Publishing a version after un-publishing is not supported by most package managers.
 


### PR DESCRIPTION
- remove unnecessarily apostrophe in FAQ "how to revert section"
- improve punctuation of the how-to revert a release section