### PR TITLE
docs(Troubleshooting): release not found in prereleases branch (e.g. `beta`) after rebase on `master`)

### DIFF
--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -54,3 +54,14 @@ $ git branch --contains <tag name>
 $ git tag -d <tag name>
 $ git push origin :refs/tags/<tag name>
 ```
+
+## release not found in prereleases branch (e.g. `beta`) after rebase on `master`
+
+**semantic-release** is using [git notes](https://git-scm.com/docs/git-notes) to store information about which releases happened in which branch. Git notes are attached to commits. After git history rewrite due to a rebase, the git notes created by **semantic-release** are lost.
+
+To recover from that situation, do the following:
+
+1. Delete the tag(s) for the release(s) that have been lost from the git history. You can delete each tag from remote using `git push origin :[TAG NAME]`, e.g. `git push origin :v2.0.0-beta.1`. You can delete tags locally using `git tag -d [TAG NAME]`, e.g. `git tag -d v2.0.0-beta.1`.
+2. Re-create the tags locally: `git tag [TAG NAME] [COMMIT HASH]`, where `[COMMIT HASH]` is the new commit that created the release for the lost tag. E.g. `git tag v2.0.0-beta.1 abcdef0`
+3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v3.0.0-beta.1`
+4. Push the local notes: `git push --force origin refs/notes/semantic-release`. The `--force` is needed after the rebase. Be careful.

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -55,13 +55,13 @@ $ git tag -d <tag name>
 $ git push origin :refs/tags/<tag name>
 ```
 
-## release not found in prereleases branch (e.g. `beta`) after rebase on `master`
+## release not found release branch after `git push --force`
 
-**semantic-release** is using [git notes](https://git-scm.com/docs/git-notes) to store information about which releases happened in which branch. Git notes are attached to commits. After git history rewrite due to a rebase, the git notes created by **semantic-release** are lost.
+**semantic-release** is using [git notes](https://git-scm.com/docs/git-notes) to store information about which releases happened in which branch. Git notes are attached to commits. After git history rewrite due to a `git push --force`, the git notes created by **semantic-release** are lost.
 
 To recover from that situation, do the following:
 
 1. Delete the tag(s) for the release(s) that have been lost from the git history. You can delete each tag from remote using `git push origin :[TAG NAME]`, e.g. `git push origin :v2.0.0-beta.1`. You can delete tags locally using `git tag -d [TAG NAME]`, e.g. `git tag -d v2.0.0-beta.1`.
 2. Re-create the tags locally: `git tag [TAG NAME] [COMMIT HASH]`, where `[COMMIT HASH]` is the new commit that created the release for the lost tag. E.g. `git tag v2.0.0-beta.1 abcdef0`
-3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v3.0.0-beta.1`
+3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v3.0.0-beta.1`. Add all channels where the version was added. If it's only the default channel (usually `master`), then set it to an empty array: `'{"channels":[]}'`
 4. Push the local notes: `git push --force origin refs/notes/semantic-release`. The `--force` is needed after the rebase. Be careful.

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -59,6 +59,10 @@ $ git push origin :refs/tags/<tag name>
 
 **semantic-release** is using [git notes](https://git-scm.com/docs/git-notes) to store information about which releases happened in which branch. Git notes are attached to commits. After git history rewrite due to a `git push --force`, the git notes created by **semantic-release** are lost.
 
+**semantic-release** is using both [git tags](https://git-scm.com/docs/git-tag) and [git notes](https://git-scm.com/docs/git-notes) to store information about which releases happened in which branch.
+
+After a git history rewrite due to a `git push --force`, the git tags and notes referencing the commits that were rewritten are lost.
+
 To recover from that situation, do the following:
 
 1. Delete the tag(s) for the release(s) that have been lost from the git history. You can delete each tag from remote using `git push origin :[TAG NAME]`, e.g. `git push origin :v2.0.0-beta.1`. You can delete tags locally using `git tag -d [TAG NAME]`, e.g. `git tag -d v2.0.0-beta.1`.

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -57,8 +57,6 @@ $ git push origin :refs/tags/<tag name>
 
 ## release not found release branch after `git push --force`
 
-**semantic-release** is using [git notes](https://git-scm.com/docs/git-notes) to store information about which releases happened in which branch. Git notes are attached to commits. After git history rewrite due to a `git push --force`, the git notes created by **semantic-release** are lost.
-
 **semantic-release** is using both [git tags](https://git-scm.com/docs/git-tag) and [git notes](https://git-scm.com/docs/git-notes) to store information about which releases happened in which branch.
 
 After a git history rewrite due to a `git push --force`, the git tags and notes referencing the commits that were rewritten are lost.

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -65,5 +65,5 @@ To recover from that situation, do the following:
 
 1. Delete the tag(s) for the release(s) that have been lost from the git history. You can delete each tag from remote using `git push origin :[TAG NAME]`, e.g. `git push origin :v2.0.0-beta.1`. You can delete tags locally using `git tag -d [TAG NAME]`, e.g. `git tag -d v2.0.0-beta.1`.
 2. Re-create the tags locally: `git tag [TAG NAME] [COMMIT HASH]`, where `[COMMIT HASH]` is the new commit that created the release for the lost tag. E.g. `git tag v2.0.0-beta.1 abcdef0`
-3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v3.0.0-beta.1`. Add all channels where the version was added. If it's only the default channel (usually `master`), then set it to an empty array: `'{"channels":[]}'`
+3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v3.0.0-beta.1`. If the release was also published in the default channel (usually `master`), then set the first channel to `null`, e.g. `git notes --ref semantic-release add -f -m '{"channels":[null, "beta"]}'
 4. Push the local notes: `git push --force origin refs/notes/semantic-release`. The `--force` is needed after the rebase. Be careful.


### PR DESCRIPTION
fixes #1442