### PR TITLE
feat: use `conventionalcommits` as the default preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/semantic-release/semantic-release/badge">
   </a>
   <a href="#badge">
-    <img alt="semantic-release: angular" src="https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release">
+    <img alt="semantic-release: conventionalcommits" src="https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release">
   </a>
 </p>
 <p align="center">
@@ -50,7 +50,7 @@ This removes the immediate connection between human emotions and version numbers
 **semantic-release** uses the commit messages to determine the consumer impact of changes in the codebase.
 Following formalized conventions for commit messages, **semantic-release** automatically determines the next [semantic version](https://semver.org) number, generates a changelog and publishes the release.
 
-By default, **semantic-release** uses [Angular Commit Message Conventions](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md).
+By default, **semantic-release** uses the [Conventional Commits convention](https://www.conventionalcommits.org/).
 The commit message format can be changed with the [`preset` or `config` options](https://semantic-release.org/usage/configuration/#options) of the [@semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer#options) and [@semantic-release/release-notes-generator](https://github.com/semantic-release/release-notes-generator#options) plugins.
 
 Tools such as [commitizen](https://github.com/commitizen/cz-cli) or [commitlint](https://github.com/conventional-changelog/commitlint) can be used to help contributors and enforce valid commit messages.
@@ -147,10 +147,10 @@ In order to use **semantic-release** you need:
 
 Let people know that your package is published using **semantic-release** and which [commit-convention](#commit-message-format) is followed by including this badge in your readme.
 
-[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![semantic-release: conventionalcommits](https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
 ```md
-[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![semantic-release: conventionalcommits](https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 ```
 
 ## Team

--- a/cli.js
+++ b/cli.js
@@ -24,6 +24,7 @@ Usage:
     .option("r", { alias: "repository-url", describe: "Git repository URL", type: "string", group: "Options" })
     .option("t", { alias: "tag-format", describe: "Git tag format", type: "string", group: "Options" })
     .option("p", { alias: "plugins", describe: "Plugins", ...stringList, group: "Options" })
+    .option("preset", { describe: "Commit message format convention", type: "string", group: "Options" })
     .option("e", { alias: "extends", describe: "Shareable configurations", ...stringList, group: "Options" })
     .option("ci", { describe: "Toggle CI verifications", type: "boolean", group: "Options" })
     .option("verify-conditions", { ...stringList, group: "Plugins" })

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -78,6 +78,7 @@ export default async (context, cliOptions) => {
       "@semantic-release/npm",
       "@semantic-release/github",
     ],
+    preset: "conventionalcommits",
     // Remove `null` and `undefined` options, so they can be replaced with default ones
     ...pickBy(options, (option) => !isNil(option)),
     ...(options.branches ? { branches: castArray(options.branches) } : {}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@semantic-release/npm": "^13.1.1",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "aggregate-error": "^5.0.0",
+        "conventional-changelog-conventionalcommits": "^9.0.0",
         "cosmiconfig": "^9.0.0",
         "debug": "^4.0.0",
         "env-ci": "^11.0.0",
@@ -3983,6 +3984,18 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
       "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@semantic-release/npm": "^13.1.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "aggregate-error": "^5.0.0",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "cosmiconfig": "^9.0.0",
     "debug": "^4.0.0",
     "env-ci": "^11.0.0",

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -53,6 +53,7 @@ test("Default values, reading repositoryUrl from package.json", async (t) => {
   ]);
   t.is(result.repositoryUrl, "https://host.null/owner/package.git");
   t.is(result.tagFormat, `v\${version}`);
+  t.is(result.preset, "conventionalcommits");
 });
 
 test("Default values, reading repositoryUrl from repo if not set in package.json", async (t) => {
@@ -75,6 +76,7 @@ test("Default values, reading repositoryUrl from repo if not set in package.json
   ]);
   t.is(result.repositoryUrl, "https://host.null/owner/module.git");
   t.is(result.tagFormat, `v\${version}`);
+  t.is(result.preset, "conventionalcommits");
 });
 
 test("Default values, reading repositoryUrl (http url) from package.json if not set in repo", async (t) => {
@@ -98,6 +100,7 @@ test("Default values, reading repositoryUrl (http url) from package.json if not 
   ]);
   t.is(result.repositoryUrl, "https://host.null/owner/module.git");
   t.is(result.tagFormat, `v\${version}`);
+  t.is(result.preset, "conventionalcommits");
 });
 
 test('Convert "ci" option to "noCi"', async (t) => {
@@ -122,6 +125,7 @@ test.serial("Read options from package.json", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Verify the plugins module is called with the plugin options from package.json
   td.when(plugins({ cwd, options }, {})).thenResolve(pluginsConfig);
@@ -143,6 +147,7 @@ test.serial("Read options from .releaserc.yml", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json in repository root
   await writeFile(path.resolve(cwd, ".releaserc.yml"), yaml.dump(options));
@@ -164,6 +169,7 @@ test.serial("Read options from .releaserc.json", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json in repository root
   await outputJson(path.resolve(cwd, ".releaserc.json"), options);
@@ -185,6 +191,7 @@ test.serial("Read options from .releaserc.js", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json in repository root
   await writeFile(path.resolve(cwd, ".releaserc.js"), `module.exports = ${JSON.stringify(options)}`);
@@ -206,6 +213,7 @@ test.serial("Read options from .releaserc.cjs", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create .releaserc.cjs in repository root
   await writeFile(path.resolve(cwd, ".releaserc.cjs"), `module.exports = ${JSON.stringify(options)}`);
@@ -227,6 +235,7 @@ test.serial("Read options from .releaserc.mjs", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create .releaserc.mjs in repository root
   await writeFile(path.resolve(cwd, ".releaserc.mjs"), `export default ${JSON.stringify(options)}`);
@@ -248,6 +257,7 @@ test.serial("Read options from release.config.js", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json in repository root
   await writeFile(path.resolve(cwd, "release.config.js"), `module.exports = ${JSON.stringify(options)}`);
@@ -269,6 +279,7 @@ test.serial("Read options from release.config.cjs", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Verify the plugins module is called with the plugin options from release.config.cjs
   td.when(plugins({ cwd, options }, {})).thenResolve(pluginsConfig);
@@ -290,6 +301,7 @@ test.serial("Read options from release.config.mjs", async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Verify the plugins module is called with the plugin options from release.config.mjs
   td.when(plugins({ cwd, options }, {})).thenResolve(pluginsConfig);
@@ -318,6 +330,7 @@ test.serial("Prioritise CLI/API parameters over file configuration and git repo"
     repositoryUrl: "http://cli-url.com/owner/package",
     tagFormat: `cli\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Verify the plugins module is called with the plugin options from CLI/API
   td.when(plugins({ cwd, options }, {})).thenResolve(pluginsConfig);
@@ -342,6 +355,7 @@ test.serial('Read configuration from file path in "extends"', async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: ["plugin-1", ["plugin-2", { plugin2Opt: "value" }]],
+    preset: "conventionalcommits",
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -376,6 +390,7 @@ test.serial('Read configuration from module path in "extends"', async (t) => {
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -408,6 +423,7 @@ test.serial('Read configuration from an array of paths in "extends"', async (t) 
     branches: ["test_branch"],
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -451,6 +467,7 @@ test.serial('Read configuration from an array of CJS files in "extends"', async 
     branches: ["test_branch"],
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -494,6 +511,7 @@ test.serial('Read configuration from an array of ESM files in "extends"', async 
     branches: ["test_branch"],
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -537,6 +555,7 @@ test.serial('Prioritize configuration from config file over "extends"', async (t
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -588,6 +607,7 @@ test.serial('Prioritize configuration from cli/API options over "extends"', asyn
     branches: ["test_branch2"],
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create package.json, shareable1.json and shareable2.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -623,6 +643,7 @@ test.serial('Allow to unset properties defined in shareable config with "null"',
     analyzeCommits: { path: "analyzeCommits", param: "analyzeCommits_param" },
     tagFormat: `v\${version}`,
     plugins: ["test-plugin"],
+    preset: "conventionalcommits",
   };
   // Create package.json and shareable.json in repository root
   await outputJson(path.resolve(cwd, "package.json"), { release: pkgOptions });
@@ -673,6 +694,7 @@ test.serial('Allow to unset properties defined in shareable config with "undefin
     analyzeCommits: { path: "analyzeCommits", param: "analyzeCommits_param" },
     tagFormat: `v\${version}`,
     plugins: false,
+    preset: "conventionalcommits",
   };
   // Create release.config.js and shareable.json in repository root
   await writeFile(path.resolve(cwd, "release.config.js"), `module.exports = ${format(pkgOptions)}`);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -97,6 +97,7 @@ test.serial("Plugins are called with expected values", async (t) => {
     originalRepositoryURL: repositoryUrl,
     globalOpt: "global",
     tagFormat: `v\${version}`,
+    preset: "conventionalcommits",
   };
   const branches = [
     {
@@ -912,6 +913,7 @@ test.serial('Call all "success" plugins even if one errors out', async (t) => {
     repositoryUrl,
     globalOpt: "global",
     tagFormat: `v\${version}`,
+    preset: "conventionalcommits",
   };
   const options = {
     ...config,
@@ -962,6 +964,7 @@ test.serial('Log all "verifyConditions" errors', async (t) => {
     repositoryUrl,
     originalRepositoryURL: repositoryUrl,
     tagFormat: `v\${version}`,
+    preset: "conventionalcommits",
   };
   const options = {
     ...config,
@@ -1012,7 +1015,12 @@ test.serial('Log all "verifyRelease" errors', async (t) => {
   const error1 = new SemanticReleaseError("error 1", "ERR1");
   const error2 = new SemanticReleaseError("error 2", "ERR2");
   const fail = stub().resolves();
-  const config = { branches: [{ name: "master" }], repositoryUrl, tagFormat: `v\${version}` };
+  const config = {
+    branches: [{ name: "master" }],
+    repositoryUrl,
+    tagFormat: `v\${version}`,
+    preset: "conventionalcommits",
+  };
   const options = {
     ...config,
     verifyConditions: stub().resolves(),


### PR DESCRIPTION
Nowadays the `conventionalcommits` is the closest thing we have that looks like a standard and neutral.

Also, a new cli option was added: `--preset`.

BREAKING CHANGE: Previously, the default preset was `angular`. Despite the similarities, the new one has some differences, such as accepting exclamation marks (e.g. `feat!:`) for identifying breaking changes.  To restore the previous behavior, use `preset: 'angular'` or the new cli option, `--preset angular`.

Closes #1652
Closes #3406