### PR TITLE
Filter out empty branch results

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -65,8 +65,8 @@ async function getCommits(from, to, execaOpts) {
 async function getBranches(repositoryUrl, execaOpts) {
   return (await execa('git', ['ls-remote', '--heads', repositoryUrl], execaOpts)).stdout
     .split('\n')
-    .map(branch => branch.match(/^.+refs\/heads\/(?<branch>.+)$/)[1])
-    .filter(Boolean);
+    .filter(Boolean)
+    .map(branch => branch.match(/^.+refs\/heads\/(?<branch>.+)$/)[1]);
 }
 
 /**

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -33,6 +33,7 @@ import {
   gitAddNote,
   gitGetNote,
   gitFetch,
+  initGit,
 } from './helpers/git-utils';
 
 test('Get the last commit sha', async t => {
@@ -180,6 +181,11 @@ test('Get all branches', async t => {
   await gitPush(repositoryUrl, 'third-branch', {cwd});
 
   t.deepEqual((await getBranches(repositoryUrl, {cwd})).sort(), ['master', 'second-branch', 'third-branch'].sort());
+});
+
+test('Return empty array if there are no branches', async t => {
+  const {cwd, repositoryUrl} = await initGit(true);
+  t.deepEqual(await getBranches(repositoryUrl, {cwd}), []);
 });
 
 test('Get the commit sha for a given tag', async t => {


### PR DESCRIPTION
This PR adds `try-catch` block to `git.js`'s `getBranches` function. When you run the script without having any branches on remote origin (an empty repo) it throws an unclear error
```
An error occurred while running semantic-release: TypeError: Cannot read property '1' of null`
```
This PR fixes it so now the message looks like this:

```
ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.
A minimum of 1 and a maximum of 3 release branches are required in the branches configuration.

This may occur if your repository does not have a release branch, such as master.

Your configuration for the problematic branches is [].

AggregateError:
    SemanticReleaseError: The release branches are invalid in the `branches` configuration.
```