### PR TITLE
fix(windows): fixed issues preventing execution from windows

### DIFF
--- a/bin/semantic-release.js
+++ b/bin/semantic-release.js
@@ -25,7 +25,7 @@ See https://github.com/semantic-release/semantic-release/blob/master/docs/suppor
 
 execa("git", ["--version"])
   .then(({ stdout }) => {
-    const gitVersion = findVersions(stdout)[0];
+    const gitVersion = findVersions(stdout, { loose: true })[0];
     if (lt(gitVersion, MIN_GIT_VERSION)) {
       console.error(`[semantic-release]: Git version ${MIN_GIT_VERSION} is required. Found ${gitVersion}.`);
       process.exit(1);

--- a/lib/plugins/utils.js
+++ b/lib/plugins/utils.js
@@ -52,9 +52,14 @@ export async function loadPlugin({cwd}, name, pluginsPath) {
     ? dirname(resolveFrom.silent(__dirname, pluginsPath[name]) || resolveFrom(cwd, pluginsPath[name]))
     : __dirname;
 
-  // See https://github.com/mysticatea/eslint-plugin-node/issues/250
-  // eslint-disable-next-line node/no-unsupported-features/es-syntax
-  return isFunction(name) ? name : (await import(resolveFrom.silent(basePath, name) || resolveFrom(cwd, name))).default;
+  if (!isFunction(name)) {
+    const file = resolveFrom.silent(basePath, name) || resolveFrom(cwd, name);
+    // See https://github.com/mysticatea/eslint-plugin-node/issues/250
+    // eslint-disable-next-line node/no-unsupported-features/es-syntax
+    name = (await import(`file://${file}`)).default;
+  }
+
+  return name;
 }
 
 export function parseConfig(plugin) {


### PR DESCRIPTION
Updates to support running on Windows post the esm conversion.

1. [fix: Detect git version on windows](https://github.com/semantic-release/semantic-release/commit/301687fc0cb9e8caf0999b3926132168826d47be) 
 git does not fully match semver, especially on the windows version. Using loose checking in findVersions is able to match the version.
2. [fix: use file:// url loading plugins](https://github.com/semantic-release/semantic-release/commit/3ec47a33fe98c857d773865187253ebadf766875)
 The `file://` url is required for the `win32`platform but supported on all platforms.