### PR TITLE
feat: use Git notes to store the channels on which a version has been released

### DIFF
--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -1,34 +1,29 @@
-const {template, escapeRegExp, flatMap} = require('lodash');
+const {template, escapeRegExp} = require('lodash');
 const semver = require('semver');
 const pReduce = require('p-reduce');
 const debug = require('debug')('semantic-release:get-tags');
-const {getTags} = require('../../lib/git');
+const {getTags, getNote} = require('../../lib/git');
 
 module.exports = async ({cwd, env, options: {tagFormat}}, branches) => {
   // Generate a regex to parse tags formatted with `tagFormat`
   // by replacing the `version` variable in the template by `(.+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
-  const tagRegexp = `^${escapeRegExp(template(tagFormat)({version: ' '})).replace(' ', '(.[^@]+)@?(.+)?')}`;
+  const tagRegexp = `^${escapeRegExp(template(tagFormat)({version: ' '})).replace(' ', '(.+)')}`;
 
   return pReduce(
     branches,
     async (branches, branch) => {
-      const versions = (await getTags(branch.name, {cwd, env})).reduce((versions, tag) => {
-        const [, version, channel] = tag.match(tagRegexp) || [];
-        if (version && semver.valid(semver.clean(version))) {
-          return {
-            ...versions,
-            [version]: versions[version]
-              ? {...versions[version], channels: [...versions[version].channels, channel]}
-              : {gitTag: tag, version, channels: [channel]},
-          };
-        }
-
-        return versions;
-      }, {});
-
-      const branchTags = flatMap(versions);
+      const branchTags = await pReduce(
+        await getTags(branch.name, {cwd, env}),
+        async (branchTags, tag) => {
+          const [, version] = tag.match(tagRegexp) || [];
+          return version && semver.valid(semver.clean(version))
+            ? [...branchTags, {gitTag: tag, version, channels: (await getNote(tag, {cwd, env})).channels || [null]}]
+            : branchTags;
+        },
+        []
+      );
 
       debug('found tags for branch %s: %o', branch.name, branchTags);
       return [...branches, {...branch, tags: branchTags}];

--- a/lib/branches/index.js
+++ b/lib/branches/index.js
@@ -3,7 +3,7 @@ const AggregateError = require('aggregate-error');
 const pEachSeries = require('p-each-series');
 const DEFINITIONS = require('../definitions/branches');
 const getError = require('../get-error');
-const {fetch, verifyBranchName} = require('../git');
+const {fetch, fetchNotes, verifyBranchName} = require('../git');
 const expand = require('./expand');
 const getTags = require('./get-tags');
 const normalize = require('./normalize');
@@ -20,6 +20,8 @@ module.exports = async (repositoryUrl, context) => {
   await pEachSeries(remoteBranches, async ({name}) => {
     await fetch(repositoryUrl, name, {cwd, env});
   });
+
+  await fetchNotes(repositoryUrl, {cwd, env});
 
   const branches = await getTags(context, remoteBranches);
 

--- a/lib/definitions/constants.js
+++ b/lib/definitions/constants.js
@@ -14,6 +14,8 @@ const SECRET_REPLACEMENT = '[secure]';
 
 const SECRET_MIN_SIZE = 5;
 
+const GIT_NOTE_REF = 'semantic-release';
+
 module.exports = {
   RELEASE_TYPE,
   FIRST_RELEASE,
@@ -23,4 +25,5 @@ module.exports = {
   RELEASE_NOTES_SEPARATOR,
   SECRET_REPLACEMENT,
   SECRET_MIN_SIZE,
+  GIT_NOTE_REF,
 };

--- a/lib/get-release-to-add.js
+++ b/lib/get-release-to-add.js
@@ -23,12 +23,12 @@ module.exports = context => {
     .slice(branches.findIndex(({name}) => name === branch.name) + 1)
     // Exclude prerelease branches
     .filter(({type}) => type !== 'prerelease')
-    .map(({channel}) => channel);
+    .map(({channel}) => channel || null);
 
   const versiontoAdd = uniqBy(
     branch.tags.filter(
       ({channels, version}) =>
-        !channels.includes(branch.channel) &&
+        !channels.includes(branch.channel || null) &&
         intersection(channels, higherChannels).length > 0 &&
         (branch.type !== 'maintenance' || semver.gte(version, getLowerBound(branch.mergeRange)))
     ),
@@ -50,8 +50,8 @@ module.exports = context => {
       nextRelease: {
         type,
         version,
-        channel: branch.channel,
-        gitTag: makeTag(tagFormat, version, branch.channel),
+        channel: branch.channel || null,
+        gitTag: makeTag(tagFormat, version),
         name,
         gitHead: gitTag,
       },

--- a/lib/git.js
+++ b/lib/git.js
@@ -2,6 +2,7 @@ const gitLogParser = require('git-log-parser');
 const getStream = require('get-stream');
 const execa = require('execa');
 const debug = require('debug')('semantic-release:git');
+const {GIT_NOTE_REF} = require('./definitions/constants');
 
 Object.assign(gitLogParser.fields, {hash: 'H', message: 'B', gitTags: 'd', committerDate: {key: 'ci', type: Date}});
 
@@ -147,6 +148,27 @@ async function fetch(repositoryUrl, branch, execaOpts) {
 }
 
 /**
+ * Unshallow the git repository if necessary and fetch all the notes.
+ *
+ * @param {String} repositoryUrl The remote repository URL.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ */
+async function fetchNotes(repositoryUrl, execaOpts) {
+  try {
+    await execa(
+      'git',
+      ['fetch', '--unshallow', repositoryUrl, `+refs/notes/${GIT_NOTE_REF}:refs/notes/${GIT_NOTE_REF}`],
+      execaOpts
+    );
+  } catch (_) {
+    await execa('git', ['fetch', repositoryUrl, `+refs/notes/${GIT_NOTE_REF}:refs/notes/${GIT_NOTE_REF}`], {
+      ...execaOpts,
+      reject: false,
+    });
+  }
+}
+
+/**
  * Get the HEAD sha.
  *
  * @param {Object} [execaOpts] Options to pass to `execa`.
@@ -231,6 +253,18 @@ async function push(repositoryUrl, execaOpts) {
 }
 
 /**
+ * Push notes to the remote repository.
+ *
+ * @param {String} repositoryUrl The remote repository URL.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @throws {Error} if the push failed.
+ */
+async function pushNotes(repositoryUrl, execaOpts) {
+  await execa('git', ['push', repositoryUrl, `refs/notes/${GIT_NOTE_REF}`], execaOpts);
+}
+
+/**
  * Verify a tag name is a valid Git reference.
  *
  * @param {String} tagName the tag name to verify.
@@ -280,6 +314,38 @@ async function isBranchUpToDate(repositoryUrl, branch, execaOpts) {
   }
 }
 
+/**
+ * Get and parse the JSON note of a given reference.
+ *
+ * @param {String} ref The Git reference for which to retrieve the note.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @return {Object} the parsed JSON note if there is one, an empty object otherwise.
+ */
+async function getNote(ref, execaOpts) {
+  try {
+    return JSON.parse((await execa('git', ['notes', '--ref', GIT_NOTE_REF, 'show', ref], execaOpts)).stdout);
+  } catch (error) {
+    if (error.exitCode === 1) {
+      return {};
+    }
+
+    debug(error);
+    throw error;
+  }
+}
+
+/**
+ * Get and parse the JSON note of a given reference.
+ *
+ * @param {Object} note The object to save in the reference note.
+ * @param {String} ref The Git reference to add the note to.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ */
+async function addNote(note, ref, execaOpts) {
+  await execa('git', ['notes', '--ref', GIT_NOTE_REF, 'add', '-f', '-m', JSON.stringify(note), ref], execaOpts);
+}
+
 module.exports = {
   getTagHead,
   getTags,
@@ -288,13 +354,17 @@ module.exports = {
   isRefInHistory,
   isRefExists,
   fetch,
+  fetchNotes,
   getGitHead,
   repoUrl,
   isGitRepo,
   verifyAuth,
   tag,
   push,
+  pushNotes,
   verifyTagName,
   isBranchUpToDate,
   verifyBranchName,
+  getNote,
+  addNote,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,8 +67,8 @@ function getRange(min, max) {
   return `>=${min}${max ? ` <${max}` : ''}`;
 }
 
-function makeTag(tagFormat, version, channel) {
-  return template(tagFormat)({version: `${version}${channel ? `@${channel}` : ''}`});
+function makeTag(tagFormat, version) {
+  return template(tagFormat)({version});
 }
 
 function isSameChannel(channel, otherChannel) {

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import getTags from '../../lib/branches/get-tags';
-import {gitRepo, gitCommits, gitTagVersion, gitCheckout} from '../helpers/git-utils';
+import {gitRepo, gitCommits, gitTagVersion, gitCheckout, gitAddNote} from '../helpers/git-utils';
 
 test('Get the valid tags', async t => {
   const {cwd} = await gitRepo();
@@ -20,9 +20,9 @@ test('Get the valid tags', async t => {
     {
       name: 'master',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined]},
-        {gitTag: 'v2.0.0', version: '2.0.0', channels: [undefined]},
-        {gitTag: 'v3.0.0-beta.1', version: '3.0.0-beta.1', channels: [undefined]},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null]},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: [null]},
+        {gitTag: 'v3.0.0-beta.1', version: '3.0.0-beta.1', channels: [null]},
       ],
     },
   ]);
@@ -30,20 +30,21 @@ test('Get the valid tags', async t => {
 
 test('Get the valid tags from multiple branches', async t => {
   const {cwd} = await gitRepo();
-  const commits = await gitCommits(['First'], {cwd});
+  await gitCommits(['First'], {cwd});
   await gitTagVersion('v1.0.0', undefined, {cwd});
-  await gitTagVersion('v1.0.0@1.x', undefined, {cwd});
-  commits.push(...(await gitCommits(['Second'], {cwd})));
+  await gitAddNote(JSON.stringify({channels: [null, '1.x']}), 'v1.0.0', {cwd});
+  await gitCommits(['Second'], {cwd});
   await gitTagVersion('v1.1.0', undefined, {cwd});
-  await gitTagVersion('v1.1.0@1.x', undefined, {cwd});
+  await gitAddNote(JSON.stringify({channels: [null, '1.x']}), 'v1.1.0', {cwd});
   await gitCheckout('1.x', true, {cwd});
   await gitCheckout('master', false, {cwd});
-  commits.push(...(await gitCommits(['Third'], {cwd})));
+  await gitCommits(['Third'], {cwd});
   await gitTagVersion('v2.0.0', undefined, {cwd});
-  await gitTagVersion('v2.0.0@next', undefined, {cwd});
+  await gitAddNote(JSON.stringify({channels: [null, 'next']}), 'v2.0.0', {cwd});
   await gitCheckout('next', true, {cwd});
-  commits.push(...(await gitCommits(['Fourth'], {cwd})));
-  await gitTagVersion('v3.0.0@next', undefined, {cwd});
+  await gitCommits(['Fourth'], {cwd});
+  await gitTagVersion('v3.0.0', undefined, {cwd});
+  await gitAddNote(JSON.stringify({channels: ['next']}), 'v3.0.0', {cwd});
 
   const result = await getTags({cwd, options: {tagFormat: `v\${version}`}}, [
     {name: '1.x'},
@@ -55,39 +56,17 @@ test('Get the valid tags from multiple branches', async t => {
     {
       name: '1.x',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined, '1.x']},
-        {gitTag: 'v1.1.0', version: '1.1.0', channels: [undefined, '1.x']},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null, '1.x']},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: [null, '1.x']},
       ],
     },
     {
       name: 'master',
-      tags: [...result[0].tags, {gitTag: 'v2.0.0', version: '2.0.0', channels: [undefined, 'next']}],
+      tags: [...result[0].tags, {gitTag: 'v2.0.0', version: '2.0.0', channels: [null, 'next']}],
     },
     {
       name: 'next',
-      tags: [...result[1].tags, {gitTag: 'v3.0.0@next', version: '3.0.0', channels: ['next']}],
-    },
-  ]);
-});
-
-test('Match the tag name from the begining of the string and the channel from the last "@"', async t => {
-  const {cwd} = await gitRepo();
-  await gitCommits(['First'], {cwd});
-  await gitTagVersion('prefix@v1.0.0', undefined, {cwd});
-  await gitTagVersion('prefix@v1.0.0@next', undefined, {cwd});
-  await gitTagVersion('prefix@v2.0.0', undefined, {cwd});
-  await gitTagVersion('prefix@v2.0.0@next', undefined, {cwd});
-  await gitTagVersion('other-prefix@v3.0.0', undefined, {cwd});
-
-  const result = await getTags({cwd, options: {tagFormat: `prefix@v\${version}`}}, [{name: 'master'}]);
-
-  t.deepEqual(result, [
-    {
-      name: 'master',
-      tags: [
-        {gitTag: 'prefix@v1.0.0', version: '1.0.0', channels: [undefined, 'next']},
-        {gitTag: 'prefix@v2.0.0', version: '2.0.0', channels: [undefined, 'next']},
-      ],
+      tags: [...result[1].tags, {gitTag: 'v3.0.0', version: '3.0.0', channels: ['next']}],
     },
   ]);
 });
@@ -112,11 +91,13 @@ test('Return branches with and empty tags array if no valid tag is found in hist
   await gitCheckout('next', true, {cwd});
   await gitCommits(['Second'], {cwd});
   await gitTagVersion('v1.0.0', undefined, {cwd});
-  await gitTagVersion('v1.0.0@next', undefined, {cwd});
+  await gitAddNote(JSON.stringify({channels: [null, 'next']}), 'v1.0.0', {cwd});
+  await gitCommits(['Third'], {cwd});
   await gitTagVersion('v2.0.0', undefined, {cwd});
-  await gitTagVersion('v2.0.0@next', undefined, {cwd});
+  await gitAddNote(JSON.stringify({channels: [null, 'next']}), 'v2.0.0', {cwd});
+  await gitCommits(['Fourth'], {cwd});
   await gitTagVersion('v3.0.0', undefined, {cwd});
-  await gitTagVersion('v3.0.0@next', undefined, {cwd});
+  await gitAddNote(JSON.stringify({channels: [null, 'next']}), 'v3.0.0', {cwd});
   await gitCheckout('master', false, {cwd});
 
   const result = await getTags({cwd, options: {tagFormat: `prefix@v\${version}`}}, [{name: 'master'}, {name: 'next'}]);
@@ -133,19 +114,19 @@ test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
 
   await gitTagVersion('1.0.0', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `\${version}`}}, [{name: 'master'}]), [
-    {name: 'master', tags: [{gitTag: '1.0.0', version: '1.0.0', channels: [undefined]}]},
+    {name: 'master', tags: [{gitTag: '1.0.0', version: '1.0.0', channels: [null]}]},
   ]);
 
   await gitTagVersion('foo-1.0.0-bar', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `foo-\${version}-bar`}}, [{name: 'master'}]), [
-    {name: 'master', tags: [{gitTag: 'foo-1.0.0-bar', version: '1.0.0', channels: [undefined]}]},
+    {name: 'master', tags: [{gitTag: 'foo-1.0.0-bar', version: '1.0.0', channels: [null]}]},
   ]);
 
   await gitTagVersion('foo-v1.0.0-bar', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `foo-v\${version}-bar`}}, [{name: 'master'}]), [
     {
       name: 'master',
-      tags: [{gitTag: 'foo-v1.0.0-bar', version: '1.0.0', channels: [undefined]}],
+      tags: [{gitTag: 'foo-v1.0.0-bar', version: '1.0.0', channels: [null]}],
     },
   ]);
 
@@ -153,7 +134,7 @@ test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
   t.deepEqual(await getTags({cwd, options: {tagFormat: `(.+)/\${version}/(a-z)`}}, [{name: 'master'}]), [
     {
       name: 'master',
-      tags: [{gitTag: '(.+)/1.0.0/(a-z)', version: '1.0.0', channels: [undefined]}],
+      tags: [{gitTag: '(.+)/1.0.0/(a-z)', version: '1.0.0', channels: [null]}],
     },
   ]);
 
@@ -161,12 +142,12 @@ test('Get the highest valid tag corresponding to the "tagFormat"', async t => {
   t.deepEqual(await getTags({cwd, options: {tagFormat: `2.0.0-\${version}-bar.1`}}, [{name: 'master'}]), [
     {
       name: 'master',
-      tags: [{gitTag: '2.0.0-1.0.0-bar.1', version: '1.0.0', channels: [undefined]}],
+      tags: [{gitTag: '2.0.0-1.0.0-bar.1', version: '1.0.0', channels: [null]}],
     },
   ]);
 
   await gitTagVersion('3.0.0-bar.2', undefined, {cwd});
   t.deepEqual(await getTags({cwd, options: {tagFormat: `\${version}-bar.2`}}, [{name: 'master'}]), [
-    {name: 'master', tags: [{gitTag: '3.0.0-bar.2', version: '3.0.0', channels: [undefined]}]},
+    {name: 'master', tags: [{gitTag: '3.0.0-bar.2', version: '3.0.0', channels: [null]}]},
   ]);
 });

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -8,7 +8,7 @@ test('Get the highest non-prerelease valid tag', t => {
       tags: [
         {version: '2.0.0', gitTag: 'v2.0.0', gitHead: 'v2.0.0'},
         {version: '1.0.0', gitTag: 'v1.0.0', gitHead: 'v1.0.0'},
-        {version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: 'v3.0.0-beta.1@beta'},
+        {version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1', gitHead: 'v3.0.0-beta.1'},
       ],
       type: 'release',
     },
@@ -25,14 +25,9 @@ test('Get the highest prerelease valid tag, ignoring other tags from other prere
       prerelease: 'beta',
       channel: 'beta',
       tags: [
-        {version: '1.0.0-beta.1', gitTag: 'v1.0.0-beta.1@beta', gitHead: 'v1.0.0-beta.1@beta', channels: ['beta']},
-        {version: '1.0.0-beta.2', gitTag: 'v1.0.0-beta.2@beta', gitHead: 'v1.0.0-beta.2@beta', channels: ['beta']},
-        {
-          version: '1.0.0-alpha.1',
-          gitTag: 'v1.0.0-alpha.1@alpha',
-          gitHead: 'v1.0.0-alpha.1@alpha',
-          channels: ['alpha'],
-        },
+        {version: '1.0.0-beta.1', gitTag: 'v1.0.0-beta.1', gitHead: 'v1.0.0-beta.1', channels: ['beta']},
+        {version: '1.0.0-beta.2', gitTag: 'v1.0.0-beta.2', gitHead: 'v1.0.0-beta.2', channels: ['beta']},
+        {version: '1.0.0-alpha.1', gitTag: 'v1.0.0-alpha.1', gitHead: 'v1.0.0-alpha.1', channels: ['alpha']},
       ],
       type: 'prerelease',
     },
@@ -41,9 +36,9 @@ test('Get the highest prerelease valid tag, ignoring other tags from other prere
 
   t.deepEqual(result, {
     version: '1.0.0-beta.2',
-    gitTag: 'v1.0.0-beta.2@beta',
+    gitTag: 'v1.0.0-beta.2',
     name: 'v1.0.0-beta.2',
-    gitHead: 'v1.0.0-beta.2@beta',
+    gitHead: 'v1.0.0-beta.2',
     channels: ['beta'],
   });
 });
@@ -52,7 +47,7 @@ test('Return empty object if no valid tag is found', t => {
   const result = getLastRelease({
     branch: {
       name: 'master',
-      tags: [{version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1@beta', gitHead: 'v3.0.0-beta.1@beta'}],
+      tags: [{version: '3.0.0-beta.1', gitTag: 'v3.0.0-beta.1', gitHead: 'v3.0.0-beta.1'}],
       type: 'release',
     },
     options: {tagFormat: `v\${version}`},
@@ -70,7 +65,7 @@ test('Get the highest non-prerelease valid tag before a certain version', t => {
         tags: [
           {version: '2.0.0', gitTag: 'v2.0.0', gitHead: 'v2.0.0'},
           {version: '1.0.0', gitTag: 'v1.0.0', gitHead: 'v1.0.0'},
-          {version: '2.0.0-beta.1', gitTag: 'v2.0.0-beta.1@beta', gitHead: 'v2.0.0-beta.1@beta'},
+          {version: '2.0.0-beta.1', gitTag: 'v2.0.0-beta.1', gitHead: 'v2.0.0-beta.1'},
           {version: '2.1.0', gitTag: 'v2.1.0', gitHead: 'v2.1.0'},
           {version: '2.1.1', gitTag: 'v2.1.1', gitHead: 'v2.1.1'},
         ],

--- a/test/get-release-to-add.test.js
+++ b/test/get-release-to-add.test.js
@@ -9,12 +9,12 @@ test('Return versions merged from release to maintenance branch, excluding lower
       type: 'maintenance',
       mergeRange: '>=2.0.0 <3.0.0',
       tags: [
-        {gitTag: 'v2.0.0@2.x', version: '2.0.0', channels: ['2.x']},
-        {gitTag: 'v2.0.0', version: '2.0.0', channels: [undefined]},
-        {gitTag: 'v2.1.0', version: '2.1.0', channels: [undefined]},
-        {gitTag: 'v2.1.1', version: '2.1.1', channels: [undefined]},
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined]},
-        {gitTag: 'v1.1.0', version: '1.1.0', channels: [undefined]},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: ['2.x']},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: [null]},
+        {gitTag: 'v2.1.0', version: '2.1.0', channels: [null]},
+        {gitTag: 'v2.1.1', version: '2.1.1', channels: [null]},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null]},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: [null]},
       ],
     },
     branches: [{name: '2.x', channel: '2.x'}, {name: 'master'}],
@@ -22,11 +22,11 @@ test('Return versions merged from release to maintenance branch, excluding lower
   });
 
   t.deepEqual(result, {
-    lastRelease: {version: '2.1.0', channels: [undefined], gitTag: 'v2.1.0', name: 'v2.1.0', gitHead: 'v2.1.0'},
+    lastRelease: {version: '2.1.0', channels: [null], gitTag: 'v2.1.0', name: 'v2.1.0', gitHead: 'v2.1.0'},
     currentRelease: {
       type: 'patch',
       version: '2.1.1',
-      channels: [undefined],
+      channels: [null],
       gitTag: 'v2.1.1',
       name: 'v2.1.1',
       gitHead: 'v2.1.1',
@@ -35,7 +35,7 @@ test('Return versions merged from release to maintenance branch, excluding lower
       type: 'patch',
       version: '2.1.1',
       channel: '2.x',
-      gitTag: 'v2.1.1@2.x',
+      gitTag: 'v2.1.1',
       name: 'v2.1.1',
       gitHead: 'v2.1.1',
     },
@@ -47,9 +47,9 @@ test('Return versions merged between release branches', t => {
     branch: {
       name: 'master',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined, 'next']},
-        {gitTag: 'v1.1.0@next', version: '1.1.0', channels: ['next']},
-        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channels: ['next-major']},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null, 'next']},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: ['next']},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: ['next-major']},
       ],
     },
     branches: [{name: 'master'}, {name: 'next', channel: 'next'}, {name: 'next-major', channel: 'next-major'}],
@@ -59,26 +59,26 @@ test('Return versions merged between release branches', t => {
   t.deepEqual(result, {
     lastRelease: {
       version: '1.1.0',
-      gitTag: 'v1.1.0@next',
+      gitTag: 'v1.1.0',
       name: 'v1.1.0',
-      gitHead: 'v1.1.0@next',
+      gitHead: 'v1.1.0',
       channels: ['next'],
     },
     currentRelease: {
       type: 'major',
       version: '2.0.0',
       channels: ['next-major'],
-      gitTag: 'v2.0.0@next-major',
+      gitTag: 'v2.0.0',
       name: 'v2.0.0',
-      gitHead: 'v2.0.0@next-major',
+      gitHead: 'v2.0.0',
     },
     nextRelease: {
       type: 'major',
       version: '2.0.0',
-      channel: undefined,
+      channel: null,
       gitTag: 'v2.0.0',
       name: 'v2.0.0',
-      gitHead: 'v2.0.0@next-major',
+      gitHead: 'v2.0.0',
     },
   });
 });
@@ -88,10 +88,9 @@ test('Return releases sorted by ascending order', t => {
     branch: {
       name: 'master',
       tags: [
-        {gitTag: 'v2.0.0@next-major', version: '2.0.0', channels: ['next-major']},
-        {gitTag: 'v1.1.0@next', version: '1.1.0', channels: ['next']},
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined, 'next']},
-        // {gitTag: 'v1.0.0@next', version: '1.0.0', channel: 'next'},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: ['next-major']},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: ['next']},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null, 'next']},
       ],
     },
     branches: [{name: 'master'}, {name: 'next', channel: 'next'}, {name: 'next-major', channel: 'next-major'}],
@@ -99,22 +98,22 @@ test('Return releases sorted by ascending order', t => {
   });
 
   t.deepEqual(result, {
-    lastRelease: {version: '1.1.0', gitTag: 'v1.1.0@next', name: 'v1.1.0', gitHead: 'v1.1.0@next', channels: ['next']},
+    lastRelease: {version: '1.1.0', gitTag: 'v1.1.0', name: 'v1.1.0', gitHead: 'v1.1.0', channels: ['next']},
     currentRelease: {
       type: 'major',
       version: '2.0.0',
       channels: ['next-major'],
-      gitTag: 'v2.0.0@next-major',
+      gitTag: 'v2.0.0',
       name: 'v2.0.0',
-      gitHead: 'v2.0.0@next-major',
+      gitHead: 'v2.0.0',
     },
     nextRelease: {
       type: 'major',
       version: '2.0.0',
-      channel: undefined,
+      channel: null,
       gitTag: 'v2.0.0',
       name: 'v2.0.0',
-      gitHead: 'v2.0.0@next-major',
+      gitHead: 'v2.0.0',
     },
   });
 });
@@ -123,7 +122,7 @@ test('No lastRelease', t => {
   const result = getReleaseToAdd({
     branch: {
       name: 'master',
-      tags: [{gitTag: 'v1.0.0@next', version: '1.0.0', channels: ['next']}],
+      tags: [{gitTag: 'v1.0.0', version: '1.0.0', channels: ['next']}],
     },
     branches: [{name: 'master'}, {name: 'next', channel: 'next'}],
     options: {tagFormat: `v\${version}`},
@@ -135,17 +134,17 @@ test('No lastRelease', t => {
       type: 'major',
       version: '1.0.0',
       channels: ['next'],
-      gitTag: 'v1.0.0@next',
+      gitTag: 'v1.0.0',
       name: 'v1.0.0',
-      gitHead: 'v1.0.0@next',
+      gitHead: 'v1.0.0',
     },
     nextRelease: {
       type: 'major',
       version: '1.0.0',
-      channel: undefined,
+      channel: null,
       gitTag: 'v1.0.0',
       name: 'v1.0.0',
-      gitHead: 'v1.0.0@next',
+      gitHead: 'v1.0.0',
     },
   });
 });
@@ -155,9 +154,9 @@ test('Ignore pre-release versions', t => {
     branch: {
       name: 'master',
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined, 'next']},
-        {gitTag: 'v1.1.0@next', version: '1.1.0', channels: ['next']},
-        {gitTag: 'v2.0.0-alpha.1@alpha', version: '2.0.0-alpha.1', channels: ['alpha']},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null, 'next']},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: ['next']},
+        {gitTag: 'v2.0.0-alpha.1', version: '2.0.0-alpha.1', channels: ['alpha']},
       ],
     },
     branches: [
@@ -169,22 +168,22 @@ test('Ignore pre-release versions', t => {
   });
 
   t.deepEqual(result, {
-    lastRelease: {version: '1.0.0', channels: [undefined, 'next'], gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: 'v1.0.0'},
+    lastRelease: {version: '1.0.0', channels: [null, 'next'], gitTag: 'v1.0.0', name: 'v1.0.0', gitHead: 'v1.0.0'},
     currentRelease: {
       type: 'minor',
       version: '1.1.0',
       channels: ['next'],
-      gitTag: 'v1.1.0@next',
+      gitTag: 'v1.1.0',
       name: 'v1.1.0',
-      gitHead: 'v1.1.0@next',
+      gitHead: 'v1.1.0',
     },
     nextRelease: {
       type: 'minor',
       version: '1.1.0',
-      channel: undefined,
+      channel: null,
       gitTag: 'v1.1.0',
       name: 'v1.1.0',
-      gitHead: 'v1.1.0@next',
+      gitHead: 'v1.1.0',
     },
   });
 });
@@ -197,12 +196,12 @@ test('Exclude versions merged from release to maintenance branch if they have th
       type: 'maintenance',
       mergeRange: '>=2.0.0 <3.0.0',
       tags: [
-        {gitTag: 'v2.0.0', version: '2.0.0', channels: [undefined]},
-        {gitTag: 'v2.0.0', version: '2.0.0', channels: [undefined]},
-        {gitTag: 'v2.1.0', version: '2.1.0', channels: [undefined]},
-        {gitTag: 'v2.1.1', version: '2.1.1', channels: [undefined]},
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined]},
-        {gitTag: 'v1.1.0', version: '1.1.0', channels: [undefined]},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: [null]},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: [null]},
+        {gitTag: 'v2.1.0', version: '2.1.0', channels: [null]},
+        {gitTag: 'v2.1.1', version: '2.1.1', channels: [null]},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null]},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: [null]},
       ],
     },
     branches: [
@@ -243,9 +242,9 @@ test('Exclude versions merged between release branches if they all have "channel
       name: 'master',
       channel: false,
       tags: [
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined]},
-        {gitTag: 'v1.1.0', version: '1.1.0', channels: [undefined]},
-        {gitTag: 'v2.0.0', version: '2.0.0', channels: [undefined]},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null]},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: [null]},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: [null]},
       ],
     },
     branches: [
@@ -267,12 +266,12 @@ test('Exclude versions number less than the latest version already released on t
       type: 'maintenance',
       mergeRange: '>=2.0.0 <3.0.0',
       tags: [
-        {gitTag: 'v2.0.0@2.x', version: '2.0.0', channels: ['2.x']},
-        {gitTag: 'v2.0.0', version: '2.0.0', channels: [undefined]},
-        {gitTag: 'v2.1.0', version: '2.1.0', channels: [undefined]},
-        {gitTag: 'v2.1.1', version: '2.1.1', channels: [undefined, '2.x']},
-        {gitTag: 'v1.0.0', version: '1.0.0', channels: [undefined]},
-        {gitTag: 'v1.1.0', version: '1.1.0', channels: [undefined]},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: ['2.x']},
+        {gitTag: 'v2.0.0', version: '2.0.0', channels: [null]},
+        {gitTag: 'v2.1.0', version: '2.1.0', channels: [null]},
+        {gitTag: 'v2.1.1', version: '2.1.1', channels: [null, '2.x']},
+        {gitTag: 'v1.0.0', version: '1.0.0', channels: [null]},
+        {gitTag: 'v1.1.0', version: '1.1.0', channels: [null]},
       ],
     },
     branches: [{name: '2.x', channel: '2.x'}, {name: 'master'}],

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -4,6 +4,7 @@ import fileUrl from 'file-url';
 import pEachSeries from 'p-each-series';
 import gitLogParser from 'git-log-parser';
 import getStream from 'get-stream';
+import {GIT_NOTE_REF} from '../../lib/definitions/constants';
 
 /**
  * Commit message informations.
@@ -257,4 +258,25 @@ export async function mergeFf(ref, execaOpts) {
  */
 export async function rebase(ref, execaOpts) {
   await execa('git', ['rebase', ref], execaOpts);
+}
+
+/**
+ * Add a note to a Git reference.
+ *
+ * @param {String} note The note to add.
+ * @param {String} ref The ref to add the note to.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ */
+export async function gitAddNote(note, ref, execaOpts) {
+  await execa('git', ['notes', '--ref', GIT_NOTE_REF, 'add', '-m', note, ref], execaOpts);
+}
+
+/**
+ * Get the note associated with a Git reference.
+ *
+ * @param {String} ref The ref to get the note from.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ */
+export async function gitGetNote(ref, execaOpts) {
+  return (await execa('git', ['notes', '--ref', GIT_NOTE_REF, 'show', ref], execaOpts)).stdout;
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -174,10 +174,6 @@ test('getRange', t => {
 
 test('makeTag', t => {
   t.is(makeTag(`v\${version}`, '1.0.0'), 'v1.0.0');
-  t.is(makeTag(`v\${version}`, '1.0.0', false), 'v1.0.0');
-  t.is(makeTag(`v\${version}`, '1.0.0', null), 'v1.0.0');
-  t.is(makeTag(`v\${version}`, '1.0.0', 'next'), 'v1.0.0@next');
-  t.is(makeTag(`v\${version}@test`, '1.0.0', 'next'), 'v1.0.0@next@test');
 });
 
 test('isSameChannel', t => {


### PR DESCRIPTION
### BREAKING CHANGE

this feature change the way semantic-release keep track of the channels on which a version has been released.

It now use a JSON object stored in a [Git note](https://git-scm.com/docs/git-notes) instead of Git tags formatted as v{version}@{channel}.

The tags formatted as v{version}@{channel} will now be ignored. If you have made releases with v16.0.0 on branches other than the default one you will have to update your repository.

The changes to make consist in:
- Finding all the versions that have been released on a branch other than the default one by searching for all tags formatted v{version}@{channel}
- For each of those version:
  - Create a tag without the `{@channel}` if none doesn't already exists
  - Add a Git note to the tag without the `{@channel}` containing the channels on which the version was released formatted as `{"channels":["channel1","channel2"]}` and using `null` for the default channel (for example.`{"channels":[null,"channel1","channel2"]}`)
  - Push the tags and notes
  - Update the GitHub releases that refer to a tag formatted as v{version}@{channel} to use the tag without it
  - Delete the tags formatted as v{version}@{channel}

Fix #1191, Fix #1101

See this script to help with the migration: https://gist.github.com/pvdlg/6b19e529ee5c1a20645675a44e5b3239