### PR TITLE
docs(README): semantic-release only cares about commit message not PR title

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ By default **semantic-release** uses [Angular Commit Message Conventions](https:
 
 Tools such as [commitizen](https://github.com/commitizen/cz-cli) or [commitlint](https://github.com/conventional-changelog/commitlint) can be used to help contributors and enforce valid commit messages.
 
+**semantic-release** does not care about the pull request title, the only thing that matters is the commit message you end up with after a normal merge, squash merge, or rebase. For example, if you squash-merge a pull request, the pull request title will become the main commit message.
+
 The table below shows which commit message gets you which release type when `semantic-release` runs (using the default configuration):
 
 | Commit message                                                                                                                                                                                   | Release type               |


### PR DESCRIPTION
## Changes:

- Explain that semantic-release only cares about the commit message after merge/squash/rebase

## Context:

I had trouble figuring out if the PR title with a `!` would result in **semantic-release** making a BREAKING CHANGE release, when the repository uses the `commit-analyzer` plugin with the `conventionalcommits` preset, and with squash-merges as the only merge option.

The essence of the problem was that I did not understand what would happen once you squash-merge a PR. The PR title becomes the main commit message that **semantic-release** uses.

I think it's clearer if we explain the distinction between pull request title and commit message.

Pinging @travi for a review, as they know the full context.

See https://github.com/renovatebot/renovate/pull/10243 for my confusion on understanding how **semantic-release** and the `commit-analyzer` plugin work together. 😄 