### PR TITLE
fix: choose branch instead of prBranch when noCi is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ marked.setOptions({renderer: new TerminalRenderer()});
 async function run(context, plugins) {
   const {cwd, env, options, logger} = context;
   const {isCi, branch, prBranch, isPr} = context.envCi;
-  const ciBranch = isPr ? prBranch : branch;
+  const ciBranch = isPr && !options.noCi ? prBranch : branch;
 
   if (!isCi && !options.dryRun && !options.noCi) {
     logger.warn('This run was not triggered in a known CI environment, running in dry-run mode.');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1258,7 +1258,7 @@ test('Allow local releases with "noCi" option', async (t) => {
 
   const semanticRelease = requireNoCache('..', {
     './lib/get-logger': () => t.context.logger,
-    'env-ci': () => ({isCi: false, branch: 'master', isPr: false}),
+    'env-ci': () => ({isCi: false, branch: 'master', isPr: true, prBranch: 'refs/pull/4/merge'}),
   });
   t.truthy(
     await semanticRelease(options, {


### PR DESCRIPTION
Resolves #1596

Open to any feedback on this PR, including if it is not a good change for the project and just needs to be closed.

Question on the tests: I started to add a new test for the change, but found an existing assertion that prior to #1521 seemed to be verifying `noCi` wouldn't reject even if `isPr` were `true`. Was the change I made sufficient or would you like a separate test for this use case?

This also has me wondering if there should/could be another way to provide what **semantic-release** uses as the branch for any situations where inferring it from `envCi` may not provide the correct answer?