### PR TITLE
docs: remove deprecated keyword in gitlab-ci.md

### DIFF
--- a/docs/recipes/ci-configurations/gitlab-ci.md
+++ b/docs/recipes/ci-configurations/gitlab-ci.md
@@ -66,8 +66,8 @@ release:
     - npm install -g semantic-release @semantic-release/gitlab
   script:
     - semantic-release
-  only:
-    - master
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
 
 release:
   image: node:12-buster-slim
@@ -77,8 +77,8 @@ release:
     - npm install -g semantic-release @semantic-release/gitlab
   script:
     - semantic-release
-  only:
-    - master
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
 ```
 
 ### `package.json` configuration


### PR DESCRIPTION
The usage of only/except in Gitlab pipelines is not recommended to use for newer pipelines according to this documentation: https://docs.gitlab.com/ee/ci/yaml/#only--except

We should update the documentation accordingly.