### PR TITLE
docs: reorder default plugins list

### DIFF
--- a/docs/usage/plugins.md
+++ b/docs/usage/plugins.md
@@ -21,12 +21,12 @@ A plugin is a npm module that can implement one or more of the following steps:
 
 ### Default plugins
 
-These four plugins are already part of **semantic-release** and don't have to be installed separately:
+These four plugins are already part of **semantic-release** and are listed in order of execution. They do not have to be installed separately:
 ```
 "@semantic-release/commit-analyzer"
-"@semantic-release/github"
-"@semantic-release/npm"
 "@semantic-release/release-notes-generator"
+"@semantic-release/npm"
+"@semantic-release/github"
 ```
 
 ### Additional plugins


### PR DESCRIPTION
**Summary**
Reorder the list of default plugins in the documentation from alphabetical to execution order. 

**Motivation**
The documentation clearly states the four default plugins that are already installed with semantic-release. However their default order of execution is not explicitly stated and when listed in alphabetical order implies the incorrect order.

When a package maintainer needs to configure options on one or more default plugins the documentation states that the `plugins` property will be overridden instead of merged.

> Note: If the plugins option is defined, it overrides the default plugin list, rather than merging with it.

For that reason the maintainer must add all default plugins to the configuration list to modify the configuration of a single plugin. When looking at the documentation it is easy to find the default list of plugins but not so easy to find the default order in which the plugins must be listed. Personally, I made the mistake of assuming the order in which they are listed would be the order in which they would execute and modified my `.releaserc` to be:

```json
{
  "plugins": [
    ["@semantic-release/commit-analyzer", {
      "releaseRules": [
        {"type": "docs", "scope":"README", "release": "patch"}
      ],
    }],
    "@semantic-release/github",
    "@semantic-release/npm",
    "@semantic-release/release-notes-generator"
  ]
}
```

Obviously, this changes the behaviour of the default release because `@semantic-release/github` had switched places with `@semantic-release/release-notes-generator`.

**Solution**
This is simply a user vs documentation problem and can be prevented in the future by explicitly stating the order in which plugins are listed. Furthermore, by changing the order from alphabetical to order of execution the user doesn't need to search the [codebase to find the correct order](https://github.com/semantic-release/semantic-release/blob/master/lib/get-config.js#L79).