### PR TITLE
docs: add npm-deprecate-old-versions in plugins list

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -105,3 +105,6 @@
   - `verifyConditions`: Locate and validate a `.gemspec` file, locate and validate a `lib/**/version.rb` file, verify the presence of the `GEM_HOST_API_KEY` environment variable, and create a credentials file with the API key.
   - `prepare`: Update the version in the `lib/**/version.rb` version file and [build](https://guides.rubygems.org/command-reference/#gem-build) the gem.
   - `publish`: [Push the Ruby gem](https://guides.rubygems.org/command-reference/#gem-push) to the gem server. 
+- [semantic-release-npm-deprecate-old-versions](https://github.com/ghusse/semantic-release-npm-deprecate-old-versions)
+  - `verifyConditions`: Validates configuration.
+  - `publish`: Deprecates old versions, based on the declaration of supported versions in the config. 


### PR DESCRIPTION
Adds a new plugin in the list of additional plugins for `semantic-release`.

This plugin allows to automatically deprecate old versions as part of the release process.