### PR TITLE
docs: add semantic-release-npm-deprecate plugin

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -150,3 +150,5 @@
   - `verifyConditions`: Validate configuration and verify `TELEGRAM_BOT_TOKEN` and package name
   - `success`: Publish a success message to certain telegram chats
   - `fail`: Publish a fail message to certain telegram chats
+- [semantic-release-npm-deprecate](https://github.com/jpoehnelt/semantic-release-npm-deprecate)
+  - `publish`: Automatically mark old versions as deprecated.


### PR DESCRIPTION
This plugin allows automatically marking NPM releases as deprecated.

```yml
  [
      "semantic-release-npm-deprecate",
      {
        "deprecations": [
          {
            "version": "< ${nextRelease.version.split('.')[0]}",
            "message": "Please use ^${nextRelease.version.split('.')[0]}.0.0."
          }
        ]
      }
    ]
```