### PR TITLE
docs: add semantic-release-mattermost to the plugin list

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -143,3 +143,4 @@
 - [semantic-release-mattermost](https://github.com/ttrobisch/semantic-release-mattermost)
   - `verifyConditions`: Verify that the webhook is setup and release-notes-generator is present.
   - `success`: Send a message about the new release and its notes to a mattermost webhook.
+

--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -142,5 +142,5 @@
   - `publish`: Publish version to heroku
 - [semantic-release-mattermost](https://github.com/ttrobisch/semantic-release-mattermost)
   - `verifyConditions`: Verify that the webhook is setup and release-notes-generator is present.
-  - `success`: Send a message about the new release and its notes to a mattermost webhook.
+  - `success`: Send a message about the new release and its notes to a [mattermost](https://mattermost.com/) webhook.
 

--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -140,3 +140,6 @@
   - `verifyConditions`: Validate configuration and verify ```HEROKU_API_KEY```
   - `prepare`: Update the package.json version and create release tarball
   - `publish`: Publish version to heroku
+- [semantic-release-mattermost](https://github.com/ttrobisch/semantic-release-mattermost)
+  - `verifyConditions`: Verify that the webhook is setup and release-notes-generator is present.
+  - `success`: Send a message about the new release and its notes to a mattermost webhook.


### PR DESCRIPTION
The plugin will send information about the new release to a mattermost webhook.