### PR TITLE
docs: update github documentation to `docs.github.com`

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -74,7 +74,7 @@ The branches on which releases should happen. By default **semantic-release** wi
 
 **Note**: If your repository does not have a release branch, then **semantic-release** will fail with an `ERELEASEBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `master` branch.
 
-**Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://help.github.com/articles/about-protected-branches).
+**Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://docs.github.com/github/administering-a-repository/about-protected-branches).
 
 See [Workflow configuration](workflow-configuration.md#workflow-configuration) for more details.
 


### PR DESCRIPTION
Thanks again for the awesome project!!!
github documentation has moved to `docs.github.com`
addressing this change