### PR TITLE
docs(CONTRIBUTING): fix commit message examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,17 +183,17 @@ The footer should contain any information about **Breaking Changes** and is also
 #### Examples
 
 ```commit
-`fix(pencil): stop graphite breaking when too much pressure applied`
+fix(pencil): stop graphite breaking when too much pressure applied
 ```
 
 ```commit
-`feat(pencil): add 'graphiteWidth' option`
+feat(pencil): add 'graphiteWidth' option
 
 Fix #42
 ```
 
 ```commit
-perf(pencil): remove graphiteWidth option`
+perf(pencil): remove graphiteWidth option
 
 BREAKING CHANGE: The graphiteWidth option has been removed.
 


### PR DESCRIPTION
It had the backticks (`) around the messages, but I think they were unintentional, probably a leftover from copy-pasting.