### PR TITLE
fix: pin semver to 7.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "p-reduce": "^2.0.0",
     "read-pkg-up": "^7.0.0",
     "resolve-from": "^5.0.0",
-    "semver": "^7.1.1",
+    "semver": "7.3.0",
     "semver-diff": "^3.1.1",
     "signale": "^1.2.1",
     "yargs": "^15.0.1"


### PR DESCRIPTION
until https://github.com/semantic-release/semantic-release/issues/1524 is resolved