### PR TITLE
Replacing firefox plugin in the community list

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -65,10 +65,10 @@
   - `verifyConditions`: Verify the presence of the authentication (set via environment variables)
   - `prepare`: Write the correct version to the `manifest.json` and creates a zip file of the whole dist folder
   - `publish`: Uploads the generated zip file to the webstore, and publish the item
-- [semantic-release-firefox](https://github.com/felixfbecker/semantic-release-firefox)
-  - `verifyConditions`: Verify the presence of the authentication (set via environment variables)
-  - `prepare`: Write the correct version to the `manifest.json`, creates a `xpi` file of the dist folder and a zip of the sources
-  - `publish`: Submit the generated archives to the webstore for review, and publish the item including release notes
+- [semantic-release-firefox-add-on](https://github.com/tophat/semantic-release-firefox-add-on)
+  - `verifyConditions`: Verify that all required options are present and authentication is set via environment variables
+  - `prepare`: Write the correct version to the `manifest.json`
+  - `publish`: Creates an unsigned `.xpi` file, and submits it to the Mozilla Add On store for signing. Once the package is signed, downloads the signed `.xpi` to a local directory
 - [semantic-release-gerrit](https://github.com/pascalMN/semantic-release-gerrit)
   - `generateNotes`: Generate release notes with Gerrit reviews URL
 - [semantic-release-expo](https://github.com/bycedric/semantic-release-expo)


### PR DESCRIPTION
Our company built an in-house extension and wanted to be able to release it to Chrome and Firefox both for distribution. The Chrome plugin worked without any issues, but we could not get the Firefox plugin to work. The package hasn't had a release for almost a year and half, and we think the Mozilla Add On store API changed since their last release. 

We built our own version using a different method to communicate with the Add On store that we've been using for almost 6 months now without any issues. We decided to open source the package, and will be maintaining it for the future. You can find our package [here](https://github.com/tophat/semantic-release-firefox-add-on).

We have detailed documentation about how to configure the plugin and unit testing. We're not on version 1.0 yet but will be soon, we just wanted wider adoption to make sure we didn't miss any features before bumping the major version.