### PR TITLE
fix(deps): update to yargs 16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "^7.3.2",
     "semver-diff": "^3.1.1",
     "signale": "^1.2.1",
-    "yargs": "^15.0.1"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "ava": "^3.1.0",


### PR DESCRIPTION
fixes vulnerability in y18n which is a dependency of yargs version 15:
https://nvd.nist.gov/vuln/detail/CVE-2020-7774

