### PR TITLE
fix: use `--no-verify` when testing the Git permissions

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -204,7 +204,7 @@ async function isGitRepo(execaOpts) {
  */
 async function verifyAuth(repositoryUrl, branch, execaOpts) {
   try {
-    await execa('git', ['push', '--dry-run', repositoryUrl, `HEAD:${branch}`], execaOpts);
+    await execa('git', ['push', '--dry-run', '--no-verify', repositoryUrl, `HEAD:${branch}`], execaOpts);
   } catch (error) {
     debug(error);
     throw error;


### PR DESCRIPTION
Fix #1423