### PR TITLE
feat: add pathFilter option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,7 @@ Usage:
     .option('p', {alias: 'plugins', describe: 'Plugins', ...stringList, group: 'Options'})
     .option('e', {alias: 'extends', describe: 'Shareable configurations', ...stringList, group: 'Options'})
     .option('ci', {describe: 'Toggle CI verifications', type: 'boolean', group: 'Options'})
+    .option('f', {alias: 'path-filter',describe: 'Path Filter', type: 'string', group: 'Options'})
     .option('verify-conditions', {...stringList, group: 'Plugins'})
     .option('analyze-commits', {type: 'string', group: 'Plugins'})
     .option('verify-release', {...stringList, group: 'Plugins'})

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -98,6 +98,21 @@ The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) format used by 
 
 **Note**: The `tagFormat` must contain the `version` variable exactly once and compile to a [valid Git reference](https://git-scm.com/docs/git-check-ref-format#_description).
 
+### pathFilter
+
+Type: `String`<br>
+Default: `null`<br>
+CLI arguments: `-f`, `--path-filter`
+
+If you need to limit commit analysis to a particular path. Default behaviour is no file filtering.
+
+Example : 
+
+* limit commit to specific directory
+* exclude one or multiple directories
+
+**Note**: Default value is `null` and is the same as `*`. You can use this regexp `^((?!mysubdir).)*$` to exclude specific dir.
+
 ### plugins
 
 Type: `Array`<br>

--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -1,5 +1,41 @@
+const {identity, memoizeWith} = require('ramda');
 const debug = require('debug')('semantic-release:get-commits');
-const {getCommits} = require('./git');
+const {getCommits, getCommitFiles} = require('./git');
+const memoizedGetCommitFiles = memoizeWith(identity, getCommitFiles);
+
+/**
+ * Filter the list of commits with regex for files path
+ *
+ * @param {Array<Object>} commits commits list
+ * @param {String} pathFilter regexp filter
+ *
+ * @return {Promise<Array<Object>>} The list of filtered commits on the branch `branch` since the last release.
+ *
+ */
+async function filterCommitsWithPath(commits, pathFilter, execaOptions) {
+
+    let commitsWithFiles = await Promise.all(commits.map(async commit => {
+        let files = await memoizedGetCommitFiles(commit.hash, execaOptions);
+        return {commit: commit, files: files}
+    }))
+
+    return commitsWithFiles.filter(commitWithFiles => {
+
+        let files = commitWithFiles.files.filter((file) => {
+            if (file.match(pathFilter) != null) {
+                // if we found file to include,
+                return true
+            }
+            return false
+        })
+
+        if (files.length > 0) {
+            return true
+        }
+        return false
+
+    }).map(commitsWithFiles => commitsWithFiles.commit);
+};
 
 /**
  * Retrieve the list of commits on the current branch since the commit sha associated with the last release, or all the commits of the current branch if there is no last released version.
@@ -7,16 +43,19 @@ const {getCommits} = require('./git');
  * @param {Object} context semantic-release context.
  *
  * @return {Promise<Array<Object>>} The list of commits on the branch `branch` since the last release.
+ *
  */
-module.exports = async ({cwd, env, lastRelease: {gitHead: from}, nextRelease: {gitHead: to = 'HEAD'} = {}, logger}) => {
+module.exports = async ({cwd, env, lastRelease: {gitHead: from}, nextRelease: {gitHead: to = 'HEAD'} = {}, logger, options}) => {
   if (from) {
     debug('Use from: %s', from);
   } else {
     logger.log('No previous release found, retrieving all commits');
   }
 
-  const commits = await getCommits(from, to, {cwd, env});
-
+  let commits = await getCommits(from, to, {cwd, env});
+  if (options.pathFilter != null) {
+      commits = await filterCommitsWithPath(commits, options.pathFilter, {cwd, env})
+  }
   logger.log(`Found ${commits.length} commits since last release`);
   debug('Parsed commits: %o', commits);
   return commits;

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -64,6 +64,7 @@ module.exports = async (context, cliOptions) => {
     ],
     repositoryUrl: (await pkgRepoUrl({normalize: false, cwd})) || (await repoUrl({cwd, env})),
     tagFormat: `v\${version}`,
+    pathFilter: null,
     plugins: [
       '@semantic-release/commit-analyzer',
       '@semantic-release/release-notes-generator',

--- a/lib/git.js
+++ b/lib/git.js
@@ -328,6 +328,21 @@ async function addNote(note, ref, execaOptions) {
   await execa('git', ['notes', '--ref', GIT_NOTE_REF, 'add', '-f', '-m', JSON.stringify(note), ref], execaOptions);
 }
 
+/**
+ * Get modified files in commit
+ * @async
+ * @param hash Git commit hash.
+ * @return {Array<String>} List of modified files in a commit.
+ */
+async function getCommitFiles(hash,execaOptions) {
+  try {
+    return (await execa('git', ['diff-tree','--root', '--no-commit-id', '--name-only', '-r', hash], execaOptions)).stdout
+        .split('\n')
+  } catch (error) {
+    debug(error);
+  }
+}
+
 module.exports = {
   getTagHead,
   getTags,
@@ -348,4 +363,5 @@ module.exports = {
   verifyBranchName,
   getNote,
   addNote,
+  getCommitFiles,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "execa": "^5.0.0",
         "figures": "^3.0.0",
         "find-versions": "^4.0.0",
+        "fs-extra": "^10.0.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
         "hook-std": "^2.0.0",
@@ -31,6 +32,7 @@
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
+        "ramda": "^0.27.1",
         "read-pkg-up": "^7.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
@@ -1630,6 +1632,21 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/ava/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/ava/node_modules/p-locate": {
       "version": "3.0.0",
@@ -4219,18 +4236,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "node_modules/eslint-module-utils/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-module-utils/node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -4239,15 +4244,6 @@
       "dependencies": {
         "p-limit": "^1.1.0"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4472,18 +4468,6 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-plugin-import/node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -4492,15 +4476,6 @@
       "dependencies": {
         "p-limit": "^1.1.0"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11644,17 +11619,22 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "p-try": "^1.0.0"
       },
       "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-limit/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-locate": {
@@ -11666,6 +11646,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
@@ -11996,17 +11990,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/pkg-conf/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pkg-conf/node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -12014,14 +11997,6 @@
       "dependencies": {
         "p-limit": "^1.1.0"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "engines": {
         "node": ">=4"
       }
@@ -12301,6 +12276,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -15442,18 +15422,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/xo/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/xo/node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -15462,15 +15430,6 @@
       "dependencies": {
         "p-limit": "^1.1.0"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/xo/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -16991,6 +16950,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
         },
         "p-locate": {
           "version": "3.0.0",
@@ -19180,15 +19148,6 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
         "p-locate": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -19197,12 +19156,6 @@
           "requires": {
             "p-limit": "^1.1.0"
           }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
@@ -19371,15 +19324,6 @@
             "validate-npm-package-license": "^3.0.1"
           }
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
         "p-locate": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -19388,12 +19332,6 @@
           "requires": {
             "p-limit": "^1.1.0"
           }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
@@ -24570,11 +24508,18 @@
       "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "^1.0.0"
+      },
+      "dependencies": {
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
       }
     },
     "p-locate": {
@@ -24583,6 +24528,16 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "requires": {
         "p-limit": "^2.2.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-map": {
@@ -24838,14 +24793,6 @@
             "path-exists": "^3.0.0"
           }
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
         "p-locate": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -24853,11 +24800,6 @@
           "requires": {
             "p-limit": "^1.1.0"
           }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "path-exists": {
           "version": "3.0.0",
@@ -25053,6 +24995,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -27573,15 +27520,6 @@
             }
           }
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
         "p-locate": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
@@ -27590,12 +27528,6 @@
           "requires": {
             "p-limit": "^1.1.0"
           }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
         },
         "pify": {
           "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "semver": "^7.3.2",
     "semver-diff": "^3.1.1",
     "signale": "^1.2.1",
-    "yargs": "^16.2.0"
+    "yargs": "^16.2.0",
+    "ramda": "^0.27.1",
+    "fs-extra": "^10.0.0"
   },
   "devDependencies": {
     "ava": "3.15.0",

--- a/test/get-commits.test.js
+++ b/test/get-commits.test.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const {stub} = require('sinon');
 const getCommits = require('../lib/get-commits');
-const {gitRepo, gitCommits, gitDetachedHead} = require('./helpers/git-utils');
+const {gitRepo, gitCommits,gitCommitsWithFiles, gitDetachedHead} = require('./helpers/git-utils');
 
 test.beforeEach((t) => {
   // Stub the logger functions
@@ -111,4 +111,32 @@ test('Return empty array if there is no commits', async (t) => {
 
   // Verify no commit is retrieved
   t.deepEqual(result, []);
+});
+
+test('Return only commit for module1 path', async (t) => {
+  // Create a git repository, set the current working directory at the root of the repo
+  const {cwd} = await gitRepo();
+  let commitsToCreate = [{message: "message1",files: ["readme.md"]},{message: "message2",files: ["module1/readme.md"]},{message: "message3",files: ["readme1.md","module1/readme2.md"]}]
+  let pathFilter = "module1/*"
+  commits = await gitCommitsWithFiles(commitsToCreate,{cwd},{cwd})
+
+  // Retrieve the commits with the commits module
+  const result = await getCommits({cwd, lastRelease: {}, logger: t.context.logger},pathFilter);
+
+  // Verify only commit is retrieved
+  t.deepEqual(result, commits.slice(0,2));
+});
+
+test('Return only commit for root path excluding module1 path', async (t) => {
+  // Create a git repository, set the current working directory at the root of the repo
+  const {cwd} = await gitRepo();
+  let commitsToCreate = [{message: "message1",files: ["readme.md"]},{message: "message2",files: ["module1/readme.md"]},{message: "message3",files: ["readme1.md","module1/readme2.md"]},{message: "message4",files: ["readme4.md"]}]
+  let pathFilter = "^((?!module1).)*$"
+  let commits = await gitCommitsWithFiles(commitsToCreate, {cwd}, {cwd})
+
+  // Retrieve the commits with the commits module
+  const result = await getCommits({cwd, lastRelease: {}, logger: t.context.logger},pathFilter);
+
+  // Verify only commit is retrieved
+  t.deepEqual(result, Array.of().concat(commits.slice(0,2),commits[3]));
 });


### PR DESCRIPTION
I need to exclude specific path in commit analysis.

**Example:** 

```
project
│   README.md
│   file001.txt    
│
└───folder1
│   │   file011.txt
│   │   file012.txt
│   
└───folder2
    │   file021.txt
    │   file022.txt
```

I want to use specific configuration for `folder1`, another for `folder2` and one for `my root folder` excluding `folder1` and `folder2`.
With pathFilter option, i can run multiple times semantic release with specific configuration to trigger release for `folder1`, `folder2` and `root folder`.
