### PR TITLE
docs: update badges to include preset names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <img alt="Build states" src="https://github.com/semantic-release/semantic-release/workflows/Test/badge.svg">
   </a>
   <a href="#badge">
-    <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
+    <img alt="semantic-release: angular" src="https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release">
   </a>
 </p>
 <p align="center">
@@ -141,10 +141,11 @@ In order to use **semantic-release** you need:
 
 Let people know that your package is published using **semantic-release** by including this badge in your readme.
 
-[![semantic-release](https://img.shields.io/badge/semantic-release-e10079.svg?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
 ```md
-[![semantic-release](https://img.shields.io/badge/semantic-release-e10079.svg?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+
 ```
 
 ## Team


### PR DESCRIPTION
From https://github.com/semantic-release/semantic-release/issues/1825#issuecomment-978119923:

> @chalkygames123 are you interested in opening a PR that updates the readme badge and the docs suggesting the badge to use in projects using semantic-release?

@travi Well, about the latter, honestly, I found it kind of hard to write because English is not my first language 😅 So for the sake of accuracy, would you mind if I leave it to you?