### PR TITLE
docs(plugins list): add semantic release cargo community plugin

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -166,3 +166,7 @@
 - [semantic-release-react-native](https://github.com/alexandermendes/semantic-release-react-native)
   - `verifyConditions` Validate configuration.
   - `prepare` Version native iOS and Android files.
+- [semantic-release-cargo](https://github.com/buehler/semantic-release-cargo)
+  - `verifyConditions` Validate configuration, `Cargo.toml`, and local cargo executable. Also, logs into into `crates.io`.
+  - `prepare` Version new version number into `Cargo.toml` file and perform `cargo check` if configured.
+  - `publish` Publish the Rust crate to `crates.io`

--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -167,6 +167,6 @@
   - `verifyConditions` Validate configuration.
   - `prepare` Version native iOS and Android files.
 - [semantic-release-cargo](https://github.com/buehler/semantic-release-cargo)
-  - `verifyConditions` Validate configuration, `Cargo.toml`, and local cargo executable. Also, logs into into `crates.io`.
-  - `prepare` Version new version number into `Cargo.toml` file and perform `cargo check` if configured.
+  - `verifyConditions` Validate configuration, `Cargo.toml`, and local cargo executable. Also, logs in into `crates.io`.
+  - `prepare` Write the new version number into `Cargo.toml` file and perform `cargo check` if configured.
   - `publish` Publish the Rust crate to `crates.io`


### PR DESCRIPTION
Add a new community plugin that I created to publish `crates.io` cargo packages (Rust language)