### PR TITLE
test: replaced proxyquire with testdouble

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,10 +55,10 @@
         "nock": "13.2.1",
         "nyc": "15.1.0",
         "p-retry": "4.6.1",
-        "proxyquire": "2.1.3",
         "sinon": "12.0.1",
         "stream-buffers": "3.0.2",
         "tempy": "1.0.1",
+        "testdouble": "3.16.6",
         "xo": "0.32.1"
       },
       "engines": {
@@ -5912,19 +5912,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true,
-      "dependencies": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -8096,15 +8083,6 @@
         "obj-props": "^1.0.0"
       }
     },
-    "node_modules/is-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
-      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -8167,6 +8145,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-relative": {
@@ -9244,12 +9231,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9489,12 +9470,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -13226,17 +13201,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/proxyquire": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
-      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
-      "dev": true,
-      "dependencies": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
-      }
-    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -13333,6 +13297,20 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quibble": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.14.tgz",
+      "integrity": "sha512-r5noQhWx61qMOjaMQ48ePOKc9MKXzXFKUNj4S7/wIB9rzht3yyyf/Ms3BhXEVEPJtUvTNNnQxnT/6sHzcbkRoA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -14710,6 +14688,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -15109,6 +15100,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/testdouble": {
+      "version": "3.16.6",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.6.tgz",
+      "integrity": "sha512-mijMgc9y7buK9IG9zSVhzlXsFMqWbLQHRei4SLX7F7K4Qtrcnglg6lIMTCmNs6RwDUyLGWtpIe+TzkugYHB+qA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.7",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -15121,6 +15127,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
     "node_modules/through": {
@@ -21467,16 +21479,6 @@
       "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==",
       "dev": true
     },
-    "fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true,
-      "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -23133,12 +23135,6 @@
         "obj-props": "^1.0.0"
       }
     },
-    "is-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
-      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
-      "dev": true
-    },
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -23184,6 +23180,12 @@
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true
     },
     "is-relative": {
       "version": "1.0.0",
@@ -24011,12 +24013,6 @@
         "yargs-parser": "^20.2.3"
       }
     },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -24205,12 +24201,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
-    },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -26869,17 +26859,6 @@
       "integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
       "dev": true
     },
-    "proxyquire": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
-      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
-      "dev": true,
-      "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
-      }
-    },
     "public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -26947,6 +26926,16 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "quibble": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.14.tgz",
+      "integrity": "sha512-r5noQhWx61qMOjaMQ48ePOKc9MKXzXFKUNj4S7/wIB9rzht3yyyf/Ms3BhXEVEPJtUvTNNnQxnT/6sHzcbkRoA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      }
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -28062,6 +28051,16 @@
         "define-properties": "^1.1.3"
       }
     },
+    "stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -28350,6 +28349,18 @@
         "minimatch": "^3.0.4"
       }
     },
+    "testdouble": {
+      "version": "3.16.6",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.6.tgz",
+      "integrity": "sha512-mijMgc9y7buK9IG9zSVhzlXsFMqWbLQHRei4SLX7F7K4Qtrcnglg6lIMTCmNs6RwDUyLGWtpIe+TzkugYHB+qA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.7",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      }
+    },
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -28359,6 +28370,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
     "nock": "13.2.1",
     "nyc": "15.1.0",
     "p-retry": "4.6.1",
-    "proxyquire": "2.1.3",
     "sinon": "12.0.1",
     "stream-buffers": "3.0.2",
     "tempy": "1.0.1",
+    "testdouble": "3.16.6",
     "xo": "0.32.1"
   },
   "engines": {

--- a/test/branches/branches.test.js
+++ b/test/branches/branches.test.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const {union} = require('lodash');
 const semver = require('semver');
-const proxyquire = require('proxyquire');
+const td = require('testdouble');
 
 const getBranch = (branches, branch) => branches.find(({name}) => name === branch);
 const release = (branches, name, version) => getBranch(branches, name).tags.push({version});
@@ -22,7 +22,9 @@ test('Enforce ranges with branching release workflow', async (t) => {
     {name: 'beta', prerelease: true, tags: []},
     {name: 'alpha', prerelease: true, tags: []},
   ];
-  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches, './expand': () => []});
+  td.replace('../../lib/branches/get-tags', () => branches);
+  td.replace('../../lib/branches/expand', () => []);
+  const getBranches = require('../../lib/branches');
 
   let result = (await getBranches('repositoryUrl', 'master', {options: {branches}})).map(({name, range}) => ({
     name,
@@ -199,7 +201,9 @@ test('Throw SemanticReleaseError for invalid configurations', async (t) => {
     {name: 'alpha', prerelease: 'alpha', tags: []},
     {name: 'preview', prerelease: 'alpha', tags: []},
   ];
-  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches, './expand': () => []});
+  td.replace('../../lib/branches/get-tags', () => branches);
+  td.replace('../../lib/branches/expand', () => []);
+  const getBranches = require('../../lib/branches');
   const errors = [...(await t.throwsAsync(getBranches('repositoryUrl', 'master', {options: {branches}})))];
 
   t.is(errors[0].name, 'SemanticReleaseError');
@@ -229,7 +233,9 @@ test('Throw a SemanticReleaseError if there is duplicate branches', async (t) =>
     {name: 'master', tags: []},
     {name: 'master', tags: []},
   ];
-  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches, './expand': () => []});
+  td.replace('../../lib/branches/get-tags', () => branches);
+  td.replace('../../lib/branches/expand', () => []);
+  const getBranches = require('../../lib/branches');
 
   const errors = [...(await t.throwsAsync(getBranches('repositoryUrl', 'master', {options: {branches}})))];
 
@@ -244,7 +250,9 @@ test('Throw a SemanticReleaseError for each invalid branch name', async (t) => {
     {name: '~master', tags: []},
     {name: '^master', tags: []},
   ];
-  const getBranches = proxyquire('../../lib/branches', {'./get-tags': () => branches, './expand': () => []});
+  td.replace('../../lib/branches/get-tags', () => branches);
+  td.replace('../../lib/branches/expand', () => []);
+  const getBranches = require('../../lib/branches');
 
   const errors = [...(await t.throwsAsync(getBranches('repositoryUrl', 'master', {options: {branches}})))];
 

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -3,7 +3,7 @@ const {format} = require('util');
 const test = require('ava');
 const {writeFile, outputJson} = require('fs-extra');
 const {omit} = require('lodash');
-const proxyquire = require('proxyquire');
+const td = require('testdouble');
 const {stub} = require('sinon');
 const yaml = require('js-yaml');
 const {gitRepo, gitTagVersion, gitCommits, gitShallowClone, gitAddConfig} = require('./helpers/git-utils');
@@ -17,7 +17,8 @@ const DEFAULT_PLUGINS = [
 
 test.beforeEach((t) => {
   t.context.plugins = stub().returns({});
-  t.context.getConfig = proxyquire('../lib/get-config', {'./plugins': t.context.plugins});
+  td.replace('../lib/plugins', t.context.plugins);
+  t.context.getConfig = require('../lib/get-config');
 });
 
 test('Default values, reading repositoryUrl from package.json', async (t) => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const test = require('ava');
-const proxyquire = require('proxyquire');
+const td = require('testdouble');
 const {escapeRegExp} = require('lodash');
 const {writeJson, readJson} = require('fs-extra');
 const execa = require('execa');
@@ -25,8 +25,6 @@ const mockServer = require('./helpers/mockserver');
 const npmRegistry = require('./helpers/npm-registry');
 
 /* eslint camelcase: ["error", {properties: "never"}] */
-
-const requireNoCache = proxyquire.noPreserveCache();
 
 // Environment variables used with semantic-release cli (similar to what a user would setup)
 const {GITHUB_ACTION, GITHUB_TOKEN, ...processEnvWithoutGitHubActionsVariables} = process.env;
@@ -509,10 +507,9 @@ test('Pass options via CLI arguments', async (t) => {
 });
 
 test('Run via JS API', async (t) => {
-  const semanticRelease = requireNoCache('..', {
-    './lib/logger': {log: () => {}, error: () => {}, stdout: () => {}},
-    'env-ci': () => ({isCi: true, branch: 'master', isPr: false}),
-  });
+  td.replace('../lib/logger', {log: () => {}, error: () => {}, stdout: () => {}});
+  td.replace('env-ci', () => ({isCi: true, branch: 'master', isPr: false}));
+  const semanticRelease = require('..');
   const packageName = 'test-js-api';
   const owner = 'git';
   // Create a git repository, set the current working directory at the root of the repo


### PR DESCRIPTION
for #2133

this takes care of one of the tasks needed for the ESM conversion, as mentioned in https://github.com/semantic-release/semantic-release/issues/2133#issuecomment-1196971437

i think we should also replace use of sinon with testdouble, but i'd rather do that as a separate step. that change is not required for the ESM conversion, like this change is, but would remove the complexity of using multiple stubbing libraries.