### PR TITLE
test: aligned pluginName with naming for functions

### DIFF
--- a/test/fixtures/plugin-noop.cjs
+++ b/test/fixtures/plugin-noop.cjs
@@ -1,1 +1,3 @@
-module.exports = () => {};
+module.exports = function noop() {
+
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -139,7 +139,7 @@ test('Plugins are called with expected values', async (t) => {
       pluginName: '[Function: functionStub]',
     },
     {...nextRelease, ...release2, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: '[Function: functionStub]'},
-    {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: pluginNoop},
+    {...nextRelease, notes: `${notes1}\n\n${notes2}\n\n${notes3}`, pluginName: '[Function: noop]'},
   ];
 
   await td.replaceEsm('../lib/get-logger.js', null, () => t.context.logger);


### PR DESCRIPTION
based on https://github.com/semantic-release/semantic-release/blob/78ea3ba966c973ccc283b88cf490bd7ddee088c7/lib/plugins/normalize.js#L17, i think this test was wrong before and this change fixes it. i think i read the logic correctly, but the fact that this test has been the other way for a long time makes my confidence low that this is the right change, so i could really use a sanity check on this one.

for #2543

