### PR TITLE
perf: use `git tag --merge <branch>` to filter tags present in a branch history

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ After running the tests, the command `semantic-release` will execute the followi
 | Publish           | Publish the release.                                                                                                            |
 | Notify            | Notify of new releases or errors.                                                                                               |
 
+## Requirements
+
+In order to use **semantic-release** you need:
+- To host your code in a [Git repository](https://git-scm.com)
+- Use a Continuous Integration service that allows you to [securely set up credentials](docs/usage/ci-configuration.md#authentication)
+- Git CLI version [2.7.1 or higher](docs/support/FAQ.md#why-does-semantic-release-require-git-version--271) installed in your Continuous Integration environment
+- [Node.js](https://nodejs.org) version [8.16.0 or higher](docs/support/FAQ.md#why-does-semantic-release-require-node-version--816) installed in your Continuous Integration environment
+
 ## Documentation
 
 - Usage

--- a/bin/semantic-release.js
+++ b/bin/semantic-release.js
@@ -10,7 +10,7 @@ var execa = require('execa');
 var findVersions = require('find-versions');
 var pkg = require('../package.json');
 
-var MIN_GIT_VERSION = '2.0.0';
+var MIN_GIT_VERSION = '2.7.1';
 
 if (!semver.satisfies(process.version, pkg.engines.node)) {
   console.error(

--- a/docs/support/FAQ.md
+++ b/docs/support/FAQ.md
@@ -238,6 +238,10 @@ In addition the [verify conditions step](../../README.md#release-steps) verifies
 
 See [Node version requirement](./node-version.md#node-version-requirement) for more details and solutions.
 
+## Why does semantic-release require Git version >= 2.7.1?
+
+**semantic-release** uses Git CLI commands to read information about the repository such as branches, commit history and tags. Certain commands and options (such as [the `--merged` option of the `git tag` command](https://git-scm.com/docs/git-tag/2.7.0#git-tag---no-mergedltcommitgt) or bug fixes related to `git ls-files`) used by **semantic-release** are only available in Git version 2.7.1 and higher.
+
 ## What is npx?
 
 [`npx`](https://www.npmjs.com/package/npx) – short for "npm exec" – is a CLI to find and execute npm binaries within the local `node_modules` folder or in the $PATH. If a binary can't be located npx will download the required package and execute it from its cache location.

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ async function run(context, plugins) {
       throw error;
     }
   } catch (error) {
-    logger.error(`The command "${error.cmd}" failed with the error message ${error.stderr}.`);
+    logger.error(`The command "${error.command}" failed with the error message ${error.stderr}.`);
     throw getError('EGITNOPERMISSION', context);
   }
 

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -25,7 +25,7 @@ module.exports = async ({cwd, env, options: {tagFormat}}, branches) => {
       const branchTags = await pReduce(
         tags,
         async (tags, {gitTag, ...rest}) =>
-          (await isRefInHistory(gitTag, branch.name, true, {cwd, env}))
+          (await isRefInHistory(gitTag, branch.name, {cwd, env}))
             ? [...tags, {...rest, gitTag, gitHead: await getTagHead(gitTag, {cwd, env})}]
             : tags,
         []

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -2,7 +2,7 @@ const {template, escapeRegExp} = require('lodash');
 const semver = require('semver');
 const pReduce = require('p-reduce');
 const debug = require('debug')('semantic-release:get-tags');
-const {getTags, isRefInHistory, getTagHead} = require('../../lib/git');
+const {getTags, getTagHead} = require('../../lib/git');
 
 module.exports = async ({cwd, env, options: {tagFormat}}, branches) => {
   // Generate a regex to parse tags formatted with `tagFormat`
@@ -10,25 +10,18 @@ module.exports = async ({cwd, env, options: {tagFormat}}, branches) => {
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
   const tagRegexp = `^${escapeRegExp(template(tagFormat)({version: ' '})).replace(' ', '(.[^@]+)@?(.+)?')}`;
-  const tags = (await getTags({cwd, env}))
-    .map(tag => {
-      const [, version, channel] = tag.match(tagRegexp) || [];
-      return {gitTag: tag, version, channel};
-    })
-    .filter(({version}) => version && semver.valid(semver.clean(version)));
-
-  debug('found tags: %o', tags);
 
   return pReduce(
     branches,
     async (branches, branch) => {
-      const branchTags = await pReduce(
-        tags,
-        async (tags, {gitTag, ...rest}) =>
-          (await isRefInHistory(gitTag, branch.name, {cwd, env}))
-            ? [...tags, {...rest, gitTag, gitHead: await getTagHead(gitTag, {cwd, env})}]
-            : tags,
-        []
+      const branchTags = await Promise.all(
+        (await getTags(branch.name, {cwd, env}))
+          .map(tag => {
+            const [, version, channel] = tag.match(tagRegexp) || [];
+            return {gitTag: tag, version, channel};
+          })
+          .filter(({version}) => version && semver.valid(semver.clean(version)))
+          .map(async ({gitTag, ...rest}) => ({gitTag, gitHead: await getTagHead(gitTag, {cwd, env}), ...rest}))
       );
 
       debug('found tags for branch %s: %o', branch.name, branchTags);

--- a/lib/git.js
+++ b/lib/git.js
@@ -22,15 +22,16 @@ async function getTagHead(tagName, execaOpts) {
 }
 
 /**
- * Get all the repository tags.
+ * Get all the tags for a given branch.
  *
+ * @param {String} branch The branch for which to retrieve the tags.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
  * @return {Array<String>} List of git tags.
  * @throws {Error} If the `git` command fails.
  */
-async function getTags(execaOpts) {
-  return (await execa('git', ['tag'], execaOpts)).stdout
+async function getTags(branch, execaOpts) {
+  return (await execa('git', ['tag', '--merged', branch], execaOpts)).stdout
     .split('\n')
     .map(tag => tag.trim())
     .filter(Boolean);

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,4 +1,3 @@
-const {matches, pick, memoize} = require('lodash');
 const gitLogParser = require('git-log-parser');
 const getStream = require('get-stream');
 const execa = require('execa');
@@ -70,21 +69,16 @@ async function getBranches(repositoryUrl, execaOpts) {
     .filter(Boolean);
 }
 
-const getBranchCommits = memoize((branch, execaOpts) =>
-  getStream.array(gitLogParser.parse({_: branch}, {cwd: execaOpts.cwd, env: {...process.env, ...execaOpts.env}}))
-);
-
 /**
  * Verify if the `ref` is in the direct history of a given branch.
  *
  * @param {String} ref The reference to look for.
  * @param {String} branch The branch for which to check if the `ref` is in history.
- * @param {Boolean} findRebasedTags Weither consider in history tags associated with a commit that was rebased to another branch (i.e. GitHub Rebase and Merge feature).
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
  * @return {Boolean} `true` if the reference is in the history of the current branch, falsy otherwise.
  */
-async function isRefInHistory(ref, branch, findRebasedTags, execaOpts) {
+async function isRefInHistory(ref, branch, execaOpts) {
   if (!(await isRefExists(branch, execaOpts))) {
     return false;
   }
@@ -94,13 +88,6 @@ async function isRefInHistory(ref, branch, findRebasedTags, execaOpts) {
     return true;
   } catch (error) {
     if (error.exitCode === 1) {
-      if (findRebasedTags) {
-        const [tagCommit] = await getStream.array(
-          gitLogParser.parse({_: ref, n: '1'}, {cwd: execaOpts.cwd, env: {...process.env, ...execaOpts.env}})
-        );
-        return (await getBranchCommits(branch, execaOpts)).some(matches(pick(tagCommit, ['message', 'author'])));
-      }
-
       return false;
     }
 
@@ -288,7 +275,7 @@ async function verifyBranchName(branch, execaOpts) {
 async function isBranchUpToDate(repositoryUrl, branch, execaOpts) {
   const {stdout: remoteHead} = await execa('git', ['ls-remote', '--heads', repositoryUrl, branch], execaOpts);
   try {
-    return await isRefInHistory(remoteHead.match(/^(\w+)?/)[1], branch, false, execaOpts);
+    return await isRefInHistory(remoteHead.match(/^(\w+)?/)[1], branch, execaOpts);
   } catch (error) {
     debug(error);
   }

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -109,15 +109,15 @@ test('Return branches with and empty tags array if no valid tag is found', async
   await gitCommits(['Third'], {cwd});
   await gitTagVersion('v3.0', undefined, {cwd});
 
-  const result = await getTags({cwd, options: {tagFormat: `prefix@v\${version}`}}, [{name: 'master'}, {name: 'next'}]);
+  const result = await getTags({cwd, options: {tagFormat: `prefix@v\${version}`}}, [{name: 'master'}]);
 
-  t.deepEqual(result, [{name: 'master', tags: []}, {name: 'next', tags: []}]);
+  t.deepEqual(result, [{name: 'master', tags: []}]);
 });
 
 test('Return branches with and empty tags array if no valid tag is found in history of configured branches', async t => {
   const {cwd} = await gitRepo();
   await gitCommits(['First'], {cwd});
-  await gitCheckout('other-branch', true, {cwd});
+  await gitCheckout('next', true, {cwd});
   await gitCommits(['Second'], {cwd});
   await gitTagVersion('v1.0.0', undefined, {cwd});
   await gitTagVersion('v1.0.0@next', undefined, {cwd});

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -91,7 +91,7 @@ test('Fetch all tags on a detached head repository', async t => {
 
   await fetch(repositoryUrl, 'master', {cwd});
 
-  t.deepEqual((await getTags({cwd})).sort(), ['v1.0.0', 'v1.0.1', 'v1.1.0'].sort());
+  t.deepEqual((await getTags('master', {cwd})).sort(), ['v1.0.0', 'v1.0.1', 'v1.1.0'].sort());
 });
 
 test('Verify if the commit `sha` is in the direct history of the current branch', async t => {
@@ -243,7 +243,7 @@ test('Return falsy for invalid tag names', async t => {
 test('Throws error if obtaining the tags fails', async t => {
   const cwd = tempy.directory();
 
-  await t.throwsAsync(getTags({cwd}));
+  await t.throwsAsync(getTags('master', {cwd}));
 });
 
 test('Return "true" if repository is up to date', async t => {

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -105,10 +105,10 @@ test('Verify if the commit `sha` is in the direct history of the current branch'
   const otherCommits = await gitCommits(['Second'], {cwd});
   await gitCheckout('master', false, {cwd});
 
-  t.true(await isRefInHistory(commits[0].hash, 'master', false, {cwd}));
-  t.falsy(await isRefInHistory(otherCommits[0].hash, 'master', false, {cwd}));
-  t.falsy(await isRefInHistory(otherCommits[0].hash, 'missing-branch', false, {cwd}));
-  await t.throwsAsync(isRefInHistory('non-existant-sha', 'master', false, {cwd}));
+  t.true(await isRefInHistory(commits[0].hash, 'master', {cwd}));
+  t.falsy(await isRefInHistory(otherCommits[0].hash, 'master', {cwd}));
+  t.falsy(await isRefInHistory(otherCommits[0].hash, 'missing-branch', {cwd}));
+  await t.throwsAsync(isRefInHistory('non-existant-sha', 'master', {cwd}));
 });
 
 test('Verify if a branch exists', async t => {

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -256,16 +256,3 @@ export async function mergeFf(ref, execaOpts) {
 export async function rebase(ref, execaOpts) {
   await execa('git', ['rebase', ref], execaOpts);
 }
-
-export async function changeAuthor(sha, execaOpts) {
-  await execa(
-    'git',
-    [
-      'filter-branch',
-      '-f',
-      '--env-filter',
-      `if [[ "$GIT_COMMIT" = "${sha}" ]]; then export GIT_COMMITTER_NAME="New Author" GIT_COMMITTER_EMAIL="author@test.com"; fi`,
-    ],
-    execaOpts
-  );
-}


### PR DESCRIPTION
Fix #1345

Required for semantic-release/git#155