### PR TITLE
Correct circleci workflow

### DIFF
--- a/docs/recipes/ci-configurations/circleci-workflows.md
+++ b/docs/recipes/ci-configurations/circleci-workflows.md
@@ -22,14 +22,12 @@ Finally, we call our release job with a `requires` parameter so that `release` w
 ```yaml
 version: 2.1
 orbs:
-  node: circleci/node@4.5
+  node: circleci/node@5.0.0
 jobs:
   release:
     executor: node/default
     steps:
       - checkout
-      - node/install:
-          lts: true
       - node/install-packages # Install and automatically cache packages
       # Run optional required steps before releasing
       # - run: npm run build-script

--- a/docs/recipes/ci-configurations/circleci-workflows.md
+++ b/docs/recipes/ci-configurations/circleci-workflows.md
@@ -28,7 +28,7 @@ jobs:
     executor: node/default
     steps:
       - checkout
-      - node/install
+      - node/install:
           lts: true
       - node/install-packages # Install and automatically cache packages
       # Run optional required steps before releasing


### PR DESCRIPTION
when I tried to apply [example Circle CI config](https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/circleci-workflows.md) to my config.yml, I found it contains a YAML syntax error, which is fixed in d2bc910.

And in a2e6ff1, the circleci/node version is upgraded and an unnecessary step is removed.
