### PR TITLE
fix: use '--no-sign' flag in git tag creation

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -221,7 +221,7 @@ async function verifyAuth(repositoryUrl, branch, execaOptions) {
  * @throws {Error} if the tag creation failed.
  */
 async function tag(tagName, ref, execaOptions) {
-  await execa('git', ['tag', tagName, ref], execaOptions);
+  await execa('git', ['tag', tagName, ref, '--no-sign'], execaOptions);
 }
 
 /**

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -50,7 +50,8 @@ async function gitRepo(withRemote, branch = 'master') {
     await gitCheckout(branch, true, {cwd});
   }
 
-  await execa('git', ['config', 'commit.gpgsign', false], {cwd});
+  await execa('git', ['config', 'commit.gpgsign', true], {cwd});
+  await execa('git', ['config', 'tag.gpgsign', true], {cwd});
 
   return {cwd, repositoryUrl};
 }
@@ -155,7 +156,7 @@ async function gitHead(execaOptions) {
  * @param {Object} [execaOpts] Options to pass to `execa`.
  */
 async function gitTagVersion(tagName, sha, execaOptions) {
-  await execa('git', sha ? ['tag', '-f', tagName, sha] : ['tag', tagName], execaOptions);
+  await execa('git', sha ? ['tag', '-f', tagName, sha] : ['tag', tagName, '--no-sign'], execaOptions);
 }
 
 /**
@@ -275,7 +276,7 @@ async function gitPush(repositoryUrl, branch, execaOptions) {
  * @param {Object} [execaOpts] Options to pass to `execa`.
  */
 async function merge(ref, execaOptions) {
-  await execa('git', ['merge', '--no-ff', ref], execaOptions);
+  await execa('git', ['merge', '--no-ff', ref, '--no-gpg-sign'], execaOptions);
 }
 
 /**
@@ -285,7 +286,7 @@ async function merge(ref, execaOptions) {
  * @param {Object} [execaOpts] Options to pass to `execa`.
  */
 async function mergeFf(ref, execaOptions) {
-  await execa('git', ['merge', '--ff', ref], execaOptions);
+  await execa('git', ['merge', '--ff', ref, '--no-gpg-sign'], execaOptions);
 }
 
 /**


### PR DESCRIPTION
## motivation
when enabled  auto-sign  git configuration, semantic-release freezes in step "Create Git tag"

## description
need to handle auto-sign  git configuration:


`git tag` command needs to handle auto-sign git configuration:
```
[tag]
    gpgSign = true
```
because otherwise, it will cause a message editor that will cause the release to freezes