### PR TITLE
feat!: support multiple git tags and publish major and minor version tag

### DIFF
--- a/docs/developer-guide/js-api.md
+++ b/docs/developer-guide/js-api.md
@@ -220,7 +220,7 @@ Information related to the newly published release:
 | type    | `String` | The [semver](https://semver.org) type of the release (`patch`, `minor` or `major`).                                           |
 | version | `String` | The version of the new release.                                                                                               |
 | gitHead | `String` | The sha of the last commit being part of the new release.                                                                     |
-| gitTag  | `String` | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the new release.                             |
+| gitTags | `Array`  | The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging)s associated with the new release.                             |
 | notes   | `String` | The release notes for the new release.                                                                                        |
 | channel | `String` | The distribution channel on which the next release will be made available (`undefined` for the default distribution channel). |
 
@@ -230,7 +230,7 @@ Example:
   type: 'minor',
   gitHead: '68eb2c4d778050b0701136ca129f837d7ed494d2',
   version: '1.1.0',
-  gitTag: 'v1.1.0',
+  gitTags: ['v1.1.0', 'v1.0', 'v1'],
   notes: 'Release notes for version 1.1.0...',
   channel : 'next'
 }

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -88,15 +88,15 @@ The git repository URL.
 
 Any valid git url format is supported (See [Git protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols)).
 
-### tagFormat
+### tagFormats
 
-Type: `String`<br>
-Default: `v${version}`<br>
-CLI arguments: `-t`, `--tag-format`
+Type: `Array`<br>
+Default: `['v${version}', 'v${major}', 'v${major}.${minor}']`<br>
+CLI arguments: `-t`, `--tag-formats`
 
-The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) format used by **semantic-release** to identify releases. The tag name is generated with [Lodash template](https://lodash.com/docs#template) and will be compiled with the `version` variable.
+The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) formats used by **semantic-release** to identify releases. The tag name is generated with [Lodash template](https://lodash.com/docs#template) and will be compiled with the `version`, `major`, `minor` and `patch` variables.
 
-**Note**: The `tagFormat` must contain the `version` variable exactly once and compile to a [valid Git reference](https://git-scm.com/docs/git-check-ref-format#_description).
+**Note**: At least one of the `tagFormats` must contain the `version` variable exactly once. All must compile to a [valid Git reference](https://git-scm.com/docs/git-check-ref-format#_description).
 
 ### plugins
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,7 @@ function getRange(min, max) {
 }
 
 function makeTag(tagFormat, version) {
-  return template(tagFormat)({version});
+  return template(tagFormat)({version, major: semver.major(version), minor: semver.minor(version), patch: semver.patch(version)});
 }
 
 function isSameChannel(channel, otherChannel) {


### PR DESCRIPTION
This adds support for multiple git tags to be specified as input. The user
can now use three new variables: `major`, `minor`, and `patch`.

The default tags aren't only `v${version}` anymore, but `v${major}.${minor}`
and `v${major}`.

This new pattern helps to spread the good practice of creating a git tag
with the major version number so the users can quickly identify what's the
revision of the latest major (or minor) release.

BREAKING CHANGE: the CLI parameter `--tag-format` was renamed to
`--tag-formats` and the `gitTag` variable in the `release`s objects from the
JavaScript API was renamed to `gitTags`, with the `Array` type rather than
`String`. For those relying on the `gitTag` variable, you should now use
`gitTags[0]`.

Fixes #1515