### PR TITLE
build(gitattributes): eol=lf for Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
As per https://github.com/semantic-release/semantic-release/pull/1574#issuecomment-643794681 this PR fixes what I experienced as unexpected and somewhat cryptic lint/test problems when checking out the repository on Windows while not specifying additional options or configured globally.

The fix is taken [right from the Prettier docs](https://prettier.io/docs/en/options.html#end-of-line). Makes sure text file line endings on Windows are `lf` instead of `crlf`, which typically has no adverse effects there when using a somewhat recent code editor.

The alternative would be to configure Prettier so it allows crlf line endings, but that would be a considerably larger diff, also because files in `bin/` would need to be excluded so these don't end up with crlf on npm, which would break the shebang when executed.