### PR TITLE
fix: bump minimal version of lodash to address `CVE-2021-23337`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "git-log-parser": "^1.2.0",
     "hook-std": "^2.0.0",
     "hosted-git-info": "^4.0.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "marked": "^2.0.0",
     "marked-terminal": "^4.1.1",
     "micromatch": "^4.0.2",


### PR DESCRIPTION
See CVE-2021-23337

fixes #1930 thanks @gnanderson