### PR TITLE
docs: update GH Actions recipe actions to v3

### DIFF
--- a/docs/recipes/ci-configurations/github-actions.md
+++ b/docs/recipes/ci-configurations/github-actions.md
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "lts/*"
       - name: Install dependencies


### PR DESCRIPTION
v2 uses a very old version of Node and produces a deprecation warning. we should use v3.