### PR TITLE
feat: allow missing stable branch if other branches match the config

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -72,7 +72,7 @@ The branches on which releases should happen. By default **semantic-release** wi
 - prereleases to the `beta` distribution channel from the branch `beta` if it exists
 - prereleases to the `alpha` distribution channel from the branch `alpha` if it exists
 
-**Note**: If your repository does not have a release branch, then **semantic-release** will fail with an `ERELEASEBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `master` branch.
+**Note**: If your repository does not have a branch matching the configuration, then **semantic-release** will fail with an `ENOBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `master`, `beta` or `alpha` branch.
 
 **Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://docs.github.com/github/administering-a-repository/about-protected-branches).
 

--- a/lib/branches/index.js
+++ b/lib/branches/index.js
@@ -31,6 +31,11 @@ module.exports = async (repositoryUrl, ciBranch, context) => {
     {}
   );
 
+  // If there are no branches matching at least one of the types, throw.
+  if (!Object.values(branchesByType).some((branches) => Boolean(branches.length))) {
+    errors.push(getError('ENOBRANCHES'));
+  }
+
   const result = Object.entries(DEFINITIONS).reduce((result, [type, {branchesValidator, branchValidator}]) => {
     branchesByType[type].forEach((branch) => {
       if (branchValidator && !branchValidator(branch)) {

--- a/lib/definitions/branches.js
+++ b/lib/definitions/branches.js
@@ -17,7 +17,7 @@ const prerelease = {
 
 const release = {
   filter: (branch) => !maintenance.filter(branch) && !prerelease.filter(branch),
-  branchesValidator: (branches) => branches.length <= 3 && branches.length > 0,
+  branchesValidator: (branches) => branches.length <= 3,
 };
 
 module.exports = {maintenance, prerelease, release};

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -164,6 +164,14 @@ Your configuration for the problematic branch is \`${stringify(branch)}\`.`,
 
 Your configuration contains duplicates for the following branch names: \`${stringify(duplicates)}\`.`,
   }),
+  ENOBRANCHES: () => ({
+    message: 'The branches are invalid in the `branches` configuration.',
+    details: `A minimum of 1 branch is required in the [branches configuration](${linkify(
+      'docs/usage/configuration.md#branches'
+    )}).
+
+This may occur if your repository does not have a branch to be released, such as \`master\`, \`beta\` or \`alpha\`.`,
+  }),
   EMAINTENANCEBRANCH: ({branch}) => ({
     message: 'A maintenance branch is invalid in the `branches` configuration.',
     details: `Each maintenance branch in the [branches configuration](${linkify(
@@ -182,11 +190,9 @@ Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
   }),
   ERELEASEBRANCHES: ({branches}) => ({
     message: 'The release branches are invalid in the `branches` configuration.',
-    details: `A minimum of 1 and a maximum of 3 release branches are required in the [branches configuration](${linkify(
+    details: `A maximum of 3 release branches are allowed in the [branches configuration](${linkify(
       'docs/usage/configuration.md#branches'
     )}).
-
-This may occur if your repository does not have a release branch, such as \`master\`.
 
 Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
   }),

--- a/test/branches/branches.test.js
+++ b/test/branches/branches.test.js
@@ -189,6 +189,17 @@ test('Enforce ranges with branching release workflow', async (t) => {
   t.is(getBranch(result, '1.x').range, '>=1.2.0 <2.0.0', 'Can release on 1.x only within range');
 });
 
+test('Throw SemanticReleaseError if there are no branches matching the configuration', async (t) => {
+  const branches = [];
+  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches, './expand': () => []});
+  const errors = [...(await t.throwsAsync(getBranches('repositoryUrl', 'master', {options: {branches}})))];
+
+  t.is(errors[0].name, 'SemanticReleaseError');
+  t.is(errors[0].code, 'ENOBRANCHES');
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+});
+
 test('Throw SemanticReleaseError for invalid configurations', async (t) => {
   const branches = [
     {name: '123', range: '123', tags: []},
@@ -198,6 +209,10 @@ test('Throw SemanticReleaseError for invalid configurations', async (t) => {
     {name: 'beta', prerelease: '', tags: []},
     {name: 'alpha', prerelease: 'alpha', tags: []},
     {name: 'preview', prerelease: 'alpha', tags: []},
+    {name: 'main', tags: []},
+    {name: 'master', tags: []},
+    {name: 'next', tags: []},
+    {name: 'next-major', tags: []},
   ];
   const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches, './expand': () => []});
   const errors = [...(await t.throwsAsync(getBranches('repositoryUrl', 'master', {options: {branches}})))];

--- a/test/definitions/branches.test.js
+++ b/test/definitions/branches.test.js
@@ -76,11 +76,11 @@ test('A "release" branch is identified by not havin a "range" or "prerelease" pr
   t.false(release.filter({name: 'some-name', prerelease: 'beta'}));
 });
 
-test('There must be between 1 and 3 release branches', (t) => {
+test('There must be at most 3 release branches', (t) => {
+  t.true(release.branchesValidator([]));
   t.true(release.branchesValidator([{name: 'branch1'}]));
   t.true(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}]));
   t.true(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}, {name: 'branch3'}]));
 
-  t.false(release.branchesValidator([]));
   t.false(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}, {name: 'branch3'}, {name: 'branch4'}]));
 });


### PR DESCRIPTION
Closes https://github.com/semantic-release/semantic-release/issues/2345 by relaxing some restrictions.

`ERELEASEBRANCHES` is no longer thrown when there are no stable branches matching the configuration. It is still thrown when there are more than 3 stable branches.
A new error `ENOBRANCHES` is now thrown where there are no (any, incl. prerelease and maintenance) branches matching the configuration.