### PR TITLE
docs: replace master references with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This way no human is directly involved in the release process and the releases a
 
 ### Triggering a release
 
-For each new commit added to one of the release branches (for example: `master`, `next`, `beta`), with `git push` or by merging a pull request or merging from another branch, a CI build is triggered and runs the `semantic-release` command to make a release if there are codebase changes since the last release that affect the package functionalities.
+For each new commit added to one of the release branches (for example: `main`, `next`, `beta`), with `git push` or by merging a pull request or merging from another branch, a CI build is triggered and runs the `semantic-release` command to make a release if there are codebase changes since the last release that affect the package functionalities.
 
 **semantic-release** offers various ways to control the timing, the content and the audience of published releases.
 See example workflows in the following recipes:

--- a/docs/developer-guide/js-api.md
+++ b/docs/developer-guide/js-api.md
@@ -15,7 +15,7 @@ try {
       // Core options
       branches: [
         "+([0-9])?(.{+([0-9]),x}).x",
-        "master",
+        "main",
         "next",
         "next-major",
         { name: "beta", prerelease: true },

--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -82,7 +82,7 @@
 - [maven-semantic-release](https://github.com/conveyal/maven-semantic-release)
   - `verifyConditions`: Verifies that the `pom.xml` file and other files exist and are setup to allow releases
   - `verifyRelease`: Checks and warns (does not error by default) if the version numbers found on maven central and within the Git project differ by quite a bit
-  - `prepare`: Changes the version number in the `pom.xml` (or all `pom.xml` files in maven projects with multiple `pom.xml` files) and optionally creates a commit with this version number and pushes it to `master`
+  - `prepare`: Changes the version number in the `pom.xml` (or all `pom.xml` files in maven projects with multiple `pom.xml` files) and optionally creates a commit with this version number and pushes it to `main`
   - `publish`: Runs `mvn deploy` to deploy to maven central and optionally will update to next snapshot version and merge changes to development branch
 - [semantic-release-ado](https://github.com/lluchmk/semantic-release-ado)
   - `prepare`: Stores the version number as an Azure DevOps pipeline variable available to downstream steps on the job

--- a/docs/recipes/ci-configurations/github-actions.md
+++ b/docs/recipes/ci-configurations/github-actions.md
@@ -14,7 +14,7 @@ In this example a publish type [`NPM_TOKEN`](https://docs.npmjs.com/creating-and
 
 ### `.github/workflows/release.yml` configuration for Node projects
 
-The following is a minimal configuration for [`semantic-release`](https://github.com/semantic-release/semantic-release) with a build running on the latest LTS version of Node when a new commit is pushed to a `master` branch.
+The following is a minimal configuration for [`semantic-release`](https://github.com/semantic-release/semantic-release) with a build running on the latest LTS version of Node when a new commit is pushed to a `main` branch.
 See [Configuring a Workflow](https://help.github.com/en/articles/configuring-a-workflow) for additional configuration options.
 
 ```yaml
@@ -22,7 +22,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release:
     name: Release
@@ -45,9 +45,9 @@ jobs:
         run: npx semantic-release
 ```
 
-## Pushing `package.json` changes to a `master` branch
+## Pushing `package.json` changes to a `main` branch
 
-To keep `package.json` updated in the `master` branch, [`@semantic-release/git`](https://github.com/semantic-release/git) plugin can be used.
+To keep `package.json` updated in the `main` branch, [`@semantic-release/git`](https://github.com/semantic-release/git) plugin can be used.
 
 **Note**: Automatically populated `GITHUB_TOKEN` cannot be used if branch protection is enabled for the target branch. It is **not** advised to mitigate this limitation by overriding an automatically populated `GITHUB_TOKEN` variable with a [Personal Access Tokens](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line), as it poses a security risk. Since Secret Variables are available for Workflows triggered by any branch, it becomes a potential vector of attack, where a Workflow triggered from a non-protected branch can expose and use a token with elevated permissions, yielding branch protection insignificant. One can use Personal Access Tokens in trusted environments, where all developers should have the ability to perform administrative actions in the given repository and branch protection is enabled solely for convenience purposes, to remind about required reviews or CI checks.
 

--- a/docs/recipes/ci-configurations/gitlab-ci.md
+++ b/docs/recipes/ci-configurations/gitlab-ci.md
@@ -53,7 +53,7 @@ This example is a minimal configuration for **semantic-release** with a build ru
 **Note**: The`semantic-release` execution command varies depending if you are using a [local](../../usage/installation.md#local-installation) or [global](../../usage/installation.md#global-installation) **semantic-release** installation.
 
 ```yaml
-# The release pipeline will run only on the master branch a commit is triggered
+# The release pipeline will run only on the main branch a commit is triggered
 stages:
   - release
 
@@ -66,7 +66,7 @@ release:
   script:
     - semantic-release
   rules:
-    - if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_BRANCH == "main"
 
 release:
   image: node:12-buster-slim
@@ -77,7 +77,7 @@ release:
   script:
     - semantic-release
   rules:
-    - if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_BRANCH == "main"
 ```
 
 ### `package.json` configuration

--- a/docs/recipes/release-workflow/distribution-channels.md
+++ b/docs/recipes/release-workflow/distribution-channels.md
@@ -4,12 +4,12 @@ This recipe will walk you through a simple example that uses distribution channe
 
 This example uses the **semantic-release** default configuration:
 
-- [branches](../../usage/configuration.md#branches): `['+([0-9])?(.{+([0-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
+- [branches](../../usage/configuration.md#branches): `['+([0-9])?(.{+([0-9]),x}).x', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
 - [plugins](../../usage/configuration.md#plugins): `['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']`
 
 ## Initial release
 
-We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit` to `master`. When pushing that commit, **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
+We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit` to `main`. When pushing that commit, **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
 
 The Git history of the repository is:
 
@@ -19,7 +19,7 @@ The Git history of the repository is:
 
 ## Releasing a bug fix
 
-We can now continue to commit changes and release updates to our users. For example we can commit a bug fix with the message `fix: a fix` to `master`. When pushing that commit, **semantic-release** will release the version `1.0.1` on the dist-tag `@latest`.
+We can now continue to commit changes and release updates to our users. For example we can commit a bug fix with the message `fix: a fix` to `main`. When pushing that commit, **semantic-release** will release the version `1.0.1` on the dist-tag `@latest`.
 
 The Git history of the repository is now:
 
@@ -63,7 +63,7 @@ We now want to develop a smaller, non-breaking feature. Its scope is small enoug
 
 If we were to commit that feature on `next` only a subset of users would get it, and we would need to wait for the end of our feedback period in order to make both the big and the small feature available to all users.
 
-Instead, we develop that small feature commit it to `master` with the message `feat: a small feature`. When pushing that commit, **semantic-release** will release the version `1.1.0` on the dist-tag `@latest` so all users can benefit from it right away.
+Instead, we develop that small feature commit it to `main` with the message `feat: a small feature`. When pushing that commit, **semantic-release** will release the version `1.1.0` on the dist-tag `@latest` so all users can benefit from it right away.
 
 The Git history of the repository is now:
 
@@ -78,7 +78,7 @@ The Git history of the repository is now:
 
 ## Porting a feature to next
 
-Most of our users now have access to the small feature, but we still need to make it available to our users using the `@next` dist-tag. To do so we need to merge our changes made on `master` (the commit `feat: a small feature`) into `next`. As `master` and `next` branches have diverged, this merge might require to resolve conflicts.
+Most of our users now have access to the small feature, but we still need to make it available to our users using the `@next` dist-tag. To do so we need to merge our changes made on `main` (the commit `feat: a small feature`) into `next`. As `main` and `next` branches have diverged, this merge might require to resolve conflicts.
 
 Once the conflicts are resolved and the merge commit is pushed to `next`, **semantic-release** will release the version `2.1.0` on the dist-tag `@next` which contains both our small and big feature.
 
@@ -91,14 +91,14 @@ The Git history of the repository is now:
 |  * feat: a big feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0 on @next
 |  * fix: fix something on the big feature # => v2.0.1 on @next
 *  | feat: a small feature # => v1.1.0 on @latest
-|  * Merge branch master into next # => v2.1.0 on @next
+|  * Merge branch main into next # => v2.1.0 on @next
 ```
 
 ## Adding a version to latest
 
-After a period of feedback from our users using the `@next` dist-tag we feel confident to make our big feature available to all users. To do so we merge the `next` branch into `master`. There should be no conflict as `next` is strictly ahead of `master`.
+After a period of feedback from our users using the `@next` dist-tag we feel confident to make our big feature available to all users. To do so we merge the `next` branch into `main`. There should be no conflict as `next` is strictly ahead of `main`.
 
-Once the merge commit is pushed to `master`, **semantic-release** will add the version `2.1.0` to the dist-tag `@latest` so all users will receive it when installing out module with `npm install example-module`.
+Once the merge commit is pushed to `main`, **semantic-release** will add the version `2.1.0` to the dist-tag `@latest` so all users will receive it when installing out module with `npm install example-module`.
 
 The Git history of the repository is now:
 
@@ -109,9 +109,9 @@ The Git history of the repository is now:
 |  * feat: a big feature \n\n BREAKING CHANGE: it breaks something # => v2.0.0 on @next
 |  * fix: fix something on the big feature # => v2.0.1 on @next
 *  | feat: a small feature # => v1.1.0 on @latest
-|  * Merge branch master into next # => v2.1.0 on @next
+|  * Merge branch main into next # => v2.1.0 on @next
 | /|
-*  | Merge branch next into master # => v2.1.0 on @latest
+*  | Merge branch next into main # => v2.1.0 on @latest
 ```
 
-We can now continue to push new fixes and features on `master`, or a new breaking change on `next` as we did before.
+We can now continue to push new fixes and features on `main`, or a new breaking change on `next` as we did before.

--- a/docs/recipes/release-workflow/maintenance-releases.md
+++ b/docs/recipes/release-workflow/maintenance-releases.md
@@ -4,12 +4,12 @@ This recipe will walk you through a simple example that uses Git branches and di
 
 This example uses the **semantic-release** default configuration:
 
-- [branches](../../usage/configuration.md#branches): `['+([0-9])?(.{+([0-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
+- [branches](../../usage/configuration.md#branches): `['+([0-9])?(.{+([0-9]),x}).x', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
 - [plugins](../../usage/configuration.md#plugins): `['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']`
 
 ## Initial release
 
-We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit`. When pushing that commit, on `master` **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
+We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit`. When pushing that commit, on `main` **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
 
 The Git history of the repository is:
 
@@ -21,7 +21,7 @@ The Git history of the repository is:
 
 We now decide to drop Node.js 6 support for our package, and require Node.js 8 or higher, which is a breaking change.
 
-We commit that change with the message `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required` to `master`. When pushing that commit, **semantic-release** will release the version `2.0.0` on the dist-tag `@latest`.
+We commit that change with the message `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required` to `main`. When pushing that commit, **semantic-release** will release the version `2.0.0` on the dist-tag `@latest`.
 
 The Git history of the repository is now:
 
@@ -34,7 +34,7 @@ The Git history of the repository is now:
 
 One of our users request a new feature, however they cannot migrate to Node.js 8 or higher due to corporate policies.
 
-If we were to push that feature on `master` and release it, the new version would require Node.js 8 or higher as the release would also contain the commit `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required`.
+If we were to push that feature on `main` and release it, the new version would require Node.js 8 or higher as the release would also contain the commit `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required`.
 
 Instead, we create the branch `1.x` from the tag `v1.0.0` with the command `git checkout -b 1.x v1.0.0` and we commit that feature with the message `feat: a feature` to the branch `1.x`. When pushing that commit, **semantic-release** will release the version `1.1.0` on the dist-tag `@release-1.x` so users who can't migrate to Node.js 8 or higher can benefit from it.
 
@@ -85,13 +85,13 @@ The Git history of the repository is now:
 |  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
 ```
 
-## Porting bug fixes and features to master
+## Porting bug fixes and features to main
 
 Finally we want to make both our feature and bug fix available to users using the `@latest` dist-tag.
 
-To do so we need to merge the changes made on `1.x` (the commits `feat: a feature` and `fix: a fix`) into `master`. As `1.x` and `master` branches have diverged, this merge might require to resolve conflicts.
+To do so we need to merge the changes made on `1.x` (the commits `feat: a feature` and `fix: a fix`) into `main`. As `1.x` and `main` branches have diverged, this merge might require to resolve conflicts.
 
-Once the conflicts are resolved and the merge commit is pushed to `master`, **semantic-release** will release the version `2.1.0` on the dist-tag `@latest` which now contains the breaking change feature, the feature and the bug fix.
+Once the conflicts are resolved and the merge commit is pushed to `main`, **semantic-release** will release the version `2.1.0` on the dist-tag `@latest` which now contains the breaking change feature, the feature and the bug fix.
 
 The Git history of the repository is now:
 
@@ -105,14 +105,14 @@ The Git history of the repository is now:
 |  | /|
 |  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
 | /|  |
-*  |  | Merge branch 1.x into master # => v2.1.0 on @latest
+*  |  | Merge branch 1.x into main # => v2.1.0 on @latest
 ```
 
 ## Releasing a bug fix for version 2.1.0 users
 
 One of our users using the version `2.1.0` version reports a bug.
 
-We can simply commit the bug fix with the message `fix: another fix` to `master`. When pushing that commit, **semantic-release** will release the version `2.1.1` on the dist-tag `@latest`.
+We can simply commit the bug fix with the message `fix: another fix` to `main`. When pushing that commit, **semantic-release** will release the version `2.1.1` on the dist-tag `@latest`.
 
 The Git history of the repository is now:
 
@@ -126,15 +126,15 @@ The Git history of the repository is now:
 |  | /|
 |  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
 | /|  |
-*  |  | Merge branch 1.x into master # => v2.1.0 on @latest
+*  |  | Merge branch 1.x into main # => v2.1.0 on @latest
 *  |  | fix: another fix # => v2.1.1 on @latest
 ```
 
-## Porting a bug fix from master to 1.x
+## Porting a bug fix from main to 1.x
 
 The bug fix `fix: another fix` also affects version `1.1.1` users, so we want to port it to the `1.x` branch.
 
-To do so we need to cherry pick our fix commit made on `master` (`fix: another fix`) into `1.x` with `git checkout 1.x && git cherry-pick <sha of fix: another fix>`. As `master` and `1.x` branches have diverged, the cherry picking might require to resolve conflicts.
+To do so we need to cherry pick our fix commit made on `main` (`fix: another fix`) into `1.x` with `git checkout 1.x && git cherry-pick <sha of fix: another fix>`. As `main` and `1.x` branches have diverged, the cherry picking might require to resolve conflicts.
 
 Once the conflicts are resolved and the commit is pushed to `1.x`, **semantic-release** will release the version `1.1.2` on the dist-tag `@release-1.x` which contains `feat: a feature`, `fix: a fix` and `fix: another fix` but not `feat: drop Node.js 6 support \n\n BREAKING CHANGE: Node.js >= 8 required`.
 
@@ -150,7 +150,7 @@ The Git history of the repository is now:
 |  | /|
 |  *  | Merge branch 1.0.x into 1.x # => v1.1.1 on @1.x
 | /|  |
-*  |  | Merge branch 1.x into master # => v2.1.0 on @latest
+*  |  | Merge branch 1.x into main # => v2.1.0 on @latest
 *  |  | fix: another fix # => v2.1.1 on @latest
 |  |  |
 |  *  | fix: another fix # => v1.1.2 on @1.x

--- a/docs/recipes/release-workflow/pre-releases.md
+++ b/docs/recipes/release-workflow/pre-releases.md
@@ -4,12 +4,12 @@ This recipe will walk you through a simple example that uses pre-releases to pub
 
 This example uses the **semantic-release** default configuration:
 
-- [branches](../../usage/configuration.md#branches): `['+([0-9])?(.{+([0-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
+- [branches](../../usage/configuration.md#branches): `['+([0-9])?(.{+([0-9]),x}).x', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`
 - [plugins](../../usage/configuration.md#plugins): `['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/npm', '@semantic-release/github']`
 
 ## Initial release
 
-We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit`. When pushing that commit, on `master` **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
+We'll start by making the first commit of the project, with the code for the initial release and the message `feat: initial commit`. When pushing that commit, on `main` **semantic-release** will release the version `1.0.0` and make it available on the default distribution channel which is the dist-tag `@latest` for npm.
 
 The Git history of the repository is:
 
@@ -46,7 +46,7 @@ With another feature, the Git history of the repository is now:
 
 In the meantime we can also continue to commit changes and release updates to our users.
 
-For example, we can commit a bug fix with the message `fix: a fix` to `master`. When pushing that commit, **semantic-release** will release the version `1.0.1` on the dist-tag `@latest`.
+For example, we can commit a bug fix with the message `fix: a fix` to `main`. When pushing that commit, **semantic-release** will release the version `1.0.1` on the dist-tag `@latest`.
 
 The Git history of the repository is now:
 
@@ -95,9 +95,9 @@ With another feature, the Git history of the repository is now:
 
 Once we've developed and pushed all the feature we want to include in the future version `2.0.0` in the `beta` branch and all our tests are successful we can release it to our users.
 
-To do so we need to merge our changes made on `beta` into `master`. As `beta` and `master` branches have diverged, this merge might require to resolve conflicts.
+To do so we need to merge our changes made on `beta` into `main`. As `beta` and `main` branches have diverged, this merge might require to resolve conflicts.
 
-Once the conflicts are resolved and the merge commit is pushed to `master`, **semantic-release** will release the version `2.0.0` on the dist-tag `@latest`.
+Once the conflicts are resolved and the merge commit is pushed to `main`, **semantic-release** will release the version `2.0.0` on the dist-tag `@latest`.
 
 The Git history of the repository is now:
 
@@ -111,14 +111,14 @@ The Git history of the repository is now:
 |  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
 |  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
 | /|  |
-*  |  | Merge branch beta into master # => v2.0.0 on @latest
+*  |  | Merge branch beta into main # => v2.0.0 on @latest
 ```
 
 ## Publishing the 3.0.0 alpha release to the beta distribution channel
 
 Now that we published our the version `2.0.0` that was previously in beta, we decide to promote the version `3.0.0` in alpha to beta.
 
-To do so we need to merge our changes made on `alpha` into `beta`. There should be no conflict as `alpha` is strictly ahead of `master`.
+To do so we need to merge our changes made on `alpha` into `beta`. There should be no conflict as `alpha` is strictly ahead of `main`.
 
 Once the merge commit is pushed to `beta`, **semantic-release** will publish the pre-release version `3.0.0-beta.1` on the dist-tag `@beta`, which allow us to run our integration tests.
 
@@ -134,7 +134,7 @@ The Git history of the repository is now:
 |  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
 |  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
 | /|  |
-*  |  | Merge branch beta into master # => v2.0.0 on @latest
+*  |  | Merge branch beta into main # => v2.0.0 on @latest
 |  | /|
 |  *  | Merge branch alpha into beta # => v3.0.0-beta.1 on @beta
 ```
@@ -143,9 +143,9 @@ The Git history of the repository is now:
 
 Once we've developed and pushed all the feature we want to include in the future version `3.0.0` in the `beta` branch and all our tests are successful we can release it to our users.
 
-To do so we need to merge our changes made on `beta` into `master`. As `beta` and `master` branches have diverged, this merge might require to resolve conflicts.
+To do so we need to merge our changes made on `beta` into `main`. As `beta` and `main` branches have diverged, this merge might require to resolve conflicts.
 
-Once the conflicts are resolved and the merge commit is pushed to `master`, **semantic-release** will release the version `3.0.0` on the dist-tag `@latest`.
+Once the conflicts are resolved and the merge commit is pushed to `main`, **semantic-release** will release the version `3.0.0` on the dist-tag `@latest`.
 
 The Git history of the repository is now:
 
@@ -159,18 +159,18 @@ The Git history of the repository is now:
 |  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
 |  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
 | /|  |
-*  |  | Merge branch beta into master # => v2.0.0 on @latest
+*  |  | Merge branch beta into main # => v2.0.0 on @latest
 |  | /|
 |  *  | Merge branch alpha into beta # => v3.0.0-beta.1 on @beta
 | /|  |
-*  |  | Merge branch beta into master # => v3.0.0 on @latest
+*  |  | Merge branch beta into main # => v3.0.0 on @latest
 ```
 
 ## Working on a third future release
 
 We can now start to work on a new future major release, version `4.0.0`, on the `@beta` distribution channel.
 
-To do so we first need to update the `beta` branch with all the changes from `master` (the commits `fix: a fix`). As `beta` and `master` branches have diverged, this merge might require to resolve conflicts.
+To do so we first need to update the `beta` branch with all the changes from `main` (the commits `fix: a fix`). As `beta` and `main` branches have diverged, this merge might require to resolve conflicts.
 
 We can now commit our new feature on `beta`. When pushing that commit, **semantic-release** will publish the pre-release version `3.1.0-beta.1` on the dist-tag `@beta`. That allow us to run integration tests by installing our module with `npm install example-module@beta`. Other users installing with `npm install example-module` will still receive the version `3.0.0`.
 
@@ -186,12 +186,12 @@ The Git history of the repository is now:
 |  |  * feat: first feature of other release \n\n BREAKING CHANGE: it breaks something # => v3.0.0-alpha.1 on @alpha
 |  |  * feat: second feature of other release # => v3.0.0-alpha.2 on @alpha
 | /|  |
-*  |  | Merge branch beta into master # => v2.0.0 on @latest
+*  |  | Merge branch beta into main # => v2.0.0 on @latest
 |  | /|
 |  *  | Merge branch alpha into beta # => v3.0.0-beta.1 on @beta
 | /|  |
-*  |  | Merge branch beta into master # => v3.0.0 on @latest
+*  |  | Merge branch beta into main # => v3.0.0 on @latest
 | \|  |
-|  *  | Merge branch master into beta
+|  *  | Merge branch main into beta
 |  *  | feat: new feature # => v3.1.0-beta.1 on @beta
 ```

--- a/docs/support/FAQ.md
+++ b/docs/support/FAQ.md
@@ -191,11 +191,11 @@ This is fully customizable with the [`@semantic-release/commit-analyzer`](https:
 
 ## Is it _really_ a good idea to release on every push?
 
-It is indeed a great idea because it _forces_ you to follow best practices. If you don’t feel comfortable releasing every feature or fix on your `master` you might not treat your `master` branch as intended.
+It is indeed a great idea because it _forces_ you to follow best practices. If you don’t feel comfortable releasing every feature or fix on your `main` you might not treat your `main` branch as intended.
 
 From [Understanding the GitHub Flow](https://guides.github.com/introduction/flow/index.html):
 
-> Branching is a core concept in Git, and the entire GitHub Flow is based upon it. There's only one rule: anything in the master branch is always deployable.
+> Branching is a core concept in Git, and the entire GitHub Flow is based upon it. There's only one rule: anything in the main branch is always deployable.
 
 If you need more control over the timing of releases, see [Triggering a release](../../README.md#triggering-a-release) for different options.
 

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -66,5 +66,5 @@ To recover from that situation, do the following:
 
 1. Delete the tag(s) for the release(s) that have been lost from the git history. You can delete each tag from remote using `git push origin -d :[TAG NAME]`, e.g. `git push origin -d :v2.0.0-beta.1`. You can delete tags locally using `git tag -d [TAG NAME]`, e.g. `git tag -d v2.0.0-beta.1`.
 2. Re-create the tags locally: `git tag [TAG NAME] [COMMIT HASH]`, where `[COMMIT HASH]` is the new commit that created the release for the lost tag. E.g. `git tag v2.0.0-beta.1 abcdef0`
-3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v2.0.0-beta.1`. If the release was also published in the default channel (usually `master`), then set the first channel to `null`, e.g. `git notes --ref semantic-release add -f -m '{"channels":[null, "beta"]}'`
+3. Re-create the git notes for each release tag, e.g. `git notes --ref semantic-release add -f -m '{"channels":["beta"]}' v2.0.0-beta.1`. If the release was also published in the default channel (usually `main`), then set the first channel to `null`, e.g. `git notes --ref semantic-release add -f -m '{"channels":[null, "beta"]}'`
 4. Push the local notes: `git push --force origin refs/notes/semantic-release`. The `--force` is needed after the rebase. Be careful.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -27,7 +27,7 @@ The following three examples are the same.
 ```json
 {
   "release": {
-    "branches": ["master", "next"]
+    "branches": ["main", "next"]
   }
 }
 ```
@@ -36,7 +36,7 @@ The following three examples are the same.
 
 ```json
 {
-  "branches": ["master", "next"]
+  "branches": ["main", "next"]
 }
 ```
 
@@ -66,19 +66,19 @@ List of modules or file paths containing a [shareable configuration](shareable-c
 ### branches
 
 Type: `Array`, `String`, `Object`<br>
-Default: `['+([0-9])?(.{+([0-9]),x}).x', 'master', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`<br>
+Default: `['+([0-9])?(.{+([0-9]),x}).x', 'main', 'next', 'next-major', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}]`<br>
 CLI arguments: `--branches`
 
 The branches on which releases should happen. By default **semantic-release** will release:
 
-- regular releases to the default distribution channel from the branch `master`
+- regular releases to the default distribution channel from the branch `main`
 - regular releases to a distribution channel matching the branch name from any existing branch with a name matching a maintenance release range (`N.N.x` or `N.x.x` or `N.x` with `N` being a number)
 - regular releases to the `next` distribution channel from the branch `next` if it exists
 - regular releases to the `next-major` distribution channel from the branch `next-major` if it exists
 - pre-releases to the `beta` distribution channel from the branch `beta` if it exists
 - pre-releases to the `alpha` distribution channel from the branch `alpha` if it exists
 
-**Note**: If your repository does not have a release branch, then **semantic-release** will fail with an `ERELEASEBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `master` branch.
+**Note**: If your repository does not have a release branch, then **semantic-release** will fail with an `ERELEASEBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `main` branch.
 
 **Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://docs.github.com/github/administering-a-repository/about-protected-branches).
 
@@ -162,7 +162,7 @@ If a release has been published before setting up **semantic-release** you must 
 
 If the previous releases were published with [`npm publish`](https://docs.npmjs.com/cli/publish) this should already be the case.
 
-For example, if your release branch is `master`, the last release published on your project is `1.1.0` and the last commit included has the sha `1234567`, you must make sure this commit is in `master` history and is tagged with `v1.1.0`.
+For example, if your release branch is `main`, the last release published on your project is `1.1.0` and the last commit included has the sha `1234567`, you must make sure this commit is in `main` history and is tagged with `v1.1.0`.
 
 ```bash
 # Make sure the commit 1234567 is in the release branch history

--- a/docs/usage/workflow-configuration.md
+++ b/docs/usage/workflow-configuration.md
@@ -36,14 +36,14 @@ It can be defined as a [glob](https://github.com/micromatch/micromatch#matching-
 
 If `name` doesn't match to any branch existing in the repository, the definition will be ignored. For example the default configuration includes the definition `next` and `next-major` which will become active only when the branches `next` and/or `next-major` are created in the repository. This allow to define your workflow once with all potential branches you might use and have the effective configuration evolving as you create new branches.
 
-For example the configuration `['+([0-9])?(.{+([0-9]),x}).x', 'master', 'next']` will be expanded as:
+For example the configuration `['+([0-9])?(.{+([0-9]),x}).x', 'main', 'next']` will be expanded as:
 
 ```js
 {
   branches: [
     { name: "1.x", range: "1.x", channel: "1.x" }, // Only after the `1.x` is created in the repo
     { name: "2.x", range: "2.x", channel: "2.x" }, // Only after the `2.x` is created in the repo
-    { name: "master" },
+    { name: "main" },
     { name: "next", channel: "next" }, // Only after the `next` is created in the repo
   ];
 }
@@ -56,12 +56,12 @@ If the `channel` property is set to `false` the default channel will be used.
 
 The value of `channel`, if defined as a string, is generated with [Lodash template](https://lodash.com/docs#template) with the variable `name` available.
 
-For example the configuration `['master', {name: 'next', channel: 'channel-${name}'}]` will be expanded as:
+For example the configuration `['main', {name: 'next', channel: 'channel-${name}'}]` will be expanded as:
 
 ```js
 {
   branches: [
-    { name: "master" }, // `channel` is undefined so the default distribution channel will be used
+    { name: "main" }, // `channel` is undefined so the default distribution channel will be used
     { name: "next", channel: "channel-next" }, // `channel` is built with the template `channel-${name}`
   ];
 }
@@ -71,14 +71,14 @@ For example the configuration `['master', {name: 'next', channel: 'channel-${nam
 
 A `range` only applies to maintenance branches, is required and must be formatted like `N.N.x` or `N.x` (`N` is a number). In case the `name` is formatted as a range (for example `1.x` or `1.5.x`) the branch will be considered a maintenance branch and the `name` value will be used for the `range`.
 
-For example the configuration `['1.1.x', '1.2.x', 'master']` will be expanded as:
+For example the configuration `['1.1.x', '1.2.x', 'main']` will be expanded as:
 
 ```js
 {
   branches: [
     { name: "1.1.x", range: "1.1.x", channel: "1.1.x" },
     { name: "1.2.x", range: "1.2.x", channel: "1.2.x" },
-    { name: "master" },
+    { name: "main" },
   ];
 }
 ```
@@ -90,12 +90,12 @@ If the `prerelease` property is set to `true` the `name` value will be used.
 
 The value of `prerelease`, if defined as a string, is generated with [Lodash template](https://lodash.com/docs#template) with the variable `name` available.
 
-For example the configuration `['master', {name: 'pre/rc', prerelease: '${name.replace(/^pre\\//g, "")}'}, {name: 'beta', prerelease: true}]` will be expanded as:
+For example the configuration `['main', {name: 'pre/rc', prerelease: '${name.replace(/^pre\\//g, "")}'}, {name: 'beta', prerelease: true}]` will be expanded as:
 
 ```js
 {
   branches: [
-    { name: "master" },
+    { name: "main" },
     { name: "pre/rc", channel: "pre/rc", prerelease: "rc" }, // `prerelease` is built with the template `${name.replace(/^pre\\//g, "")}`
     { name: "beta", channel: "beta", prerelease: true }, // `prerelease` is set to `beta` as it is the value of `name`
   ];
@@ -118,19 +118,19 @@ See [publishing on distribution channels recipe](../recipes/release-workflow/dis
 
 #### Pushing to a release branch
 
-With the configuration `"branches": ["master", "next"]`, if the last release published from `master` is `1.0.0` and the last one from `next` is `2.0.0` then:
+With the configuration `"branches": ["main", "next"]`, if the last release published from `main` is `1.0.0` and the last one from `next` is `2.0.0` then:
 
-- Only versions in range `1.x.x` can be published from `master`, so only `fix` and `feat` commits can be pushed to `master`
-- Once `next` get merged into `master` the release `2.0.0` will be made available on the channel associated with `master` and both `master` and `next` will accept any commit type
+- Only versions in range `1.x.x` can be published from `main`, so only `fix` and `feat` commits can be pushed to `main`
+- Once `next` get merged into `main` the release `2.0.0` will be made available on the channel associated with `main` and both `main` and `next` will accept any commit type
 
 This verification prevent scenario such as:
 
 1. Create a `feat` commit on `next` which triggers the release of version `1.0.0` on the `next` channel
-2. Merge `next` into `master` which adds `1.0.0` on the default channel
+2. Merge `next` into `main` which adds `1.0.0` on the default channel
 3. Create a `feat` commit on `next` which triggers the release of version `1.1.0` on the `next` channel
-4. Create a `feat` commit on `master` which would attempt to release the version `1.1.0` on the default channel
+4. Create a `feat` commit on `main` which would attempt to release the version `1.1.0` on the default channel
 
-In step 4 **semantic-release** will throw an `EINVALIDNEXTVERSION` error to prevent the attempt at releasing version `1.1.0` which was already released on step 3 with a different codebase. The error will indicate that the commit should be created on `next` instead. Alternatively if the `next` branch is merged into `master`, the version `1.1.0` will be made available on the default channel and the `feat` commit would be allowed on `master` to release `1.2.0`.
+In step 4 **semantic-release** will throw an `EINVALIDNEXTVERSION` error to prevent the attempt at releasing version `1.1.0` which was already released on step 3 with a different codebase. The error will indicate that the commit should be created on `next` instead. Alternatively if the `next` branch is merged into `main`, the version `1.1.0` will be made available on the default channel and the `feat` commit would be allowed on `main` to release `1.2.0`.
 
 #### Merging into a release branch
 
@@ -154,19 +154,19 @@ See [publishing maintenance releases recipe](../recipes/release-workflow/mainten
 
 #### Pushing to a maintenance branch
 
-With the configuration `"branches": ["1.0.x", "1.x", "master"]`, if the last release published from `master` is `1.5.0` then:
+With the configuration `"branches": ["1.0.x", "1.x", "main"]`, if the last release published from `main` is `1.5.0` then:
 
 - Only versions in range `>=1.0.0 <1.1.0` can be published from `1.0.x`, so only `fix` commits can be pushed to `1.0.x`
 - Only versions in range `>=1.1.0 <1.5.0` can be published from `1.x`, so only `fix` and `feat` commits can be pushed to `1.x` as long the resulting release is lower than `1.5.0`
-- Once `2.0.0` is released from `master`, versions in range `>=1.1.0 <2.0.0` can be published from `1.x`, so any number of `fix` and `feat` commits can be pushed to `1.x`
+- Once `2.0.0` is released from `main`, versions in range `>=1.1.0 <2.0.0` can be published from `1.x`, so any number of `fix` and `feat` commits can be pushed to `1.x`
 
 #### Merging into a maintenance branch
 
-With the configuration `"branches": ["1.0.x", "1.x", "master"]`, if the last release published from `master` is `1.0.0` then:
+With the configuration `"branches": ["1.0.x", "1.x", "main"]`, if the last release published from `main` is `1.0.0` then:
 
-- Creating the branch `1.0.x` from `master` will make the `1.0.0` release available on the `1.0.x` distribution channel
+- Creating the branch `1.0.x` from `main` will make the `1.0.0` release available on the `1.0.x` distribution channel
 - Pushing a `fix` commit on the `1.0.x` branch will release the version `1.0.1` on the `1.0.x` distribution channel
-- Creating the branch `1.x` from `master` will make the `1.0.0` release available on the `1.x` distribution channel
+- Creating the branch `1.x` from `main` will make the `1.0.0` release available on the `1.x` distribution channel
 - Merging the branch `1.0.x` into `1.x` will make the version `1.0.1` available on the `1.x` distribution channel
 
 ### Pre-release branches
@@ -185,14 +185,14 @@ See [publishing pre-releases recipe](../recipes/release-workflow/pre-releases.md
 
 #### Pushing to a pre-release branch
 
-With the configuration `"branches": ["master", {"name": "beta", "prerelease": true}]`, if the last release published from `master` is `1.0.0` then:
+With the configuration `"branches": ["main", {"name": "beta", "prerelease": true}]`, if the last release published from `main` is `1.0.0` then:
 
 - Pushing a `BREAKING CHANGE` commit on the `beta` branch will release the version `2.0.0-beta.1` on the `beta` distribution channel
 - Pushing either a `fix`, `feat` or a `BREAKING CHANGE` commit on the `beta` branch will release the version `2.0.0-beta.2` (then `2.0.0-beta.3`, `2.0.0-beta.4`, etc...) on the `beta` distribution channel
 
 #### Merging into a pre-release branch
 
-With the configuration `"branches": ["master", {"name": "beta", "prerelease": true}]`, if the last release published from `master` is `1.0.0` and the last one published from `beta` is `2.0.0-beta.1` then:
+With the configuration `"branches": ["main", {"name": "beta", "prerelease": true}]`, if the last release published from `main` is `1.0.0` and the last one published from `beta` is `2.0.0-beta.1` then:
 
-- Pushing a `fix` commit on the `master` branch will release the version `1.0.1` on the default distribution channel
-- Merging the branch `master` into `beta` will release the version `2.0.0-beta.2` on the `beta` distribution channel
+- Pushing a `fix` commit on the `main` branch will release the version `1.0.1` on the default distribution channel
+- Merging the branch `main` into `beta` will release the version `2.0.0-beta.2` on the `beta` distribution channel


### PR DESCRIPTION
Many organizations, and the GitHub default have migrated from naming the default branch `master` to `main`. When working with the documents, it's nice to see this newer convention referenced.