### PR TITLE
fix: aggregate error v4

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,11 @@ const semver = require('semver');
 const hideSensitive = require('./hide-sensitive');
 
 function extractErrors(err) {
-  return err && isFunction(err[Symbol.iterator]) ? [...err] : [err];
+  return err.errors && isFunction(err.errors[Symbol.iterator])
+    ? [...err.errors]
+    : err && isFunction(err[Symbol.iterator])
+    ? [...err]
+    : [err];
 }
 
 function hideSensitiveValues(env, objs) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -18,13 +18,12 @@ const {
 } = require('../lib/utils');
 
 test('extractErrors', (t) => {
-  const errors = [new Error("Error 1"), new Error("Error 2")];
+  const errors = [new Error('Error 1'), new Error('Error 2')];
 
   t.deepEqual(extractErrors(new AggregateError(errors)), errors);
   t.deepEqual(extractErrors(errors[0]), [errors[0]]);
 
-  // aggregate-error v4 stores errors in a `errors` property
-  // See https://github.com/sindresorhus/aggregate-error/issues/4
+  // aggregate-error v4 stores errors in an `errors` property
   const aggregateErrorv4 = new Error();
   aggregateErrorv4.errors = errors;
   t.deepEqual(extractErrors(aggregateErrorv4), errors);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -18,10 +18,16 @@ const {
 } = require('../lib/utils');
 
 test('extractErrors', (t) => {
-  const errors = [new Error('Error 1'), new Error('Error 2')];
+  const errors = [new Error("Error 1"), new Error("Error 2")];
 
   t.deepEqual(extractErrors(new AggregateError(errors)), errors);
   t.deepEqual(extractErrors(errors[0]), [errors[0]]);
+
+  // aggregate-error v4 stores errors in a `errors` property
+  // See https://github.com/sindresorhus/aggregate-error/issues/4
+  const aggregateErrorv4 = new Error();
+  aggregateErrorv4.errors = errors;
+  t.deepEqual(extractErrors(aggregateErrorv4), errors);
 });
 
 test('tagsToVersions', (t) => {


### PR DESCRIPTION
This change makes `utils.extractErrors` compatible with aggregate-error v4, which changes its implementation to store the errors in an `.errors` property instead of making the Error instance iterable. 

See https://github.com/sindresorhus/aggregate-error/commit/02342f97aa10c73fc12a909bb71e1db8caca0791

_Note: could not run the linter due to `Error: Cannot find module 'prettier'`_