### PR TITLE
docs: update node LTS version for npx command

### DIFF
--- a/docs/support/node-version.md
+++ b/docs/support/node-version.md
@@ -24,7 +24,7 @@ See [CI configuration](../usage/ci-configuration.md) and [CI configuration recip
 Use it to execute the `semantic-release` command.
 
 ```bash
-$ npx -p node@lts -c "npx semantic-release"
+$ npx -p node@v18-lts -c "npx semantic-release"
 ```
 
 **Note**: See [What is npx](./FAQ.md#what-is-npx) for more details.


### PR DESCRIPTION
The [lts tag](https://www.npmjs.com/package/node?activeTab=versions) refers to Node.js 16.13.2. To use v18 of Node you need to use the tag `v18-lts`.