### PR TITLE
docs: improve the docs navigation

### DIFF
--- a/docs/developer-guide/js-api.md
+++ b/docs/developer-guide/js-api.md
@@ -282,3 +282,6 @@ Example:
    }
  ]
 ```
+
+---
+[<- Publishing pre-releases](../recipes/pre-releases.md) | [Plugins ->](plugin.md)

--- a/docs/developer-guide/plugin.md
+++ b/docs/developer-guide/plugin.md
@@ -104,3 +104,6 @@ if (env.GITHUB_TOKEN) {
     //...
 }
 ```
+
+---
+[<- JavaScript API](js-api.md) | [Shareable configuration ->](shareable-configuration.md)

--- a/docs/developer-guide/shareable-configuration.md
+++ b/docs/developer-guide/shareable-configuration.md
@@ -1,1 +1,4 @@
 # Shareable configuration developer guide
+
+---
+[<- Plugins](plugin.md) | [Resources ->](../support/resources.md)

--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -105,3 +105,6 @@
   - `verifyConditions`: Locate and validate a `.gemspec` file, locate and validate a `lib/**/version.rb` file, verify the presence of the `GEM_HOST_API_KEY` environment variable, and create a credentials file with the API key.
   - `prepare`: Update the version in the `lib/**/version.rb` version file and [build](https://guides.rubygems.org/command-reference/#gem-build) the gem.
   - `publish`: [Push the Ruby gem](https://guides.rubygems.org/command-reference/#gem-push) to the gem server. 
+
+---
+[<- Shareable configurations](../usage/shareable-configurations.md) | [Shareable configuration list ->](shareable-configurations-list.md)

--- a/docs/extending/shareable-configurations-list.md
+++ b/docs/extending/shareable-configurations-list.md
@@ -19,3 +19,5 @@
   - Bumps a version in package.json.
   - Publishes the new version to [NPM](https://npmjs.org).
   
+---
+[<- Plugins list](plugins-list.md) | [CircleCI 2.0 workflows ->](../recipes/circleci-workflows.md)

--- a/docs/recipes/circleci-workflows.md
+++ b/docs/recipes/circleci-workflows.md
@@ -63,3 +63,6 @@ A `package.json` is required only for [local](../usage/installation.md#local-ins
   }
 }
 ```
+
+---
+[<- Shareable configuration list](../extending/shareable-configurations-list.md) | [Travis CI ->](travis.md)

--- a/docs/recipes/distribution-channels.md
+++ b/docs/recipes/distribution-channels.md
@@ -114,3 +114,6 @@ The Git history of the repository is now:
 ```
 
 We can now continue to push new fixes and features on `master`, or a new breaking change on `next` as we did before.
+
+---
+[<- Git authentication with SSH keys](git-auth-ssh-keys.md) | [Publishing maintenance releases ->](maintenance-releases.md)

--- a/docs/recipes/git-auth-ssh-keys.md
+++ b/docs/recipes/git-auth-ssh-keys.md
@@ -161,3 +161,6 @@ $ git add git_deploy_key.enc .circleci/config.yml
 $ git commit -m "ci(circle): Add the encrypted private ssh key"
 $ git push
 ```
+
+---
+[<- Jenkins CI](jenkins-ci.md) | [Publishing on distribution channels ->](distribution-channels.md)

--- a/docs/recipes/github-actions.md
+++ b/docs/recipes/github-actions.md
@@ -78,3 +78,6 @@ If you'd like to use a GitHub app to manage this instead of creating a personal 
 
 * [Actions Panel](https://www.actionspanel.app/) - A declaratively configured way for triggering GitHub Actions
 * [Action Button](https://github-action-button.web.app/#details) - A simple badge based mechanism for triggering GitHub Actions
+
+---
+[<- GitLab CI](gitlab-ci.md) | [Jenkins CI ->](jenkins-ci.md)

--- a/docs/recipes/gitlab-ci.md
+++ b/docs/recipes/gitlab-ci.md
@@ -50,7 +50,7 @@ publish:
 
 This example is a minimal configuration for **semantic-release** with a build running Node 10 and 12. See [GitLab CI - Configuration of your jobs with .gitlab-ci.yml](https://docs.gitlab.com/ee/ci/yaml/README.html) for additional configuration options.
 
-**Note**: The`semantic-release` execution command varies depending if you are using a [local](../usage/installation.md#local-installation) or [global](../usage/installation.md#global-installation) **semantic-release** installation.
+**Note**: The `semantic-release` execution command varies depending if you are using a [local](../usage/installation.md#local-installation) or [global](../usage/installation.md#global-installation) **semantic-release** installation.
 
 
 ```yaml
@@ -92,3 +92,6 @@ A `package.json` is required only for [local](../usage/installation.md#local-ins
   }
 }
 ```
+
+---
+[<- Travis CI](travis.md) | [GitHub Actions ->](github-actions.md)

--- a/docs/recipes/jenkins-ci.md
+++ b/docs/recipes/jenkins-ci.md
@@ -59,3 +59,6 @@ A `package.json` is required only for [local](../usage/installation.md#local-ins
   }
 }
 ```
+
+---
+[<- GitHub Actions](github-actions.md) | [Git authentication with SSH keys ->](git-auth-ssh-keys.md)

--- a/docs/recipes/maintenance-releases.md
+++ b/docs/recipes/maintenance-releases.md
@@ -154,3 +154,6 @@ The Git history of the repository is now:
 |  |  |
 |  *  | fix: another fix # => v1.1.2 on @1.x
 ```
+
+---
+[<- Publishing on distribution channels](distribution-channels.md) | [Publishing pre-releases ->](pre-releases.md)

--- a/docs/recipes/pre-releases.md
+++ b/docs/recipes/pre-releases.md
@@ -194,3 +194,6 @@ The Git history of the repository is now:
 |  *  | Merge branch master into beta
 |  *  | feat: new feature # => v3.1.0-beta.1 on @beta
 ```
+
+---
+[<- Publishing maintenance releases](maintenance-releases.md) | [JavaScript API ->](../developer-guide/js-api.md)

--- a/docs/recipes/travis.md
+++ b/docs/recipes/travis.md
@@ -95,3 +95,6 @@ jobs:
         on:
           all_branches: true
 ```
+
+---
+[<- CircleCI 2.0 workflows](circleci-workflows.md) | [GitLab CI ->](gitlab-ci.md)

--- a/docs/support/FAQ.md
+++ b/docs/support/FAQ.md
@@ -249,3 +249,6 @@ See [Node version requirement](./node-version.md#node-version-requirement) for m
 [`npx`](https://www.npmjs.com/package/npx) – short for "npm exec" – is a CLI to find and execute npm binaries within the local `node_modules` folder or in the $PATH. If a binary can't be located npx will download the required package and execute it from its cache location.
 The tool is bundled with [npm](https://www.npmjs.com/package/npm) >= 5.2, or can be installed via `npm install -g npx`.
 For more details and motivation read the [introductory blog post](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) by [@zkat](https://github.com/zkat).
+
+---
+[<- Resources](resources.md) | [Troubleshooting ->](troubleshooting.md)

--- a/docs/support/node-support-policy.md
+++ b/docs/support/node-support-policy.md
@@ -11,3 +11,6 @@ As each Node LTS version reaches its end-of-life we will remove that version fro
 We will accept code that allows this package to run on newer, non-LTS, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, our continuous integration setup runs against all LTS versions of Node in addition the most recent Node release; called current.
 
 JavaScript package managers should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our node engines property. If you encounter issues installing this package, please report the issue to your package manager.
+
+---
+[<- Node version requirement](node-version.md)

--- a/docs/support/node-version.md
+++ b/docs/support/node-version.md
@@ -33,3 +33,6 @@ If your CI environment provides [nvm](https://github.com/creationix/nvm) you can
 ```bash
 $ nvm install 8 && npx semantic-release
 ```
+
+---
+[<- Troubleshooting](troubleshooting.md) | [Node Support Policy ->](node-support-policy.md)

--- a/docs/support/resources.md
+++ b/docs/support/resources.md
@@ -19,3 +19,6 @@
 ## Tutorials
 
 - ["How to Write a JavaScript Library - Automating Releases with semantic-release" – egghead.io](https://egghead.io/lessons/javascript-automating-releases-with-semantic-release)
+
+---
+[<- Shareable configuration](../developer-guide/shareable-configuration.md) | [Frequently Asked Questions ->](FAQ.md)

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -67,3 +67,6 @@ To recover from that situation, do the following:
 2. Re-create the tags locally: `git tag [TAG NAME] [COMMIT HASH]`, where `[COMMIT HASH]` is the new commit that created the release for the lost tag. E.g. `git tag v2.0.0-beta.1 abcdef0`
 3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v3.0.0-beta.1`. If the release was also published in the default channel (usually `master`), then set the first channel to `null`, e.g. `git notes --ref semantic-release add -f -m '{"channels":[null, "beta"]}'
 4. Push the local notes: `git push --force origin refs/notes/semantic-release`. The `--force` is needed after the rebase. Be careful.
+
+---
+[<- Frequently Asked Questions](FAQ.md) | [Node version requirement ->](node-version.md)

--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -47,3 +47,6 @@ The authentication token/credentials have to be made available in the CI service
 See [CI configuration recipes](../recipes/README.md#ci-configurations) for more details on how to configure environment variables in your CI service.
 
 **Note**: The environment variables `GH_TOKEN`, `GITHUB_TOKEN`, `GL_TOKEN` and `GITLAB_TOKEN` can be used for both the Git authentication and the API authentication required by [@semantic-release/github](https://github.com/semantic-release/github) and [@semantic-release/gitlab](https://github.com/semantic-release/gitlab).
+
+---
+[<- Installation](installation.md#installation) | [Configuration ->](configuration.md#configuration)

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -174,3 +174,6 @@ $ git tag --contains 1234567
 $ git tag v1.1.0 1234567
 $ git push origin v1.1.0
 ```
+
+---
+[<- CI Configuration](ci-configuration.md#ci-configuration) | [Plugins ->](plugins.md)

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -19,3 +19,6 @@ npx semantic-release-cli setup
 See the [semantic-release-cli](https://github.com/semantic-release/cli#what-it-does) documentation for more details.
 
 **Note**: only a limited number of options, CI services and plugins are currently supported by `semantic-release-cli`.
+
+---
+[Installation ->](installation.md#installation)

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -27,3 +27,6 @@ $ npx semantic-release
 **Note**: For a global installation, it's recommended to specify the major **semantic-release** version to install (for example with with `npx semantic-release@15`). This way your build will not automatically use the next major **semantic-release** release that could possibly break your build. You will have to upgrade manually when a new major version is released.
 
 **Note**: `npx` is a tool bundled with `npm@>=5.2.0`. It is used to conveniently install the semantic-release binary and to execute it. See [What is npx](../support/FAQ.md#what-is-npx) for more details.
+
+---
+[<- Getting started](getting-started.md#getting-started) | [CI Configuration ->](ci-configuration.md#ci-configuration)

--- a/docs/usage/plugins.md
+++ b/docs/usage/plugins.md
@@ -92,3 +92,6 @@ Global plugin configuration can be defined at the root of the **semantic-release
 With this configuration:
 - All plugins will receive the `preset` option, which will be used by both `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` (and ignored by `@semantic-release/github` and `@semantic-release/git`)
 - The `@semantic-release/github` plugin will receive the `assets` options (`@semantic-release/git` will not receive it and therefore will use it's default value for that option)
+
+---
+[<- Configuration](configuration.md#configuration) | [Workflow configuration ->](workflow-configuration.md)

--- a/docs/usage/shareable-configurations.md
+++ b/docs/usage/shareable-configurations.md
@@ -5,3 +5,6 @@ A shareable configuration is an [npm](https://www.npmjs.com/) package that expor
 The shareable configurations to use can be set with the [extends](configuration.md#extends) option.
 
 See [shareable configurations list](../extending/shareable-configurations-list.md).
+
+---
+[<- Workflow configuration](workflow-configuration.md) | [Plugins list ->](../extending/plugins-list.md)

--- a/docs/usage/workflow-configuration.md
+++ b/docs/usage/workflow-configuration.md
@@ -184,3 +184,6 @@ With the configuration `"branches": ["master", {"name": "beta", "prerelease": tr
 With the configuration `"branches": ["master", {"name": "beta", "prerelease": true}]`, if the last release published from `master` is `1.0.0` and the last one published from `beta` is `2.0.0-beta.1` then:
 - Pushing a `fix` commit on the `master` branch will release the version `1.0.1` on the default distribution channel
 - Merging the branch `master` into `beta` will release the version `2.0.0-beta.2` on the `beta` distribution channel
+
+---
+[<- Plugins](plugins.md) | [Shareable configurations ->](shareable-configurations.md)


### PR DESCRIPTION
Links to the previous and next articles were added in all articles to improve the linear reading. Currently, the reader must back to the index to select the next article. After this change, the reader will jump to the next article by clicking in a link at the end of the page.