### PR TITLE
chore: add Renovate Dependency Dashboard to config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"],
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
This adds my recommendation to use the Renovate Dependency Dashboard to the proposed Renovate config.

This only turns the Dependency Dashboard on, there are more configuration options for the Dashboard in the [Renovate docs for the Dependency Dashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard) that you can tinker with.

See https://github.com/semantic-release/semantic-release/pull/1664#issuecomment-714665525 for my recommendation that you use the Dashboard.