### PR TITLE
feat: Support staying on v0.x.y with --unstable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/cli.js
+++ b/cli.js
@@ -35,6 +35,7 @@ Usage:
     .option('fail', {...stringList, group: 'Plugins'})
     .option('debug', {describe: 'Output debugging information', type: 'boolean', group: 'Options'})
     .option('d', {alias: 'dry-run', describe: 'Skip publishing', type: 'boolean', group: 'Options'})
+    .option('unstable', {describe: 'Enforce staying on v0.x.y.', type: 'boolean', group: 'Options'})
     .option('h', {alias: 'help', group: 'Options'})
     .option('v', {alias: 'version', group: 'Options'})
     .strict(false)

--- a/lib/definitions/constants.js
+++ b/lib/definitions/constants.js
@@ -2,6 +2,8 @@ const RELEASE_TYPE = ['patch', 'minor', 'major'];
 
 const FIRST_RELEASE = '1.0.0';
 
+const FIRST_RELEASE_UNSTABLE = '0.1.0';
+
 const FIRSTPRERELEASE = '1';
 
 const COMMIT_NAME = 'semantic-release-bot';
@@ -19,6 +21,7 @@ const GIT_NOTE_REF = 'semantic-release';
 module.exports = {
   RELEASE_TYPE,
   FIRST_RELEASE,
+  FIRST_RELEASE_UNSTABLE,
   FIRSTPRERELEASE,
   COMMIT_NAME,
   COMMIT_EMAIL,

--- a/lib/get-next-version.js
+++ b/lib/get-next-version.js
@@ -1,11 +1,20 @@
 const semver = require('semver');
-const {FIRST_RELEASE, FIRSTPRERELEASE} = require('./definitions/constants');
+const {FIRST_RELEASE, FIRST_RELEASE_UNSTABLE, FIRSTPRERELEASE} = require('./definitions/constants');
 const {isSameChannel, getLatestVersion, tagsToVersions, highest} = require('./utils');
 
-module.exports = ({branch, nextRelease: {type, channel}, lastRelease, logger}) => {
+module.exports = ({branch, nextRelease: {type, channel}, lastRelease, logger, options}) => {
+  const unstable = Boolean(options && options.unstable);
   let version;
   if (lastRelease.version) {
     const {major, minor, patch} = semver.parse(lastRelease.version);
+
+    if (unstable && major < 1) {
+      if (type === 'major') {
+        type = 'minor';
+      } else if (type === 'minor') {
+        type = 'patch';
+      }
+    }
 
     if (branch.type === 'prerelease') {
       if (
@@ -27,7 +36,8 @@ module.exports = ({branch, nextRelease: {type, channel}, lastRelease, logger}) =
 
     logger.log('The next release version is %s', version);
   } else {
-    version = branch.type === 'prerelease' ? `${FIRST_RELEASE}-${branch.prerelease}.${FIRSTPRERELEASE}` : FIRST_RELEASE;
+    const firstRelease = unstable ? FIRST_RELEASE_UNSTABLE : FIRST_RELEASE;
+    version = branch.type === 'prerelease' ? `${firstRelease}-${branch.prerelease}.${FIRSTPRERELEASE}` : firstRelease;
     logger.log(`There is no previous release, the next release version is ${version}`);
   }
 

--- a/test/get-next-version.test.js
+++ b/test/get-next-version.test.js
@@ -275,3 +275,55 @@ test('Increase version for release on prerelease branch when there is no regular
     '1.0.0-beta.2'
   );
 });
+
+test('Increase version for patch release (unstable)', (t) => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release', tags: [{gitTag: 'v0.1.0', version: '0.1.0', channels: [null]}]},
+      nextRelease: {type: 'patch'},
+      lastRelease: {version: '0.1.0', channels: [null]},
+      logger: t.context.logger,
+      options: {unstable: true},
+    }),
+    '0.1.1'
+  );
+});
+
+test('Increase version for minor release (unstable)', (t) => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release', tags: [{gitTag: 'v0.1.0', version: '0.1.0', channels: [null]}]},
+      nextRelease: {type: 'minor'},
+      lastRelease: {version: '0.1.0', channels: [null]},
+      logger: t.context.logger,
+      options: {unstable: true},
+    }),
+    '0.1.1'
+  );
+});
+
+test('Increase version for major release (unstable)', (t) => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release', tags: [{gitTag: 'v0.1.0', version: '0.1.0', channels: [null]}]},
+      nextRelease: {type: 'major'},
+      lastRelease: {version: '0.1.0', channels: [null]},
+      logger: t.context.logger,
+      options: {unstable: true},
+    }),
+    '0.2.0'
+  );
+});
+
+test('Return 0.1.0 if there is no previous release (unstable)', (t) => {
+  t.is(
+    getNextVersion({
+      branch: {name: 'master', type: 'release', tags: []},
+      nextRelease: {type: 'minor'},
+      lastRelease: {},
+      logger: t.context.logger,
+      options: {unstable: true},
+    }),
+    '0.1.0'
+  );
+});


### PR DESCRIPTION
As a follow-up to https://github.com/semantic-release/semantic-release/issues/1507#issuecomment-643552928 this is an initial draft implementation to opt-in to keep versions in the `v0.x.y` range.

Context is that we are building what's essentially a [TS to Wasm compiler](https://github.com/AssemblyScript/assemblyscript), with the underlying tech being pretty much still in flux, so we'd prefer to keep the version below a `v1` while certain critical language features are not yet available and do a `v1` once the project is ready to be perceived as something reasonably finished. Yet we'd like to switch to using semantic-release.

Idea is to specify the `--unstable` option as long as a `v1` is not wanted, and remove it again once a `v1` is ready. As such there are no functional changes for existing users, and it's fully opt-in.

~~Coincidentally, I also fixed linting and testing on Windows by making Git checkout with `\n` instead of `\r\n` line endings.~~ addressed in https://github.com/semantic-release/semantic-release/pull/1575

Is this something you'd be willing to support officially? And yeah, from the existing issues I learned that this is a somewhat sensitive topic :)