### PR TITLE
ci: updates for running on Windows

### DIFF
--- a/test/helpers/gitbox.js
+++ b/test/helpers/gitbox.js
@@ -20,11 +20,15 @@ export const gitCredential = `${GIT_USERNAME}:${GIT_PASSWORD}`;
 export async function start() {
   await getStream(await docker.pull(IMAGE));
 
-  container = await docker.createContainer({
+  const options = {
     Tty: true,
     Image: IMAGE,
-    PortBindings: {[`${SERVER_PORT}/tcp`]: [{HostPort: `${HOST_PORT}`}]},
-  });
+  };
+  const portKey = `"${SERVER_PORT}/tcp"`;
+  options.HostConfig = JSON.parse(`{"PortBindings": {${portKey} : [{"HostPort" : "${HOST_PORT}"}]}}`);
+  options.ExposedPorts = JSON.parse(`{${portKey} : {}}`)
+  container = await docker.createContainer( options );
+
   await container.start();
 
   const exec = await container.exec({

--- a/test/helpers/mockserver.js
+++ b/test/helpers/mockserver.js
@@ -16,12 +16,16 @@ let container;
 export async function start() {
   await getStream(await docker.pull(IMAGE));
 
-  container = await docker.createContainer({
+  const options = {
     Tty: true,
     Image: IMAGE,
-    PortBindings: {[`${MOCK_SERVER_PORT}/tcp`]: [{HostPort: `${MOCK_SERVER_PORT}`}]},
-  });
-  await container.start();
+  };
+  const portKey = `"${MOCK_SERVER_PORT}/tcp"`;
+  options.HostConfig = JSON.parse(`{"PortBindings": {${portKey} : [{"HostPort" : "${MOCK_SERVER_PORT}"}]}}`);
+  options.ExposedPorts = JSON.parse(`{${portKey} : {}}`)
+  container = await docker.createContainer( options );
+
+  await container.start( );
 
   try {
     // Wait for the mock server to be ready

--- a/test/helpers/npm-registry.js
+++ b/test/helpers/npm-registry.js
@@ -22,12 +22,15 @@ let container, npmToken;
 export async function start() {
   await getStream(await docker.pull(IMAGE));
 
-  container = await docker.createContainer({
+  const options = {
     Tty: true,
     Image: IMAGE,
-    PortBindings: {[`${REGISTRY_PORT}/tcp`]: [{HostPort: `${REGISTRY_PORT}`}]},
     Binds: [`${path.join(__dirname, 'config.yaml')}:/verdaccio/conf/config.yaml`],
-  });
+  };
+  const portKey = `"${REGISTRY_PORT}/tcp"`;
+  options.HostConfig = JSON.parse(`{"PortBindings": {${portKey} : [{"HostPort" : "${REGISTRY_PORT}"}]}}`);
+  options.ExposedPorts = JSON.parse(`{${portKey} : {}}`)
+  container = await docker.createContainer( options );
 
   await container.start();
   await delay(4000);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,7 @@ test.beforeEach((t) => {
   };
 });
 
-test("Plugins are called with expected values", async (t) => {
+test.serial("Plugins are called with expected values", async (t) => {
   // Create a git repository, set the current working directory at the root of the repo
   const { cwd, repositoryUrl } = await gitRepo(true);
   // Add commits to the master branch

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -66,7 +66,7 @@ test.after.always(async () => {
 });
 
 test("Release patch, minor and major versions", async (t) => {
-  const packageName = "test-release";
+  const packageName = "sr-test-release";
   const owner = "git";
   // Create a git repository, set the current working directory at the root of the repo
   t.log("Create git repository and package.json");

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -598,7 +598,7 @@ test("Log unexpected errors from plugins and exit with 1", async (t) => {
   // Verify the type and message are logged
   t.regex(stderr, /Error: a/);
   // Verify the the stacktrace is logged
-  t.regex(stderr, new RegExp(pluginError));
+  t.regex(stderr, new RegExp(process.platform != "win32" ? pluginError : pluginError.replace(/\\/g, '\\\\') ));
   // Verify the Error properties are logged
   t.regex(stderr, /errorProperty: 'errorProperty'/);
   t.is(exitCode, 1);
@@ -687,6 +687,7 @@ test("Use the valid git credentials when multiple are provided", async (t) => {
         BB_TOKEN_BASIC_AUTH: gitbox.gitCredential,
         GIT_ASKPASS: "echo",
         GIT_TERMINAL_PROMPT: 0,
+        GIT_CONFIG_PARAMETERS: "'credential.helper='",
       },
       branch: { name: "master" },
       options: { repositoryUrl: "http://toto@localhost:2080/git/test-auth.git" },
@@ -707,6 +708,7 @@ test("Use the repository URL as is if none of the given git credentials are vali
         GITLAB_TOKEN: "trash",
         GIT_ASKPASS: "echo",
         GIT_TERMINAL_PROMPT: 0,
+        GIT_CONFIG_PARAMETERS: "'credential.helper='",
       },
       branch: { name: "master" },
       options: { repositoryUrl: dummyUrl },

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -515,8 +515,8 @@ test("Pass options via CLI arguments", async (t) => {
 });
 
 test("Run via JS API", async (t) => {
-  td.replace("../lib/logger", { log: () => {}, error: () => {}, stdout: () => {} });
-  td.replace("env-ci", () => ({ isCi: true, branch: "master", isPr: false }));
+  await td.replaceEsm("../lib/logger", null, { log: () => {}, error: () => {}, stdout: () => {} });
+  await td.replaceEsm("env-ci", null, () => ({ isCi: true, branch: "master", isPr: false }));
   const semanticRelease = (await import("../index.js")).default;
   const packageName = "test-js-api";
   const owner = "git";


### PR DESCRIPTION
This patch series contains updates to support the ci tests running on Windows.

1. ci: run docker tests on Windows
    The latest docker engine api needs some more config specs to allow an open port (equivalent to -p on the command line).

2. ci: windows support
   - change the path separator in a test regex when running on Windows
   - turn off `credential.helper` in the git config in the credential tests.  This will suppress pop-ups for the password on Windows systems.

3. ci: use td.repleaseEsm instead of td.replace
    The replace functions are now the same as the other tests.

4. ci: change package name to avoid collision
    There is a test-release package in the docker image at a higher release. A different package name will now be used.

5. ci: serialize a plugin test
    The index test `Plugins are called with expected values` is now serialized to avoid possible concurrency problems.  This matches the rest of the tests in `index.test.js`.