### PR TITLE
fix: call `getTagHead` only when necessary

### DIFF
--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -2,7 +2,7 @@ const {template, escapeRegExp} = require('lodash');
 const semver = require('semver');
 const pReduce = require('p-reduce');
 const debug = require('debug')('semantic-release:get-tags');
-const {getTags, getTagHead} = require('../../lib/git');
+const {getTags} = require('../../lib/git');
 
 module.exports = async ({cwd, env, options: {tagFormat}}, branches) => {
   // Generate a regex to parse tags formatted with `tagFormat`
@@ -21,7 +21,7 @@ module.exports = async ({cwd, env, options: {tagFormat}}, branches) => {
             return {gitTag: tag, version, channel};
           })
           .filter(({version}) => version && semver.valid(semver.clean(version)))
-          .map(async ({gitTag, ...rest}) => ({gitTag, gitHead: await getTagHead(gitTag, {cwd, env}), ...rest}))
+          .map(async ({gitTag, ...rest}) => ({gitTag, ...rest}))
       );
 
       debug('found tags for branch %s: %o', branch.name, branchTags);

--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -7,7 +7,10 @@ const {makeTag} = require('./utils');
  *
  * @typedef {Object} LastRelease
  * @property {string} version The version number of the last release.
- * @property {string} [gitHead] The Git reference used to make the last release.
+ * @property {string} gitHead The Git reference used to make the last release.
+ * @property {string} gitTag The git tag associated with the last release.
+ * @property {string} channel The channel on which of the last release was published.
+ * @property {string} name The name of the last release.
  */
 
 /**
@@ -24,13 +27,13 @@ const {makeTag} = require('./utils');
  * @return {LastRelease} The last tagged release or empty object if none is found.
  */
 module.exports = ({branch, options: {tagFormat}}, {before} = {}) => {
-  const [{version, gitTag, gitHead, channel} = {}] = branch.tags
+  const [{version, gitTag, channel} = {}] = branch.tags
     .filter(tag => (branch.type === 'prerelease' && branch.channel === tag.channel) || !semver.prerelease(tag.version))
     .filter(tag => isUndefined(before) || semver.lt(tag.version, before))
     .sort((a, b) => semver.rcompare(a.version, b.version));
 
   if (gitTag) {
-    return {version, gitTag, gitHead, channel, name: makeTag(tagFormat, version)};
+    return {version, gitTag, channel, gitHead: gitTag, name: makeTag(tagFormat, version)};
   }
 
   return {};

--- a/lib/get-releases-to-add.js
+++ b/lib/get-releases-to-add.js
@@ -47,20 +47,20 @@ module.exports = context => {
             // Sort in ascending order to add the most recent release last
             .sort((a, b) => semver.compare(a.version, b.version))
             // Construct the last and next release to add to the building branch channel
-            .map(({version, gitHead, gitTag}) => {
+            .map(({version, gitTag}) => {
               const lastRelease = getLastRelease(context, {before: version});
               const type = lastRelease.version ? semverDiff(lastRelease.version, version) : 'major';
               const name = makeTag(tagFormat, version);
               return {
                 lastRelease,
-                currentRelease: {type, version, channel: higherBranch.channel, gitTag, name, gitHead},
+                currentRelease: {type, version, channel: higherBranch.channel, gitTag, name, gitHead: gitTag},
                 nextRelease: {
                   type,
                   version,
                   channel: branch.channel,
                   gitTag: makeTag(tagFormat, version, branch.channel),
                   name,
-                  gitHead,
+                  gitHead: gitTag,
                 },
               };
             }),

--- a/lib/git.js
+++ b/lib/git.js
@@ -14,11 +14,7 @@ Object.assign(gitLogParser.fields, {hash: 'H', message: 'B', gitTags: 'd', commi
  * @return {String} The commit sha of the tag in parameter or `null`.
  */
 async function getTagHead(tagName, execaOpts) {
-  try {
-    return (await execa('git', ['rev-list', '-1', tagName], execaOpts)).stdout;
-  } catch (error) {
-    debug(error);
-  }
+  return (await execa('git', ['rev-list', '-1', tagName], execaOpts)).stdout;
 }
 
 /**

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -20,9 +20,9 @@ test('Get the valid tags', async t => {
     {
       name: 'master',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[1].hash},
-        {gitTag: 'v2.0.0', version: '2.0.0', channel: undefined, gitHead: commits[0].hash},
-        {gitTag: 'v3.0.0-beta.1', version: '3.0.0-beta.1', channel: undefined, gitHead: commits[3].hash},
+        {gitTag: 'v1.0.0', version: '1.0.0', channel: undefined},
+        {gitTag: 'v2.0.0', version: '2.0.0', channel: undefined},
+        {gitTag: 'v3.0.0-beta.1', version: '3.0.0-beta.1', channel: undefined},
       ],
     },
   ]);
@@ -55,30 +55,30 @@ test('Get the valid tags from multiple branches', async t => {
     {
       name: '1.x',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[0].hash},
-        {gitTag: 'v1.0.0@1.x', version: '1.0.0', channel: '1.x', gitHead: commits[0].hash},
-        {gitTag: 'v1.1.0', version: '1.1.0', channel: undefined, gitHead: commits[1].hash},
-        {gitTag: 'v1.1.0@1.x', version: '1.1.0', channel: '1.x', gitHead: commits[1].hash},
+        {gitTag: 'v1.0.0', version: '1.0.0', channel: undefined},
+        {gitTag: 'v1.0.0@1.x', version: '1.0.0', channel: '1.x'},
+        {gitTag: 'v1.1.0', version: '1.1.0', channel: undefined},
+        {gitTag: 'v1.1.0@1.x', version: '1.1.0', channel: '1.x'},
       ],
     },
     {
       name: 'master',
       tags: [
         ...result[0].tags,
-        {gitTag: 'v2.0.0', version: '2.0.0', channel: undefined, gitHead: commits[2].hash},
-        {gitTag: 'v2.0.0@next', version: '2.0.0', channel: 'next', gitHead: commits[2].hash},
+        {gitTag: 'v2.0.0', version: '2.0.0', channel: undefined},
+        {gitTag: 'v2.0.0@next', version: '2.0.0', channel: 'next'},
       ],
     },
     {
       name: 'next',
-      tags: [...result[1].tags, {gitTag: 'v3.0.0@next', version: '3.0.0', channel: 'next', gitHead: commits[3].hash}],
+      tags: [...result[1].tags, {gitTag: 'v3.0.0@next', version: '3.0.0', channel: 'next'}],
     },
   ]);
 });
 
 test('Match the tag name from the begining of the string and the channel from the last "@"', async t => {
   const {cwd} = await gitRepo();
-  const commits = await gitCommits(['First'], {cwd});
+  await gitCommits(['First'], {cwd});
   await gitTagVersion('prefix@v1.0.0', undefined, {cwd});
   await gitTagVersion('prefix@v1.0.0@next', undefined, {cwd});
   await gitTagVersion('prefix@v2.0.0', undefined, {cwd});
@@ -91,10 +91,10 @@ test('Match the tag name from the begining of the string and the channel from th
     {
       name: 'master',
       tags: [
-        {gitTag: 'prefix@v1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[0].hash},
-        {gitTag: 'prefix@v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: commits[0].hash},
-        {gitTag: 'prefix@v2.0.0', version: '2.0.0', channel: undefined, gitHead: commits[0].hash},
-        {gitTag: 'prefix@v2.0.0@next', version: '2.0.0', channel: 'next', gitHead: commits[0].hash},
+        {gitTag: 'prefix@v1.0.0', version: '1.0.0', channel: undefined},
+        {gitTag: 'prefix@v1.0.0@next', version: '1.0.0', channel: 'next'},
+        {gitTag: 'prefix@v2.0.0', version: '2.0.0', channel: undefined},
+        {gitTag: 'prefix@v2.0.0@next', version: '2.0.0', channel: 'next'},
       ],
     },
   ]);
@@ -134,23 +134,23 @@ test('Return branches with and empty tags array if no valid tag is found in hist
 
 test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
   const {cwd} = await gitRepo();
-  const commits = await gitCommits(['First'], {cwd});
+  await gitCommits(['First'], {cwd});
 
   await gitTagVersion('1.0.0', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `\${version}`}}, [{name: 'master'}]), [
-    {name: 'master', tags: [{gitTag: '1.0.0', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}]},
+    {name: 'master', tags: [{gitTag: '1.0.0', version: '1.0.0', channel: undefined}]},
   ]);
 
   await gitTagVersion('foo-1.0.0-bar', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `foo-\${version}-bar`}}, [{name: 'master'}]), [
-    {name: 'master', tags: [{gitTag: 'foo-1.0.0-bar', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}]},
+    {name: 'master', tags: [{gitTag: 'foo-1.0.0-bar', version: '1.0.0', channel: undefined}]},
   ]);
 
   await gitTagVersion('foo-v1.0.0-bar', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `foo-v\${version}-bar`}}, [{name: 'master'}]), [
     {
       name: 'master',
-      tags: [{gitTag: 'foo-v1.0.0-bar', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}],
+      tags: [{gitTag: 'foo-v1.0.0-bar', version: '1.0.0', channel: undefined}],
     },
   ]);
 
@@ -158,7 +158,7 @@ test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
   t.deepEqual(await getTags({cwd, options: {tagFormat: `(.+)/\${version}/(a-z)`}}, [{name: 'master'}]), [
     {
       name: 'master',
-      tags: [{gitTag: '(.+)/1.0.0/(a-z)', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}],
+      tags: [{gitTag: '(.+)/1.0.0/(a-z)', version: '1.0.0', channel: undefined}],
     },
   ]);
 
@@ -166,12 +166,12 @@ test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
   t.deepEqual(await getTags({cwd, options: {tagFormat: `2.0.0-\${version}-bar.1`}}, [{name: 'master'}]), [
     {
       name: 'master',
-      tags: [{gitTag: '2.0.0-1.0.0-bar.1', version: '1.0.0', channel: undefined, gitHead: commits[0].hash}],
+      tags: [{gitTag: '2.0.0-1.0.0-bar.1', version: '1.0.0', channel: undefined}],
     },
   ]);
 
   await gitTagVersion('3.0.0-bar.2', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `\${version}-bar.2`}}, [{name: 'master'}]), [
-    {name: 'master', tags: [{gitTag: '3.0.0-bar.2', version: '3.0.0', channel: undefined, gitHead: commits[0].hash}]},
+    {name: 'master', tags: [{gitTag: '3.0.0-bar.2', version: '3.0.0', channel: undefined}]},
   ]);
 });

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -6,16 +6,16 @@ test('Get the highest non-prerelease valid tag', t => {
     branch: {
       name: 'master',
       tags: [
-        {version: '2.0.0', gitTag: 'v2.0.0', gitHead: '222'},
-        {version: '1.0.0', gitTag: 'v1.0.0', gitHead: '111'},
-        {version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: '333'},
+        {version: '2.0.0', gitTag: 'v2.0.0', gitHead: 'v2.0.0'},
+        {version: '1.0.0', gitTag: 'v1.0.0', gitHead: 'v1.0.0'},
+        {version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: 'v3.0.0-beta.1@beta'},
       ],
       type: 'release',
     },
     options: {tagFormat: `v\${version}`},
   });
 
-  t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: '222', channel: undefined});
+  t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: 'v2.0.0', channel: undefined});
 });
 
 test('Get the highest prerelease valid tag, ignoring other tags from other prerelease channels', t => {
@@ -25,9 +25,9 @@ test('Get the highest prerelease valid tag, ignoring other tags from other prere
       prerelease: 'beta',
       channel: 'beta',
       tags: [
-        {version: '1.0.0-beta.1', gitTag: 'v1.0.0-beta.1@beta', gitHead: '111', channel: 'beta'},
-        {version: '1.0.0-beta.2', gitTag: 'v1.0.0-beta.2@beta', gitHead: '222', channel: 'beta'},
-        {version: '1.0.0-alpha.1', gitTag: 'v1.0.0-alpha.1@alpha', gitHead: '333', channel: 'alpha'},
+        {version: '1.0.0-beta.1', gitTag: 'v1.0.0-beta.1@beta', gitHead: 'v1.0.0-beta.1@beta', channel: 'beta'},
+        {version: '1.0.0-beta.2', gitTag: 'v1.0.0-beta.2@beta', gitHead: 'v1.0.0-beta.2@beta', channel: 'beta'},
+        {version: '1.0.0-alpha.1', gitTag: 'v1.0.0-alpha.1@alpha', gitHead: 'v1.0.0-alpha.1@alpha', channel: 'alpha'},
       ],
       type: 'prerelease',
     },
@@ -38,7 +38,7 @@ test('Get the highest prerelease valid tag, ignoring other tags from other prere
     version: '1.0.0-beta.2',
     gitTag: 'v1.0.0-beta.2@beta',
     name: 'v1.0.0-beta.2',
-    gitHead: '222',
+    gitHead: 'v1.0.0-beta.2@beta',
     channel: 'beta',
   });
 });
@@ -47,7 +47,7 @@ test('Return empty object if no valid tag is found', t => {
   const result = getLastRelease({
     branch: {
       name: 'master',
-      tags: [{version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: '111'}],
+      tags: [{version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: 'v3.0.0-beta.1@beta'}],
       type: 'release',
     },
     options: {tagFormat: `v\${version}`},
@@ -63,11 +63,11 @@ test('Get the highest non-prerelease valid tag before a certain version', t => {
         name: 'master',
         channel: undefined,
         tags: [
-          {version: '2.0.0', gitTag: 'v2.0.0', gitHead: '333'},
-          {version: '1.0.0', gitTag: 'v1.0.0', gitHead: '111'},
-          {version: '2.0.0-beta.1', gitTag: 'v2.0.0-beta.1@beta', gitHead: '222'},
-          {version: '2.1.0', gitTag: 'v2.1.0', gitHead: '444'},
-          {version: '2.1.1', gitTag: 'v2.1.1', gitHead: '555'},
+          {version: '2.0.0', gitTag: 'v2.0.0', gitHead: 'v2.0.0'},
+          {version: '1.0.0', gitTag: 'v1.0.0', gitHead: 'v1.0.0'},
+          {version: '2.0.0-beta.1', gitTag: 'v2.0.0-beta.1@beta', gitHead: 'v2.0.0-beta.1@beta'},
+          {version: '2.1.0', gitTag: 'v2.1.0', gitHead: 'v2.1.0'},
+          {version: '2.1.1', gitTag: 'v2.1.1', gitHead: 'v2.1.1'},
         ],
         type: 'release',
       },
@@ -76,5 +76,5 @@ test('Get the highest non-prerelease valid tag before a certain version', t => {
     {before: '2.1.0'}
   );
 
-  t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: '333', channel: undefined});
+  t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: 'v2.0.0', channel: undefined});
 });

--- a/test/get-releases-to-add.test.js
+++ b/test/get-releases-to-add.test.js
@@ -9,12 +9,12 @@ test('Return versions merged from release to maintenance branch, excluding lower
       type: 'maintenance',
       mergeRange: '>=2.0.0 <3.0.0',
       tags: [
-        {gitTag: 'v2.0.0@2.x', version: '2.0.0', channel: '2.x', gitHead: '111'},
-        {gitTag: 'v2.0.0', version: '2.0.0', gitHead: '111'},
-        {gitTag: 'v2.1.0', version: '2.1.0', gitHead: '222'},
-        {gitTag: 'v2.1.1', version: '2.1.1', gitHead: '333'},
-        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '444'},
-        {gitTag: 'v1.1.0', version: '1.1.0', gitHead: '555'},
+        {gitTag: 'v2.0.0@2.x', version: '2.0.0', channel: '2.x'},
+        {gitTag: 'v2.0.0', version: '2.0.0'},
+        {gitTag: 'v2.1.0', version: '2.1.0'},
+        {gitTag: 'v2.1.1', version: '2.1.1'},
+        {gitTag: 'v1.0.0', version: '1.0.0'},
+        {gitTag: 'v1.1.0', version: '1.1.0'},
       ],
     },
     branches: [{name: '2.x', channel: '2.x'}, {name: 'master'}],
@@ -23,14 +23,14 @@ test('Return versions merged from release to maintenance branch, excluding lower
 
   t.deepEqual(result, [
     {
-      lastRelease: {version: '2.0.0', channel: '2.x', gitTag: 'v2.0.0@2.x', name: 'v2.0.0', gitHead: '111'},
+      lastRelease: {version: '2.0.0', channel: '2.x', gitTag: 'v2.0.0@2.x', name: 'v2.0.0', gitHead: 'v2.0.0@2.x'},
       currentRelease: {
         type: 'minor',
         version: '2.1.0',
         channel: undefined,
         gitTag: 'v2.1.0',
         name: 'v2.1.0',
-        gitHead: '222',
+        gitHead: 'v2.1.0',
       },
       nextRelease: {
         type: 'minor',
@@ -38,18 +38,18 @@ test('Return versions merged from release to maintenance branch, excluding lower
         channel: '2.x',
         gitTag: 'v2.1.0@2.x',
         name: 'v2.1.0',
-        gitHead: '222',
+        gitHead: 'v2.1.0',
       },
     },
     {
-      lastRelease: {version: '2.1.0', channel: undefined, gitTag: 'v2.1.0', name: 'v2.1.0', gitHead: '222'},
+      lastRelease: {version: '2.1.0', channel: undefined, gitTag: 'v2.1.0', name: 'v2.1.0', gitHead: 'v2.1.0'},
       currentRelease: {
         type: 'patch',
         version: '2.1.1',
         channel: undefined,
         gitTag: 'v2.1.1',
         name: 'v2.1.1',
-        gitHead: '333',
+        gitHead: 'v2.1.1',
       },
       nextRelease: {
         type: 'patch',
@@ -57,7 +57,7 @@ test('Return versions merged from release to maintenance branch, excluding lower
         channel: '2.x',
         gitTag: 'v2.1.1@2.x',
         name: 'v2.1.1',
-        gitHead: '333',
+        gitHead: 'v2.1.1',
       },
     },
   ]);
@@ -68,10 +68,10 @@ test('Return versions merged between release branches', t => {
     branch: {
       name: 'master',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
-        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'},
-        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next', gitHead: '222'},
-        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channel: 'next-major', gitHead: '333'},
+        {gitTag: 'v1.0.0', version: '1.0.0'},
+        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next'},
+        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next'},
+        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channel: 'next-major'},
       ],
     },
     branches: [{name: 'master'}, {name: 'next', channel: 'next'}, {name: 'next-major', channel: 'next-major'}],
@@ -80,14 +80,14 @@ test('Return versions merged between release branches', t => {
 
   t.deepEqual(result, [
     {
-      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: '111'},
+      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: 'v1.0.0'},
       currentRelease: {
         type: 'minor',
         version: '1.1.0',
         channel: 'next',
         gitTag: 'v1.1.0@next',
         name: 'v1.1.0',
-        gitHead: '222',
+        gitHead: 'v1.1.0@next',
       },
       nextRelease: {
         type: 'minor',
@@ -95,18 +95,18 @@ test('Return versions merged between release branches', t => {
         channel: undefined,
         gitTag: 'v1.1.0',
         name: 'v1.1.0',
-        gitHead: '222',
+        gitHead: 'v1.1.0@next',
       },
     },
     {
-      lastRelease: {version: '1.1.0', gitTag: 'v1.1.0@next', name: 'v1.1.0', gitHead: '222', channel: 'next'},
+      lastRelease: {version: '1.1.0', gitTag: 'v1.1.0@next', name: 'v1.1.0', gitHead: 'v1.1.0@next', channel: 'next'},
       currentRelease: {
         type: 'major',
         version: '2.0.0',
         channel: 'next-major',
         gitTag: 'v2.0.0@next-major',
         name: 'v2.0.0',
-        gitHead: '333',
+        gitHead: 'v2.0.0@next-major',
       },
       nextRelease: {
         type: 'major',
@@ -114,7 +114,7 @@ test('Return versions merged between release branches', t => {
         channel: undefined,
         gitTag: 'v2.0.0',
         name: 'v2.0.0',
-        gitHead: '333',
+        gitHead: 'v2.0.0@next-major',
       },
     },
   ]);
@@ -125,10 +125,10 @@ test('Return releases sorted by ascending order', t => {
     branch: {
       name: 'master',
       tags: [
-        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channel: 'next-major', gitHead: '333'},
-        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next', gitHead: '222'},
-        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
-        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'},
+        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channel: 'next-major'},
+        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next'},
+        {gitTag: 'v1.0.0', version: '1.0.0'},
+        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next'},
       ],
     },
     branches: [{name: 'master'}, {name: 'next', channel: 'next'}, {name: 'next-major', channel: 'next-major'}],
@@ -137,14 +137,14 @@ test('Return releases sorted by ascending order', t => {
 
   t.deepEqual(result, [
     {
-      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: '111'},
+      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: 'v1.0.0'},
       currentRelease: {
         type: 'minor',
         version: '1.1.0',
         channel: 'next',
         gitTag: 'v1.1.0@next',
         name: 'v1.1.0',
-        gitHead: '222',
+        gitHead: 'v1.1.0@next',
       },
       nextRelease: {
         type: 'minor',
@@ -152,18 +152,18 @@ test('Return releases sorted by ascending order', t => {
         channel: undefined,
         gitTag: 'v1.1.0',
         name: 'v1.1.0',
-        gitHead: '222',
+        gitHead: 'v1.1.0@next',
       },
     },
     {
-      lastRelease: {version: '1.1.0', gitTag: 'v1.1.0@next', name: 'v1.1.0', gitHead: '222', channel: 'next'},
+      lastRelease: {version: '1.1.0', gitTag: 'v1.1.0@next', name: 'v1.1.0', gitHead: 'v1.1.0@next', channel: 'next'},
       currentRelease: {
         type: 'major',
         version: '2.0.0',
         channel: 'next-major',
         gitTag: 'v2.0.0@next-major',
         name: 'v2.0.0',
-        gitHead: '333',
+        gitHead: 'v2.0.0@next-major',
       },
       nextRelease: {
         type: 'major',
@@ -171,7 +171,7 @@ test('Return releases sorted by ascending order', t => {
         channel: undefined,
         gitTag: 'v2.0.0',
         name: 'v2.0.0',
-        gitHead: '333',
+        gitHead: 'v2.0.0@next-major',
       },
     },
   ]);
@@ -179,7 +179,10 @@ test('Return releases sorted by ascending order', t => {
 
 test('No lastRelease', t => {
   const result = getReleasesToAdd({
-    branch: {name: 'master', tags: [{gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'}]},
+    branch: {
+      name: 'master',
+      tags: [{gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next'}],
+    },
     branches: [{name: 'master'}, {name: 'next', channel: 'next'}],
     options: {tagFormat: `v\${version}`},
   });
@@ -193,7 +196,7 @@ test('No lastRelease', t => {
         channel: 'next',
         gitTag: 'v1.0.0@next',
         name: 'v1.0.0',
-        gitHead: '111',
+        gitHead: 'v1.0.0@next',
       },
       nextRelease: {
         type: 'major',
@@ -201,7 +204,7 @@ test('No lastRelease', t => {
         channel: undefined,
         gitTag: 'v1.0.0',
         name: 'v1.0.0',
-        gitHead: '111',
+        gitHead: 'v1.0.0@next',
       },
     },
   ]);
@@ -212,10 +215,10 @@ test('Ignore pre-release versions', t => {
     branch: {
       name: 'master',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
-        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next', gitHead: '111'},
-        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next', gitHead: '222'},
-        {gitTag: 'v2.0.0-alpha.1@alpha', version: '2.0.0', channel: 'alpha', gitHead: '333'},
+        {gitTag: 'v1.0.0', version: '1.0.0'},
+        {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next'},
+        {gitTag: 'v1.1.0@next', version: '1.1.0', channel: 'next'},
+        {gitTag: 'v2.0.0-alpha.1@alpha', version: '2.0.0', channel: 'alpha'},
       ],
     },
     branches: [
@@ -228,14 +231,14 @@ test('Ignore pre-release versions', t => {
 
   t.deepEqual(result, [
     {
-      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: '111'},
+      lastRelease: {version: '1.0.0', channel: undefined, gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: 'v1.0.0'},
       currentRelease: {
         type: 'minor',
         version: '1.1.0',
         channel: 'next',
         gitTag: 'v1.1.0@next',
         name: 'v1.1.0',
-        gitHead: '222',
+        gitHead: 'v1.1.0@next',
       },
       nextRelease: {
         type: 'minor',
@@ -243,7 +246,7 @@ test('Ignore pre-release versions', t => {
         channel: undefined,
         gitTag: 'v1.1.0',
         name: 'v1.1.0',
-        gitHead: '222',
+        gitHead: 'v1.1.0@next',
       },
     },
   ]);
@@ -257,12 +260,12 @@ test('Exclude versions merged from release to maintenance branch if they have th
       type: 'maintenance',
       mergeRange: '>=2.0.0 <3.0.0',
       tags: [
-        {gitTag: 'v2.0.0', version: '2.0.0', gitHead: '111'},
-        {gitTag: 'v2.0.0', version: '2.0.0', gitHead: '111'},
-        {gitTag: 'v2.1.0', version: '2.1.0', gitHead: '222'},
-        {gitTag: 'v2.1.1', version: '2.1.1', gitHead: '333'},
-        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '444'},
-        {gitTag: 'v1.1.0', version: '1.1.0', gitHead: '555'},
+        {gitTag: 'v2.0.0', version: '2.0.0'},
+        {gitTag: 'v2.0.0', version: '2.0.0'},
+        {gitTag: 'v2.1.0', version: '2.1.0'},
+        {gitTag: 'v2.1.1', version: '2.1.1'},
+        {gitTag: 'v1.0.0', version: '1.0.0'},
+        {gitTag: 'v1.1.0', version: '1.1.0'},
       ],
     },
     branches: [{name: '2.x', channel: 'latest'}, {name: 'master', channel: 'latest'}],
@@ -278,9 +281,9 @@ test('Exclude versions merged between release branches if they have the same "ch
       name: 'master',
       channel: 'latest',
       tags: [
-        {gitTag: 'v1.0.0', channel: 'latest', version: '1.0.0', gitHead: '111'},
-        {gitTag: 'v1.1.0', channel: 'latest', version: '1.1.0', gitHead: '222'},
-        {gitTag: 'v2.0.0', channel: 'latest', version: '2.0.0', gitHead: '333'},
+        {gitTag: 'v1.0.0', channel: 'latest', version: '1.0.0'},
+        {gitTag: 'v1.1.0', channel: 'latest', version: '1.1.0'},
+        {gitTag: 'v2.0.0', channel: 'latest', version: '2.0.0'},
       ],
     },
     branches: [
@@ -300,9 +303,9 @@ test('Exclude versions merged between release branches if they all have "channel
       name: 'master',
       channel: false,
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', gitHead: '111'},
-        {gitTag: 'v1.1.0', version: '1.1.0', gitHead: '222'},
-        {gitTag: 'v2.0.0', version: '2.0.0', gitHead: '333'},
+        {gitTag: 'v1.0.0', version: '1.0.0'},
+        {gitTag: 'v1.1.0', version: '1.1.0'},
+        {gitTag: 'v2.0.0', version: '2.0.0'},
       ],
     },
     branches: [{name: 'master', channel: false}, {name: 'next', channel: false}, {name: 'next-major', channel: false}],

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -140,7 +140,7 @@ test('Get all branches', async t => {
   t.deepEqual((await getBranches(repositoryUrl, {cwd})).sort(), ['master', 'second-branch', 'third-branch'].sort());
 });
 
-test('Get the commit sha for a given tag or falsy if the tag does not exists', async t => {
+test('Get the commit sha for a given tag', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd} = await gitRepo();
   // Add commits to the master branch
@@ -149,7 +149,6 @@ test('Get the commit sha for a given tag or falsy if the tag does not exists', a
   await gitTagVersion('v1.0.0', undefined, {cwd});
 
   t.is(await getTagHead('v1.0.0', {cwd}), commits[0].hash);
-  t.falsy(await getTagHead('missing_tag', {cwd}));
 });
 
 test('Return git remote repository url from config', async t => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -96,7 +96,7 @@ test('Plugins are called with expected values', async t => {
       name: 'master',
       range: '>=1.0.0 <2.0.0',
       accept: ['patch', 'minor'],
-      tags: [{channel: 'next', gitTag: 'v1.0.0@next', version: '1.0.0', gitHead: commits[commits.length - 1].hash}],
+      tags: [{channel: 'next', gitTag: 'v1.0.0@next', version: '1.0.0'}],
       type: 'release',
     },
     {
@@ -104,7 +104,7 @@ test('Plugins are called with expected values', async t => {
       name: 'next',
       range: '>=2.0.0',
       accept: ['patch', 'minor', 'major'],
-      tags: [{channel: 'next', gitHead: commits[commits.length - 1].hash, gitTag: 'v1.0.0@next', version: '1.0.0'}],
+      tags: [{channel: 'next', gitTag: 'v1.0.0@next', version: '1.0.0'}],
       type: 'release',
     },
   ];


### PR DESCRIPTION
fix #1352