### PR TITLE
Optimize npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   },
   "files": [
     "bin",
-    "docs",
     "lib",
     "index.js",
     "cli.js"


### PR DESCRIPTION
It doesn't make much sense to deliver docs to users via package