### PR TITLE
docs(pre-releases): Correct @latest version in semantic-release

### DIFF
--- a/docs/recipes/release-workflow/pre-releases.md
+++ b/docs/recipes/release-workflow/pre-releases.md
@@ -62,7 +62,7 @@ The Git history of the repository is now:
 
 We now decide to work on another future major release, in parallel of the beta one, which will also be composed of multiple features, some of them being breaking changes.
 
-To implement that workflow we can create the branch `alpha` from the branch `beta` and commit our first feature there. When pushing that commit, **semantic-release** will publish the pre-release version `3.0.0-alpha.1` on the dist-tag `@alpha`. That allow us to run integration tests by installing our module with `npm install example-module@alpha`. Other users installing with `npm install example-module` will still receive the version `1.0.0`.
+To implement that workflow we can create the branch `alpha` from the branch `beta` and commit our first feature there. When pushing that commit, **semantic-release** will publish the pre-release version `3.0.0-alpha.1` on the dist-tag `@alpha`. That allow us to run integration tests by installing our module with `npm install example-module@alpha`. Other users installing with `npm install example-module` will still receive the version `1.0.1`.
 
 The Git history of the repository is now:
 


### PR DESCRIPTION
There is a tiny typo in the version mentioned in `Working on another future release` section. It says that installing with `npm install example-module` will still receive version `1.0.0`, but in fact, there was a bug fix made on the default distribution channel one step before.