### PR TITLE
feat: added disable-push option to disable pushing to git

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,6 +35,7 @@ Usage:
     .option('fail', {...stringList, group: 'Plugins'})
     .option('debug', {describe: 'Output debugging information', type: 'boolean', group: 'Options'})
     .option('d', {alias: 'dry-run', describe: 'Skip publishing', type: 'boolean', group: 'Options'})
+    .option('disable-push', {describe: 'Skip pushing', type: 'boolean', group: 'Options'})
     .option('h', {alias: 'help', group: 'Options'})
     .option('v', {alias: 'version', group: 'Options'})
     .strict(false)

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -3,7 +3,7 @@
 **semantic-release** configuration consists of:
 - Git repository ([URL](#repositoryurl) and options [release branches](#branches) and [tag format](#tagformat))
 - Plugins [declaration](#plugins) and options
-- Run mode ([debug](#debug), [dry run](#dryrun) and [local (no CI)](#ci))
+- Run mode ([debug](#debug), [dry run](#dryrun), [local (no CI)](#ci) and [disable push](#disablepush))
 
 All of these options can be configured through config file, CLI arguments or by extending a [shareable configuration](shareable-configurations.md).
 
@@ -118,7 +118,15 @@ CLI arguments: `-d`, `--dry-run`
 
 The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following steps: prepare, publish, success and fail. In addition to this it prints the next version and release notes to the console.
 
-**Note**: The Dry-run mode verifies the repository push permission, even though nothing will be pushed. The verification is done to help user to figure out potential configuration issues.
+**Note**: The Dry-run mode verifies the repository push permission, even though nothing will be pushed. The verification is done to help user to figure out potential configuration issues. If you do not want to verify push permissions nor push any changes use the [disable push](#disablepush) flag.
+
+### disablePush
+
+Type: `Boolean`<br>
+Default: `false`<br>
+CLI arguments: `--disable-push`
+
+Set to `true` to disable verifying push permissions and pushing anything. This can be useful when wanting to handle the release by yourself.
 
 ### ci
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const {extractErrors, makeTag} = require('./lib/utils');
 const getGitAuthUrl = require('./lib/get-git-auth-url');
 const getBranches = require('./lib/branches');
 const getLogger = require('./lib/get-logger');
-const {verifyAuth, isBranchUpToDate, getGitHead, tag, push, pushNotes, getTagHead, addNote} = require('./lib/git');
+const {verifyPushAuth, isBranchUpToDate, getGitHead, tag, push, pushNotes, getTagHead, addNote} = require('./lib/git');
 const getError = require('./lib/get-error');
 const {COMMIT_NAME, COMMIT_EMAIL} = require('./lib/definitions/constants');
 
@@ -74,7 +74,8 @@ async function run(context, plugins) {
 
   try {
     try {
-      await verifyAuth(options.repositoryUrl, context.branch.name, {cwd, env});
+      await verifyPushAuth(options.repositoryUrl, context.branch.name, {cwd, env});
+      logger.success(`Allowed to push to the Git repository`);
     } catch (error) {
       if (!(await isBranchUpToDate(options.repositoryUrl, context.branch.name, {cwd, env}))) {
         logger.log(
@@ -83,14 +84,16 @@ async function run(context, plugins) {
         return false;
       }
 
-      throw error;
+      if (options.disablePush) {
+        logger.warn('No push permissions required in disable-push mode');
+      } else {
+        throw error;
+      }
     }
   } catch (error) {
     logger.error(`The command "${error.command}" failed with the error message ${error.stderr}.`);
     throw getError('EGITNOPERMISSION', context);
   }
-
-  logger.success(`Allowed to push to the Git repository`);
 
   await plugins.verifyConditions(context);
 
@@ -111,6 +114,8 @@ async function run(context, plugins) {
 
       if (options.dryRun) {
         logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
+      } else if (options.disablePush) {
+        logger.warn(`Skip ${nextRelease.gitTag} tag creation in disable-push mode`);
       } else {
         await addNote({channels: [...currentRelease.channels, nextRelease.channel]}, nextRelease.gitHead, {cwd, env});
         await push(options.repositoryUrl, {cwd, env});
@@ -186,6 +191,8 @@ async function run(context, plugins) {
 
   if (options.dryRun) {
     logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
+  } else if (options.disablePush) {
+    logger.warn(`Skip ${nextRelease.gitTag} tag creation in disable-push mode`);
   } else {
     // Create the tag before calling the publish plugins as some require the tag to exists
     await tag(nextRelease.gitTag, nextRelease.gitHead, {cwd, env});

--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -1,7 +1,7 @@
 const {parse, format} = require('url'); // eslint-disable-line node/no-deprecated-api
 const {isNil} = require('lodash');
 const hostedGitInfo = require('hosted-git-info');
-const {verifyAuth} = require('./git');
+const {verifyPushAuth} = require('./git');
 const debug = require('debug')('semantic-release:get-git-auth-url');
 
 /**
@@ -29,7 +29,7 @@ function formatAuthUrl(protocol, repositoryUrl, gitCredentials) {
 }
 
 /**
- * Verify authUrl by calling git.verifyAuth, but don't throw on failure
+ * Verify authUrl by calling git.verifyPushAuth, but don't throw on failure
  *
  * @param {Object} context semantic-release context.
  * @param {String} authUrl Repository URL to verify
@@ -38,7 +38,7 @@ function formatAuthUrl(protocol, repositoryUrl, gitCredentials) {
  */
 async function ensureValidAuthUrl({cwd, env, branch}, authUrl) {
   try {
-    await verifyAuth(authUrl, branch.name, {cwd, env});
+    await verifyPushAuth(authUrl, branch.name, {cwd, env});
     return authUrl;
   } catch (error) {
     debug(error);
@@ -88,7 +88,7 @@ module.exports = async (context) => {
   // Test if push is allowed without transforming the URL (e.g. is ssh keys are set up)
   try {
     debug('Verifying ssh auth by attempting to push to  %s', repositoryUrl);
-    await verifyAuth(repositoryUrl, branch.name, {cwd, env});
+    await verifyPushAuth(repositoryUrl, branch.name, {cwd, env});
   } catch (_) {
     debug('SSH key auth failed, falling back to https.');
     const envVars = Object.keys(GIT_TOKENS).filter((envVar) => !isNil(env[envVar]));

--- a/lib/git.js
+++ b/lib/git.js
@@ -202,7 +202,7 @@ async function isGitRepo(execaOptions) {
  *
  * @throws {Error} if not authorized to push.
  */
-async function verifyAuth(repositoryUrl, branch, execaOptions) {
+async function verifyPushAuth(repositoryUrl, branch, execaOptions) {
   try {
     await execa('git', ['push', '--dry-run', '--no-verify', repositoryUrl, `HEAD:${branch}`], execaOptions);
   } catch (error) {
@@ -339,7 +339,7 @@ module.exports = {
   getGitHead,
   repoUrl,
   isGitRepo,
-  verifyAuth,
+  verifyPushAuth,
   tag,
   push,
   pushNotes,

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -62,6 +62,7 @@ test.serial('Pass options to semantic-release API', async (t) => {
     'fail2',
     '--debug',
     '-d',
+    '--disable-push',
   ];
   const cli = proxyquire('../cli', {'.': run, process: {...process, argv}});
 
@@ -82,6 +83,7 @@ test.serial('Pass options to semantic-release API', async (t) => {
   t.deepEqual(run.args[0][0].fail, ['fail1', 'fail2']);
   t.is(run.args[0][0].debug, true);
   t.is(run.args[0][0].dryRun, true);
+  t.is(run.args[0][0].disablePush, true);
 
   t.is(exitCode, 0);
 });
@@ -104,6 +106,7 @@ test.serial('Pass options to semantic-release API with alias arguments', async (
     'config1',
     'config2',
     '--dry-run',
+    '--disable-push',
   ];
   const cli = proxyquire('../cli', {'.': run, process: {...process, argv}});
 
@@ -115,6 +118,7 @@ test.serial('Pass options to semantic-release API with alias arguments', async (
   t.deepEqual(run.args[0][0].plugins, ['plugin1', 'plugin2']);
   t.deepEqual(run.args[0][0].extends, ['config1', 'config2']);
   t.is(run.args[0][0].dryRun, true);
+  t.is(run.args[0][0].disablePush, true);
 
   t.is(exitCode, 0);
 });


### PR DESCRIPTION
I firstly thought about skipping the whole `verifyPushAuth`, but then just went with a bit of a more safe approach.

`isBranchUpToDate` is done pretty badly so it also returns false when local is up to date, but just there is some additional commit. Also the user might have or not permissions to read the repo therefore an error will throw if he can't read the repo for some reason. I didn't want to put an additional (third) try-catch, because I think it's a trivial case.
  
This will be pretty useful when using the JS API to grab the newRelease version and note.