### PR TITLE
docs: added @iam1337/create-unitypackage plugin

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -157,3 +157,6 @@
   - `verifyConditions`: Verify plugin configuration and login to Helm registry
   - `prepare`: Package Helm chart to local folder
   - `publish`: Publish Helm chart to OCI registry
+- [@iam1337/create-unitypackage](https://github.com/Iam1337/create-unitypackage)
+  - `verifyConditions`:	Verify the `packageRoot`, `projectRoot` and `output` options configuration.
+  - `prepare`: Сreation unitypackage file.


### PR DESCRIPTION
Made a simple plugin for those who use semantic-release when working with projects in Unity. Builds unitypackage, which can then be sent to release via @semantic-release/github plugin.