### PR TITLE
fix: update commit-analyzer dep version off errant publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "Pierre Vanduynslager (https://twitter.com/@pvdlg_)"
   ],
   "dependencies": {
-    "@semantic-release/commit-analyzer": "^7.0.0-beta",
+    "@semantic-release/commit-analyzer": "7.0.0-beta.6",
     "@semantic-release/error": "^2.2.0",
     "@semantic-release/github": "^5.6.0-beta",
     "@semantic-release/npm": "^6.0.0-beta",


### PR DESCRIPTION
Can't use `^7.0.0-beta.6` as it will still resolve to `7.0.0-beta-.2` which is the problem release.

More conversation about that here: https://github.com/semantic-release/semantic-release/pull/1361