### PR TITLE
fix: resolve wrong selection into get last release

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -1,6 +1,6 @@
 const {isUndefined} = require('lodash');
 const semver = require('semver');
-const {makeTag, isSameChannel} = require('./utils');
+const {makeTag, isSameChannel, isSamePrerelease} = require('./utils');
 
 /**
  * Last release.
@@ -30,7 +30,10 @@ module.exports = ({branch, options: {tagFormat}}, {before} = {}) => {
   const [{version, gitTag, channels} = {}] = branch.tags
     .filter(
       (tag) =>
-        ((branch.type === 'prerelease' && tag.channels.some((channel) => isSameChannel(branch.channel, channel))) ||
+        ((branch.type === 'prerelease' &&
+          tag.channels.some(
+            (channel) => isSameChannel(branch.channel, channel) && isSamePrerelease(branch.prerelease, tag.version)
+          )) ||
           !semver.prerelease(tag.version)) &&
         (isUndefined(before) || semver.lt(tag.version, before))
     )

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,6 +82,10 @@ function isSameChannel(channel, otherChannel) {
   return channel === otherChannel || (!channel && !otherChannel);
 }
 
+function isSamePrerelease(prerelease, version) {
+  return new RegExp(`\\d+.\\d+.\\d+-${prerelease}.\\d+`).test(version);
+}
+
 module.exports = {
   extractErrors,
   hideSensitiveValues,
@@ -98,4 +102,5 @@ module.exports = {
   getRange,
   makeTag,
   isSameChannel,
+  isSamePrerelease,
 };

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -78,3 +78,67 @@ test('Get the highest non-prerelease valid tag before a certain version', (t) =>
 
   t.deepEqual(result, {version: '2.0.0', gitTag: 'v2.0.0', name: 'v2.0.0', gitHead: 'v2.0.0', channels: undefined});
 });
+
+test('Get the highest prerelease valid tag, ignoring beta prerelease branch', (t) => {
+  const result = getLastRelease({
+    branch: {
+      name: 'alpha',
+      type: 'prerelease',
+      prerelease: 'alpha',
+      channel: 'alpha',
+      tags: [
+        {
+          gitTag: 'v1.2.3-alpha.1',
+          version: '1.2.3-alpha.1',
+          channels: ['alpha'],
+        },
+        {
+          gitTag: 'v1.2.3-beta.1',
+          version: '1.2.3-beta.1',
+          channels: ['alpha'],
+        },
+      ],
+    },
+    options: {tagFormat: `v\${version}`},
+  });
+
+  t.deepEqual(result, {
+    version: '1.2.3-alpha.1',
+    gitTag: 'v1.2.3-alpha.1',
+    name: 'v1.2.3-alpha.1',
+    gitHead: 'v1.2.3-alpha.1',
+    channels: ['alpha'],
+  });
+});
+
+test('Get the highest prerelease valid tag, ignoring alpha prerelease branch', (t) => {
+  const result = getLastRelease({
+    branch: {
+      name: 'beta',
+      type: 'prerelease',
+      prerelease: 'beta',
+      channel: 'beta',
+      tags: [
+        {
+          gitTag: 'v1.2.3-alpha.1',
+          version: '1.2.3-alpha.1',
+          channels: ['beta'],
+        },
+        {
+          gitTag: 'v1.2.3-beta.1',
+          version: '1.2.3-beta.1',
+          channels: ['beta'],
+        },
+      ],
+    },
+    options: {tagFormat: `v\${version}`},
+  });
+
+  t.deepEqual(result, {
+    version: '1.2.3-beta.1',
+    gitTag: 'v1.2.3-beta.1',
+    name: 'v1.2.3-beta.1',
+    gitHead: 'v1.2.3-beta.1',
+    channels: ['beta'],
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -15,6 +15,7 @@ const {
   getRange,
   makeTag,
   isSameChannel,
+  isSamePrerelease,
 } = require('../lib/utils');
 
 test('extractErrors', (t) => {
@@ -183,4 +184,13 @@ test('isSameChannel', (t) => {
   t.true(isSameChannel('', false));
 
   t.false(isSameChannel('next', false));
+});
+
+test('isSamePrerelease', (t) => {
+  t.true(isSamePrerelease('alpha', '1.2.4-alpha.432'));
+  t.true(isSamePrerelease('alpha', '1321.2312.4312-alpha.432'));
+
+  t.false(isSamePrerelease('alpha', '1.2.4'));
+  t.false(isSamePrerelease('beta', '1.2.4-alpha.432'));
+  t.false(isSamePrerelease('beta', '1321.2312.4312-alpha.432'));
 });


### PR DESCRIPTION
Closes #1531

Current Issue:
```
[5:48:34 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
[5:48:34 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 11 commits complete: patch release
[5:48:34 PM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[5:48:34 PM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ℹ  The next release version is 0.1.0-release-next.6
[5:48:34 PM] [semantic-release] › ℹ  Start step "verifyRelease" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ✔  Completed step "verifyRelease" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[5:48:34 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[5:48:34 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/exec"
[5:48:34 PM] [semantic-release] › ✖  An error occurred while running semantic-release: Error: Command failed with exit code 128: git tag v0.1.0-release-next.6 b35bb1c1a26b909a55f5849109bb2deeff32c0b8
```

With these changes:
```
[8:12:00 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[8:12:00 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/exec"
[8:12:00 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/exec"
[8:12:00 PM] [semantic-release] › ⚠  Skip step "prepare" of plugin "@semantic-release/exec" in dry-run mode
[8:12:00 PM] [semantic-release] › ⚠  Skip v0.1.0-develop.33 tag creation in dry-run mode
[8:12:00 PM] [semantic-release] › ⚠  Skip step "publish" of plugin "@semantic-release/github" in dry-run mode
[8:12:00 PM] [semantic-release] › ⚠  Skip step "publish" of plugin "@semantic-release/exec" in dry-run mode
[8:12:00 PM] [semantic-release] › ⚠  Skip step "success" of plugin "@semantic-release/github" in dry-run mode
[8:12:00 PM] [semantic-release] › ⚠  Skip step "success" of plugin "@semantic-release/exec" in dry-run mode
[8:12:00 PM] [semantic-release] › ✔  Published release 0.1.0-develop.33 on develop channel
[8:12:00 PM] [semantic-release] › ℹ  Release note for version 0.1.0-develop.33:
```
