### PR TITLE
feat(node-versions): raised the minimum required node version to v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.17
-          - 16.0.0
-          - 17
+          - 18.0.0
+          - 19
 
     runs-on: ubuntu-latest
 
@@ -32,7 +31,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: npm ci
+      - run: npm clean-install
+      - name: Ensure dependencies are compatible with the version of node
+        run: npx ls-engines
       - run: npm run test:ci
 
   # separate job to set as required in branch protection,
@@ -44,9 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
           cache: npm
-      - run: npm ci
-      - name: Ensure dependencies are compatible with the version of node
-        run: npx ls-engines@0.4
+      - run: npm clean-install
       - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "xo": "0.32.1"
       },
       "engines": {
-        "node": ">=16 || ^14.17"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "semantic-release": "20.0.0-beta.1"
   },
   "engines": {
-    "node": ">=16 || ^14.17"
+    "node": ">=18"
   },
   "files": [
     "bin",


### PR DESCRIPTION
in accordance with our node support policy:
https://semantic-release.gitbook.io/semantic-release/support/node-support-policy

BREAKING CHANGE: Node v18 or greater is now required. Please refer to
https://semantic-release.gitbook.io/semantic-release/support/node-version for recommended options
for releasing with a supported node version.

for #2543
