### PR TITLE
fix: remove upper limit on number of release branches

### DIFF
--- a/lib/definitions/branches.js
+++ b/lib/definitions/branches.js
@@ -17,7 +17,7 @@ const prerelease = {
 
 const release = {
   filter: (branch) => !maintenance.filter(branch) && !prerelease.filter(branch),
-  branchesValidator: (branches) => branches.length <= 3 && branches.length > 0,
+  branchesValidator: (branches) => branches.length > 0,
 };
 
 module.exports = {maintenance, prerelease, release};

--- a/test/definitions/branches.test.js
+++ b/test/definitions/branches.test.js
@@ -76,11 +76,11 @@ test('A "release" branch is identified by not havin a "range" or "prerelease" pr
   t.false(release.filter({name: 'some-name', prerelease: 'beta'}));
 });
 
-test('There must be between 1 and 3 release branches', (t) => {
+test('There must be at least 1 release branches', (t) => {
   t.true(release.branchesValidator([{name: 'branch1'}]));
   t.true(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}]));
   t.true(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}, {name: 'branch3'}]));
+  t.true(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}, {name: 'branch3'}, {name: 'branch4'}]));
 
   t.false(release.branchesValidator([]));
-  t.false(release.branchesValidator([{name: 'branch1'}, {name: 'branch2'}, {name: 'branch3'}, {name: 'branch4'}]));
 });


### PR DESCRIPTION
https://github.com/semantic-release/semantic-release/issues/1681

Hi,

As per the issue above there are scenarios where you may want more than 3 release branches.
I'm not sure where the number 3 comes from as I was unable to find it in the documentation.

Thank you