### PR TITLE
docs(badge): switched to proper semantic-release logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ In order to use **semantic-release** you need:
 
 Let people know that your package is published using **semantic-release** by including this badge in your readme.
 
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![semantic-release](https://img.shields.io/badge/semantic-release-e10079.svg?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
 ```md
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![semantic-release](https://img.shields.io/badge/semantic-release-e10079.svg?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 ```
 
 ## Team


### PR DESCRIPTION
shields.io now has our official logo available through `simple-icons`. 

i was trying to get just the logo on the dark part of the left, similar to the previous version, but was unsuccessful without text content on both sections. i dont hate having `semantic` on the left section and `release` on the right section, but removing the `-` steps away from the official name. i'm interested in thoughts around how this is actually rendering.

also, i'm not sure what the history is around the color used for the badge. is it still the most appropriate for the project? i have no reason to change it, but thought this was a good chance to at least confirm.