### PR TITLE
feat: add ability to filter commits by path

### DIFF
--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -9,7 +9,7 @@ const debug = require('debug')('semantic-release:get-commits');
  *
  * @return {Promise<Array<Object>>} The list of commits on the branch `branch` since the last release.
  */
-module.exports = async ({cwd, env, lastRelease: {gitHead}, logger}) => {
+module.exports = async ({cwd, env, lastRelease: {gitHead}, logger, commitPaths}) => {
   if (gitHead) {
     debug('Use gitHead: %s', gitHead);
   } else {
@@ -18,7 +18,7 @@ module.exports = async ({cwd, env, lastRelease: {gitHead}, logger}) => {
 
   Object.assign(gitLogParser.fields, {hash: 'H', message: 'B', gitTags: 'd', committerDate: {key: 'ci', type: Date}});
   const commits = (await getStream.array(
-    gitLogParser.parse({_: `${gitHead ? gitHead + '..' : ''}HEAD`}, {cwd, env: {...process.env, ...env}})
+    gitLogParser.parse({ _: [`${gitHead ? gitHead + '..' : ''}HEAD`,  ...(commitPaths ? ['--', ...commitPaths] : '')]}, {cwd, env: {...process.env, ...env}})
   )).map(commit => {
     commit.message = commit.message.trim();
     commit.gitTags = commit.gitTags.trim();

--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -16,9 +16,17 @@ module.exports = async ({cwd, env, lastRelease: {gitHead}, logger, commitPaths})
     logger.log('No previous release found, retrieving all commits');
   }
 
-  Object.assign(gitLogParser.fields, {hash: 'H', message: 'B', gitTags: 'd', committerDate: {key: 'ci', type: Date}});
+  Object.assign(gitLogParser.fields, {
+    hash: 'H',
+    message: 'B',
+    gitTags: 'd',
+    committerDate: {key: 'ci', type: Date},
+  });
   const commits = (await getStream.array(
-    gitLogParser.parse({ _: [`${gitHead ? gitHead + '..' : ''}HEAD`,  ...(commitPaths ? ['--', ...commitPaths] : '')]}, {cwd, env: {...process.env, ...env}})
+    gitLogParser.parse(
+      {_: [`${gitHead ? gitHead + '..' : ''}HEAD`, ...(commitPaths ? ['--', ...commitPaths] : [])]},
+      {cwd, env: {...process.env, ...env}}
+    )
   )).map(commit => {
     commit.message = commit.message.trim();
     commit.gitTags = commit.gitTags.trim();


### PR DESCRIPTION
* adds an optional parameter commitPaths that can be defined as an array of strings. This will be used to filter commit messages similar to git log -- \<paths\>
