### PR TITLE
typo: corrected ci-configurations README.md usage link

### DIFF
--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -13,7 +13,7 @@ Here are a few examples of the CI services that can be used to achieve this:
 - [Wercker Workflows](http://devcenter.wercker.com/docs/workflows)
 - [GoCD Pipelines](https://docs.gocd.org/current/introduction/concepts_in_go.html#pipeline).
 
-See [CI configuration recipes](../recipes/ci-configurations#ci-configurations) for more details.
+See [CI configuration recipes](../recipes/ci-configurations/README.md#ci-configurations) for more details.
 
 ## Authentication
 


### PR DESCRIPTION
The existing link 404s. 