### PR TITLE
docs: add new community plugin

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -140,3 +140,5 @@
   - `verifyConditions`: Validate configuration and verify ```HEROKU_API_KEY```
   - `prepare`: Update the package.json version and create release tarball
   - `publish`: Publish version to heroku
+- [semantic-release-interval](https://www.npmjs.com/package/semantic-release-interval)
+  - `analyzeCommits`: Triggers a new release if the oldest commit since the last release is over a certain age.


### PR DESCRIPTION
The [semantic-release-interval](https://www.npmjs.com/package/semantic-release-interval) plugin provides functionality to trigger a new release if the oldest commit since the last release is over a certain age.

This solves a particular use case where no fix/feat commits were made but many changes have built up in other areas (ci, build, chore) that may have some impact on the generated artifacts.

Example debug output:

```
[7:32:30 PM] [semantic-release] [semantic-release-interval] › ℹ  committerDate: 2021-09-20T17:58:24+00:00
[7:32:30 PM] [semantic-release] [semantic-release-interval] › ℹ  committerDate: 2021-09-20T19:31:05+00:00
[7:32:30 PM] [semantic-release] [semantic-release-interval] › ℹ  Oldest `committerDate` before threshold, 1 week(s).
  oldest commit: 2021-06-21T19:09:07+00:00
  threshold:     2021-09-13T19:32:30+00:00
[7:32:30 PM] [semantic-release] [semantic-release-interval] › ℹ  Setting release to 'patch' based upon interval.
```