### PR TITLE
Minor fixes to documentation

### DIFF
--- a/docs/developer-guide/plugin.md
+++ b/docs/developer-guide/plugin.md
@@ -2,7 +2,8 @@
 
 To create a plugin for `semantic-release`, you need to decide which parts of the release lifecycle are important to that plugin. For example, it is best to always have a `verify` step because you may be receiving inputs from a user and want to make sure they exist. A plugin can abide by any of the following lifecycles:
 
-- `verify`
+- `analyzeCommits`
+- `verifyConditions`
 - `prepare`
 - `publish`
 - `success`


### PR DESCRIPTION
As I was reading the documentation and starting my own plugin project, I noticed while trying to print the context object content in different situations, that the documentation has some errors:

- analyzeCommits missing from the lifecycle list
- "verify" lifecycle should be "verifyConditions"

These are addressed by this pull request.