### PR TITLE
Enable option to add custom git note

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -22,6 +22,7 @@ Usage:
     .option('b', {alias: 'branches', describe: 'Git branches to release from', ...stringList, group: 'Options'})
     .option('r', {alias: 'repository-url', describe: 'Git repository URL', type: 'string', group: 'Options'})
     .option('t', {alias: 'tag-format', describe: 'Git tag format', type: 'string', group: 'Options'})
+    .option('n', {alias: 'git-note', describe: 'Custom Git note', type: 'string', group: 'Options'})
     .option('p', {alias: 'plugins', describe: 'Plugins', ...stringList, group: 'Options'})
     .option('e', {alias: 'extends', describe: 'Shareable configurations', ...stringList, group: 'Options'})
     .option('ci', {describe: 'Toggle CI verifications', type: 'boolean', group: 'Options'})

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ async function run(context, plugins) {
   } else {
     // Create the tag before calling the publish plugins as some require the tag to exists
     await tag(nextRelease.gitTag, nextRelease.gitHead, {cwd, env});
-    await addNote({channels: [nextRelease.channel]}, nextRelease.gitHead, {cwd, env});
+    await addNote({channels: [nextRelease.channel], note: options.gitNote || ''}, nextRelease.gitHead, {cwd, env});
     await push(options.repositoryUrl, {cwd, env});
     await pushNotes(options.repositoryUrl, {cwd, env});
     logger.success(`Created tag ${nextRelease.gitTag}`);


### PR DESCRIPTION
Currently the git push is rejected if there are server side git hooks to validate git notes. So need option to add custom git note.