### PR TITLE
docs(configuration.md): `addChannel` step is skipped when `dryRun` is enabled

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -116,7 +116,7 @@ Type: `Boolean`<br>
 Default: `false` if running in a CI environment, `true` otherwise<br>
 CLI arguments: `-d`, `--dry-run`
 
-The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following steps: prepare, publish, success and fail. In addition to this it prints the next version and release notes to the console.
+The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following steps: prepare, publish, addChannel, success and fail. In addition to this it prints the next version and release notes to the console.
 
 **Note**: The Dry-run mode verifies the repository push permission, even though nothing will be pushed. The verification is done to help user to figure out potential configuration issues.
 


### PR DESCRIPTION
After a lot of suffering trying to debug some issues with semantic-release, I finally noticed `addChannel` is also skipped on dryRun mode, but it isn't documented 

https://github.com/semantic-release/semantic-release/blob/master/lib/definitions/plugins.js#L85