### PR TITLE
fix: add logging for top-level errors

### DIFF
--- a/bin/semantic-release.js
+++ b/bin/semantic-release.js
@@ -40,6 +40,7 @@ require('../cli')()
   .then((exitCode) => {
     process.exitCode = exitCode;
   })
-  .catch(() => {
+  .catch((error) => {
+    console.error(error);
     process.exitCode = 1;
   });


### PR DESCRIPTION
Log errors in the main binary to the console to help with debugging.
I wasn't sure how to add tests for this, as I couldn't find any existing tests for that file.

closes #1734

