### PR TITLE
fix: pass a branch name to `getGitAuthUrl`

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ async function run(context, plugins) {
   // Verify config
   await verify(context);
 
-  options.repositoryUrl = await getGitAuthUrl(context);
+  options.repositoryUrl = await getGitAuthUrl({...context, branch: {name: ciBranch}});
   context.branches = await getBranches(options.repositoryUrl, ciBranch, context);
   context.branch = context.branches.find(({name}) => name === ciBranch);
 


### PR DESCRIPTION
Fix #1454

the first call to `verifyAuth` would always fails because `branch` was `undefined`. As a result we wouldn't use the ssh URL in case we have ssh keys auth. 