### PR TITLE
build(engine-strict): strictly enforced node version compatibility for dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         node-version:
           - 10.18.0
-          - 10
           - 12
           - 14
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 10.18.0
           - 10
           - 12
           - 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Ensure dependencies are compatible with the version of node
+        run: echo 'engine-strict=true' >> .npmrc
       - uses: bahmutov/npm-install@v1
       - run: npm run test:ci
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
to avoid updating to a dependency version that does not support our supported range

i know we've been attempting to avoid config files in the root of the projects where possible, but i'm not sure if there is a good way to accomplish this same goal in another way. i'm open to thoughts around whether we are ok proceeding in this way or if we should consider an alternative.