### PR TITLE
fix(log-repo): use the original form of the repo url to remove the need to mask credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ async function run(context, plugins) {
   }
 
   logger[options.dryRun ? 'warn' : 'success'](
-    `Run automated release from branch ${ciBranch} on repository ${options.repositoryUrl}${
+    `Run automated release from branch ${ciBranch} on repository ${options.originalRepositoryURL}${
       options.dryRun ? ' in dry-run mode' : ''
     }`
   );
@@ -263,6 +263,7 @@ module.exports = async (cliOptions = {}, {cwd = process.cwd(), env = process.env
   context.logger.log(`Running ${pkg.name} version ${pkg.version}`);
   try {
     const {plugins, options} = await getConfig(context, cliOptions);
+    options.originalRepositoryURL = options.repositoryUrl;
     context.options = options;
     try {
       const result = await run(context, plugins);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,6 +90,7 @@ test('Plugins are called with expected values', async (t) => {
   const config = {
     branches: [{name: 'master'}, {name: 'next'}],
     repositoryUrl,
+    originalRepositoryURL: repositoryUrl,
     globalOpt: 'global',
     tagFormat: `v\${version}`,
   };
@@ -927,7 +928,12 @@ test('Log all "verifyConditions" errors', async (t) => {
   const error2 = new SemanticReleaseError('error 2', 'ERR2');
   const error3 = new SemanticReleaseError('error 3', 'ERR3');
   const fail = stub().resolves();
-  const config = {branches: [{name: 'master'}], repositoryUrl, tagFormat: `v\${version}`};
+  const config = {
+    branches: [{name: 'master'}],
+    repositoryUrl,
+    originalRepositoryURL: repositoryUrl,
+    tagFormat: `v\${version}`,
+  };
   const options = {
     ...config,
     plugins: false,


### PR DESCRIPTION
fixes #2449