### PR TITLE
feat(bitbucket-basic-auth): support for bitbucket server basic auth

### DIFF
--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -21,12 +21,13 @@ See [CI configuration recipes](../recipes/README.md#ci-configurations) for more 
 
 **semantic-release** requires push access to the project Git repository in order to create [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging). The Git authentication can be set with one of the following environment variables:
 
-| Variable                        | Description                                                                                                                                                                                                                  |
-|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `GH_TOKEN` or `GITHUB_TOKEN`    | A GitHub [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line).                                                                                                    |
-| `GL_TOKEN` or `GITLAB_TOKEN`    | A GitLab [personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html).                                                                                                                       |
-| `BB_TOKEN` or `BITBUCKET_TOKEN` | A Bitbucket [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).                                                                                                 |
-| `GIT_CREDENTIALS`               | [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding) Git username and password in the format `<username>:<password>`. The username and password must each be individually URL encoded, not the `:` separating them. |
+| Variable                                              | Description                                                                                                                                                                                                                  |
+|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `GH_TOKEN` or `GITHUB_TOKEN`                          | A GitHub [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line).                                                                                                    |
+| `GL_TOKEN` or `GITLAB_TOKEN`                          | A GitLab [personal access token](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html).                                                                                                                       |
+| `BB_TOKEN` or `BITBUCKET_TOKEN`                       | A Bitbucket [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).                                                                                                 |
+| `BB_TOKEN_BASIC_AUTH` or `BITBUCKET_TOKEN_BASIC_AUTH` | A Bitbucket [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) with basic auth support. For clearification `user:token` has to be the value of this env.        |
+| `GIT_CREDENTIALS`                                     | [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding) Git username and password in the format `<username>:<password>`. The username and password must each be individually URL encoded, not the `:` separating them. |
 
 Alternatively the Git authentication can be set up via [SSH keys](../recipes/git-auth-ssh-keys.md).
 

--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -25,6 +25,8 @@ module.exports = async ({cwd, env, branch, options: {repositoryUrl}}) => {
     GITLAB_TOKEN: 'gitlab-ci-token:',
     BB_TOKEN: 'x-token-auth:',
     BITBUCKET_TOKEN: 'x-token-auth:',
+    BB_TOKEN_BASIC_AUTH: '',
+    BITBUCKET_TOKEN_BASIC_AUTH: '',
   };
 
   const info = hostedGitInfo.fromUrl(repositoryUrl, {noGitPlus: true});

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -299,6 +299,34 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "BITB
   );
 });
 
+test('Return the "https" formatted URL if "gitCredentials" is defined with "BB_TOKEN_BASIC_AUTH"', async (t) => {
+  const {cwd} = await gitRepo();
+
+  t.is(
+    await getAuthUrl({
+      cwd,
+      env: {...env, BB_TOKEN_BASIC_AUTH: 'username:token'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
+    }),
+    'https://username:token@host.null/owner/repo.git'
+  );
+});
+
+test('Return the "https" formatted URL if "gitCredentials" is defined with "BITBUCKET_TOKEN_BASIC_AUTH"', async (t) => {
+  const {cwd} = await gitRepo();
+
+  t.is(
+    await getAuthUrl({
+      cwd,
+      env: {...env, BITBUCKET_TOKEN_BASIC_AUTH: 'username:token'},
+      branch: {name: 'master'},
+      options: {repositoryUrl: 'git@host.null:owner/repo.git'},
+    }),
+    'https://username:token@host.null/owner/repo.git'
+  );
+});
+
 test('Return the "https" formatted URL if "GITHUB_ACTION" is set', async (t) => {
   const {cwd} = await gitRepo();
 


### PR DESCRIPTION
Bitbucket Servers currently only support basic auth, so it is not possible to authenticate with `x-auth-token:{token}`, you need to put your username before the token or use bearer headers.