### PR TITLE
docs: add semantic-release-github-milestones plugin

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -143,4 +143,6 @@
 - [semantic-release-mattermost](https://github.com/ttrobisch/semantic-release-mattermost)
   - `verifyConditions`: Verify that the webhook is setup and release-notes-generator is present.
   - `success`: Send a message about the new release and its notes to a [mattermost](https://mattermost.com/) webhook.
-
+- [semantic-release-github-milestones](https://github.com/nitzano/semantic-release-github-milestones)
+  - `verifyConditions`: Verify github tokens are present and valid.
+  - `verifyRelease`: Display information regarding the matching github milestone.


### PR DESCRIPTION
closes #2182

See the full plugin info here: https://github.com/nitzano/semantic-release-github-milestones