### PR TITLE
fix(deps): Require find-versions ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "env-ci": "^5.0.0",
     "execa": "^4.0.0",
     "figures": "^3.0.0",
-    "find-versions": "^3.0.0",
+    "find-versions": "^4.0.0",
     "get-stream": "^5.0.0",
     "git-log-parser": "^1.2.0",
     "hook-std": "^2.0.0",


### PR DESCRIPTION
This new version includes a fix for a ReDoS vulnerability in `semver-regex` that is flagged by some source composition analysis tools like Snyk:

https://snyk.io/vuln/SNYK-JS-SEMVERREGEX-1047770

It's a major version because it drops support for Node.js 6.x. This doesn't affect us since we already require Node.js >=10.18.

https://github.com/sindresorhus/find-versions/releases/tag/v4.0.0