### PR TITLE
fix: prevent concurrency issue whene multiple channel are released

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,17 @@ const {extractErrors, makeTag} = require('./lib/utils');
 const getGitAuthUrl = require('./lib/get-git-auth-url');
 const getBranches = require('./lib/branches');
 const getLogger = require('./lib/get-logger');
-const {verifyAuth, isBranchUpToDate, getGitHead, tag, push, pushNotes, getTagHead, addNote} = require('./lib/git');
+const {
+  verifyAuth,
+  isBranchUpToDate,
+  getGitHead,
+  tag,
+  push,
+  pushNotes,
+  getTagHead,
+  addNote,
+  fetchNotes,
+} = require('./lib/git');
 const getError = require('./lib/get-error');
 const {COMMIT_NAME, COMMIT_EMAIL} = require('./lib/definitions/constants');
 
@@ -112,6 +122,7 @@ async function run(context, plugins) {
       if (options.dryRun) {
         logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
       } else {
+        await fetchNotes(options.repositoryUrl, {cwd, env});
         await addNote({channels: [...currentRelease.channels, nextRelease.channel]}, nextRelease.gitHead, {cwd, env});
         await push(options.repositoryUrl, {cwd, env});
         await pushNotes(options.repositoryUrl, {cwd, env});


### PR DESCRIPTION
This would reduce the risk of conflicts error when two different channels are released at the same time.

Because at each release for every channel a new note is pushed on `refs/notes/semantic-release`, sometimes we have the following error : 
```
To https://github.com/PayFit/subscriptions.git
 ! [rejected]        refs/notes/semantic-release -> refs/notes/semantic-release (fetch first)
error: failed to push some refs to 'https://github.com/PayFit/subscriptions.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

A fetch before adding a new note would reduce this risk.