### PR TITLE
fix: Add logging for when ssh falls back to http

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -2,6 +2,7 @@ const {parse, format} = require('url'); // eslint-disable-line node/no-deprecate
 const {isNil} = require('lodash');
 const hostedGitInfo = require('hosted-git-info');
 const {verifyAuth} = require('./git');
+const debug = require('debug')('semantic-release:get-git-auth-url');
 
 /**
  * Determine the the git repository URL to use to push, either:
@@ -42,8 +43,11 @@ module.exports = async ({cwd, env, branch, options: {repositoryUrl}}) => {
 
   // Test if push is allowed without transforming the URL (e.g. is ssh keys are set up)
   try {
+    debug('Verifying ssh auth by attempting to push to  %s', repositoryUrl);
     await verifyAuth(repositoryUrl, branch.name, {cwd, env});
   } catch (_) {
+    debug('SSH key auth failed, falling back to https.');
+
     const envVar = Object.keys(GIT_TOKENS).find((envVar) => !isNil(env[envVar]));
     const gitCredentials = `${GIT_TOKENS[envVar] || ''}${env[envVar] || ''}`;
 


### PR DESCRIPTION
When setting up semantic release in CI, the debug logging does not provide enough context on why it is trying to push via https, and is hard to debug without deeply reading the code.  Adding some debug logging to indicate that will make it easier to know why you're calling git via https.