### PR TITLE
docs: wrong prerelease example

### DIFF
--- a/docs/usage/workflow-configuration.md
+++ b/docs/usage/workflow-configuration.md
@@ -91,7 +91,7 @@ For example the configuration `['master', {name: 'pre/rc', prerelease: '${name.r
   branches: [
     {name: 'master'},
     {name: 'pre/rc', channel: 'pre/rc', prerelease: 'rc'}, // `prerelease` is built with the template `${name.replace(/^pre\\//g, "")}`
-    {name: 'beta', channel: 'beta', prerelease: 'beta'}, // `prerelease` is set to `beta` as it is the value of `name`
+    {name: 'beta', channel: 'beta', prerelease: true}, // `prerelease` is set to `beta` as it is the value of `name`
   ]
 }
 ```


### PR DESCRIPTION
The documentation says:

> If the `prerelease` property is set to `true` the `name` value will be used.

But then the example referring to this behaviour has the the `prerelease` value set to `'beta'` instead of `true`.