### PR TITLE
feat: add --skip-remote-check option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,7 @@ Usage:
     .option('success', {...stringList, group: 'Plugins'})
     .option('fail', {...stringList, group: 'Plugins'})
     .option('debug', {describe: 'Output debugging information', type: 'boolean', group: 'Options'})
+    .option('skip-remote-check', {describe: 'TODO', type: 'boolean', group: 'Options'})
     .option('d', {alias: 'dry-run', describe: 'Skip publishing', type: 'boolean', group: 'Options'})
     .option('h', {alias: 'help', group: 'Options'})
     .option('v', {alias: 'version', group: 'Options'})

--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -73,7 +73,7 @@ module.exports = async (context) => {
     BITBUCKET_TOKEN_BASIC_AUTH: '',
   };
 
-  let {repositoryUrl} = context.options;
+  let {repositoryUrl, skipRemoteCheck} = context.options;
   const info = hostedGitInfo.fromUrl(repositoryUrl, {noGitPlus: true});
   const {protocol, ...parsed} = parse(repositoryUrl);
 
@@ -85,35 +85,39 @@ module.exports = async (context) => {
     repositoryUrl = format({...parsed, protocol: protocol.includes('https') ? 'https' : 'http', href: null});
   }
 
-  // Test if push is allowed without transforming the URL (e.g. is ssh keys are set up)
-  try {
-    debug('Verifying ssh auth by attempting to push to  %s', repositoryUrl);
-    await verifyAuth(repositoryUrl, branch.name, {cwd, env});
-  } catch {
-    debug('SSH key auth failed, falling back to https.');
-    const envVars = Object.keys(GIT_TOKENS).filter((envVar) => !isNil(env[envVar]));
+  if (skipRemoteCheck) {
+    debug('Skipping remote verification, blindly using url  %s', repositoryUrl);
+  } else {
+    // Test if push is allowed without transforming the URL (e.g. is ssh keys are set up)
+    try {
+      debug('Verifying ssh auth by attempting to push to  %s', repositoryUrl);
+      await verifyAuth(repositoryUrl, branch.name, {cwd, env});
+    } catch {
+      debug('SSH key auth failed, falling back to https.');
+      const envVars = Object.keys(GIT_TOKENS).filter((envVar) => !isNil(env[envVar]));
 
-    // Skip verification if there is no ambiguity on which env var to use for authentication
-    if (envVars.length === 1) {
-      const gitCredentials = `${GIT_TOKENS[envVars[0]] || ''}${env[envVars[0]]}`;
-      return formatAuthUrl(protocol, repositoryUrl, gitCredentials);
-    }
-
-    if (envVars.length > 1) {
-      debug(`Found ${envVars.length} credentials in environment, trying all of them`);
-
-      const candidateRepositoryUrls = [];
-      for (const envVar of envVars) {
-        const gitCredentials = `${GIT_TOKENS[envVar] || ''}${env[envVar]}`;
-        const authUrl = formatAuthUrl(protocol, repositoryUrl, gitCredentials);
-        candidateRepositoryUrls.push(ensureValidAuthUrl(context, authUrl));
+      // Skip verification if there is no ambiguity on which env var to use for authentication
+      if (envVars.length === 1) {
+        const gitCredentials = `${GIT_TOKENS[envVars[0]] || ''}${env[envVars[0]]}`;
+        return formatAuthUrl(protocol, repositoryUrl, gitCredentials);
       }
 
-      const validRepositoryUrls = await Promise.all(candidateRepositoryUrls);
-      const chosenAuthUrlIndex = validRepositoryUrls.findIndex((url) => url !== null);
-      if (chosenAuthUrlIndex > -1) {
-        debug(`Using "${envVars[chosenAuthUrlIndex]}" to authenticate`);
-        return validRepositoryUrls[chosenAuthUrlIndex];
+      if (envVars.length > 1) {
+        debug(`Found ${envVars.length} credentials in environment, trying all of them`);
+
+        const candidateRepositoryUrls = [];
+        for (const envVar of envVars) {
+          const gitCredentials = `${GIT_TOKENS[envVar] || ''}${env[envVar]}`;
+          const authUrl = formatAuthUrl(protocol, repositoryUrl, gitCredentials);
+          candidateRepositoryUrls.push(ensureValidAuthUrl(context, authUrl));
+        }
+
+        const validRepositoryUrls = await Promise.all(candidateRepositoryUrls);
+        const chosenAuthUrlIndex = validRepositoryUrls.findIndex((url) => url !== null);
+        if (chosenAuthUrlIndex > -1) {
+          debug(`Using "${envVars[chosenAuthUrlIndex]}" to authenticate`);
+          return validRepositoryUrls[chosenAuthUrlIndex];
+        }
       }
     }
   }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -62,6 +62,7 @@ test.serial('Pass options to semantic-release API', async (t) => {
     'fail2',
     '--debug',
     '-d',
+    '--skip-remote-check',
   ];
   const cli = proxyquire('../cli', {'.': run, process: {...process, argv}});
 
@@ -82,6 +83,7 @@ test.serial('Pass options to semantic-release API', async (t) => {
   t.deepEqual(run.args[0][0].fail, ['fail1', 'fail2']);
   t.is(run.args[0][0].debug, true);
   t.is(run.args[0][0].dryRun, true);
+  t.is(run.args[0][0].skipRemoteCheck, true);
 
   t.is(exitCode, 0);
 });

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -407,3 +407,8 @@ test('Do not add git credential to repositoryUrl if push is allowed', async (t) 
     repositoryUrl
   );
 });
+
+test('Do not verify the url if skipRemoteCheck is set', (t) => {
+  // TODO: Implement this test, somehow.
+  t.true(true);
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1372,6 +1372,31 @@ test('Returns false if triggered by a PR', async (t) => {
   );
 });
 
+test('Does not allow specifying skipRemoteCheck without dryRun', async (t) => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+
+  const semanticRelease = requireNoCache('..', {
+    './lib/get-logger': () => t.context.logger,
+    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
+  });
+
+  t.false(
+    await semanticRelease(
+      {cwd, repositoryUrl, skipRemoteCheck: true},
+      {cwd, env: {}, stdout: new WritableStreamBuffer(), stderr: new WritableStreamBuffer()}
+    )
+  );
+  t.is(
+    t.context.error.args[t.context.error.args.length - 1][0],
+    '--skip-remote-check can only be specified in dry run mode.'
+  );
+});
+
+test("Doesn't call verifyAuth when skipRemoteCheck is set", (t) => {
+  // TODO: Implement this test, somehow.
+  t.true(true);
+});
+
 test('Throws "EINVALIDNEXTVERSION" if next release is out of range of the current maintenance branch', async (t) => {
   const {cwd, repositoryUrl} = await gitRepo(true);
   await gitCommits(['feat: initial commit'], {cwd});


### PR DESCRIPTION
This is a first draft of a new option to bypass checking remote access. It only works in dry run mode. There is still some work that needs to be done before it's ready to merge:

- [ ] Write a concise description
- [ ] Add tests
- [ ] Make `run` throw instead of returning `false`?

I took a first stab at writing some tests for this new flag, but I got lost in the tests and couldn't figure out how to make some of them work. If someone with more experience in this test suite could help out that would be greatly appreciated.

Closes #2232.