### PR TITLE
Use Configured Prerelease ID

### DIFF
--- a/lib/get-next-version.js
+++ b/lib/get-next-version.js
@@ -8,6 +8,13 @@ module.exports = ({branch, nextRelease: {type, channel}, lastRelease, logger}) =
     const {major, minor, patch} = semver.parse(lastRelease.version);
 
     if (branch.type === 'prerelease') {
+      const parsedVersion = semver.parse(lastRelease.version);
+
+      if (!parsedVersion.prerelease.includes(branch.prerelease)) {
+        parsedVersion.prerelease[0] = branch.prerelease;
+        lastRelease.version = parsedVersion.format();
+      }
+
       if (
         semver.prerelease(lastRelease.version) &&
         lastRelease.channels.some((lastReleaseChannel) => isSameChannel(lastReleaseChannel, channel))

--- a/test/get-next-version.test.js
+++ b/test/get-next-version.test.js
@@ -275,3 +275,26 @@ test('Increase version for release on prerelease branch when there is no regular
     '1.0.0-beta.2'
   );
 });
+
+test('Change prerelease id for version after the fact', (t) => {
+  t.is(
+    getNextVersion({
+      branch: {
+        name: 'main',
+        type: 'prerelease',
+        prerelease: 'canary',
+        tags: [
+          {
+            gitTag: 'v1.0.0-main.42',
+            version: '1.0.0-main.42',
+            channels: ['canary'],
+          },
+        ],
+      },
+      nextRelease: {type: 'patch', channel: 'canary'},
+      lastRelease: {version: 'v1.0.0-main.42', channels: ['canary']},
+      logger: t.context.logger,
+    }),
+    '1.0.0-canary.42'
+  );
+});


### PR DESCRIPTION
When `branch.prerelease` is set to a String, it's expected that this will be used as the prerelease for the version. However, if a previous version using this branch name is found in the list of tags, the logic here will always choose to use that branch name as the prerelease ID and ignore your configuration. This makes it effectively impossible to change a prerelease ID to something different than the branch name if you make a mistake (which is very easy to do since this is mostly undocumented behavior).

Fixes #2177