### PR TITLE
Allow custom arguments for finding git commits

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,6 +24,7 @@ Usage:
     .option('t', {alias: 'tag-format', describe: 'Git tag format', type: 'string', group: 'Options'})
     .option('p', {alias: 'plugins', describe: 'Plugins', ...stringList, group: 'Options'})
     .option('e', {alias: 'extends', describe: 'Shareable configurations', ...stringList, group: 'Options'})
+    .option('gitlogarg', {describe: 'Override git log parsing argument', type: 'string', group: 'Options'})
     .option('ci', {describe: 'Toggle CI verifications', type: 'boolean', group: 'Options'})
     .option('verify-conditions', {...stringList, group: 'Plugins'})
     .option('analyze-commits', {type: 'string', group: 'Plugins'})

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ async function run(context, plugins) {
   await fetch(options.repositoryUrl, {cwd, env});
 
   context.lastRelease = await getLastRelease(context);
-  context.commits = await getCommits(context);
+  context.commits = await getCommits(context, options.gitlogarg);
 
   const nextRelease = {type: await plugins.analyzeCommits(context), gitHead: await getGitHead({cwd, env})};
 

--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -9,7 +9,9 @@ const debug = require('debug')('semantic-release:get-commits');
  *
  * @return {Promise<Array<Object>>} The list of commits on the branch `branch` since the last release.
  */
-module.exports = async ({cwd, env, lastRelease: {gitHead}, logger}) => {
+module.exports = async ({cwd, env, lastRelease: {gitHead}, logger}, gitLogParseArg) => {
+  logger.log(gitLogParseArg);
+
   if (gitHead) {
     debug('Use gitHead: %s', gitHead);
   } else {
@@ -17,10 +19,13 @@ module.exports = async ({cwd, env, lastRelease: {gitHead}, logger}) => {
   }
 
   Object.assign(gitLogParser.fields, {hash: 'H', message: 'B', gitTags: 'd', committerDate: {key: 'ci', type: Date}});
+
+  if (gitLogParseArg === undefined) {
+    gitLogParseArg = `${gitHead ? gitHead + '..' : ''}HEAD`;
+  }
+
   const commits = (
-    await getStream.array(
-      gitLogParser.parse({_: `${gitHead ? gitHead + '..' : ''}HEAD`}, {cwd, env: {...process.env, ...env}})
-    )
+    await getStream.array(gitLogParser.parse({_: gitLogParseArg}, {cwd, env: {...process.env, ...env}}))
   ).map(commit => {
     commit.message = commit.message.trim();
     commit.gitTags = commit.gitTags.trim();

--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -10,8 +10,6 @@ const debug = require('debug')('semantic-release:get-commits');
  * @return {Promise<Array<Object>>} The list of commits on the branch `branch` since the last release.
  */
 module.exports = async ({cwd, env, lastRelease: {gitHead}, logger}, gitLogParseArg) => {
-  logger.log(gitLogParseArg);
-
   if (gitHead) {
     debug('Use gitHead: %s', gitHead);
   } else {

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -131,6 +131,12 @@ export async function gitTagVersion(tagName, sha, execaOpts) {
   await execa('git', sha ? ['tag', '-f', tagName, sha] : ['tag', tagName], execaOpts);
 }
 
+/**
+ * Merge branches in the current git repository
+ *
+ * @param {String} branchName The branch name to merge into the current branch
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ */
 export async function gitMerge(branchName, execaOpts) {
   await execa('git', ['merge', branchName, '-m', 'merged'], execaOpts);
 }

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -131,6 +131,10 @@ export async function gitTagVersion(tagName, sha, execaOpts) {
   await execa('git', sha ? ['tag', '-f', tagName, sha] : ['tag', tagName], execaOpts);
 }
 
+export async function gitMerge(branchName, execaOpts) {
+  await execa('git', ['merge', branchName, '-m', 'merged'], execaOpts);
+}
+
 /**
  * Create a shallow clone of a git repository and change the current working directory to the cloned repository root.
  * The shallow will contain a limited number of commit and no tags.


### PR DESCRIPTION

Use case: If we have a release branch `release-1` which has been merged into
master and on the master branch we want semantic-release to consider only the
commits which are exclusive to the `master` branch since 'A', then the output
should only include the commits B, C, merged, E and F.
Git history:

```
-----------------------------
A-B-C-merged-E-F....(master*)
 \   /
  P-Q...........(release-1.0)
-----------------------------
```
