### PR TITLE
build: remove `.github/airtable-crm.yml`

### DIFF
--- a/.github/airtable-crm.yml
+++ b/.github/airtable-crm.yml
@@ -1,1 +1,0 @@
-base: app0ZOxG0FnHmOiuU


### PR DESCRIPTION
I don't think we use that any more