### PR TITLE
docs: update broken link to CI config recipes

### DIFF
--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -13,7 +13,7 @@ Here is a few example of the CI services that can be used to achieve this:
 - [Wercker Workflows](http://devcenter.wercker.com/docs/workflows)
 - [GoCD Pipelines](https://docs.gocd.org/current/introduction/concepts_in_go.html#pipeline).
 
-See [CI configuration recipes](../recipes/ci-configurations/README.md) for more details.
+See [CI configuration recipes](../recipes/ci-configurations#ci-configurations) for more details.
 
 ## Authentication
 
@@ -44,6 +44,6 @@ See each plugin's documentation for the environment variables required.
 
 The authentication token/credentials have to be made available in the CI service via environment variables.
 
-See [CI configuration recipes](../recipes/ci-configurations/README.md) for more details on how to configure environment variables in your CI service.
+See [CI configuration recipes](../recipes/ci-configurations#ci-configurations) for more details on how to configure environment variables in your CI service.
 
 **Note**: The environment variables `GH_TOKEN`, `GITHUB_TOKEN`, `GL_TOKEN` and `GITLAB_TOKEN` can be used for both the Git authentication and the API authentication required by [@semantic-release/github](https://github.com/semantic-release/github) and [@semantic-release/gitlab](https://github.com/semantic-release/gitlab).


### PR DESCRIPTION
This PR updates the broken link to CI configuration recipes which was caused by a directory structure change I guess.