### PR TITLE
Revert "chore(deps): update dependency ava to v5.1.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "semantic-release": "bin/semantic-release.js"
       },
       "devDependencies": {
-        "ava": "5.1.1",
+        "ava": "5.1.0",
         "c8": "7.12.0",
         "clear-module": "4.1.2",
         "codecov": "3.8.3",
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/ava": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-5.1.1.tgz",
-      "integrity": "sha512-od1CWgWVIKZSdEc1dhQWhbsd6KBs0EYjek7eqZNGPvy+NyC9Q1bXixcadlgOXwDG9aM0zLMQZwRXfe9gMb1LQQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-5.1.0.tgz",
+      "integrity": "sha512-e5VFrSQ0WBPyZJWRXVrO7RFOizFeNM0t2PORwrPvWtApgkORI6cvGnY3GX1G+lzpd0HjqNx5Jus22AhxVnUMNA==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.1",
@@ -1133,10 +1133,10 @@
         "arrify": "^3.0.0",
         "callsites": "^4.0.0",
         "cbor": "^8.1.0",
-        "chalk": "^5.2.0",
+        "chalk": "^5.1.2",
         "chokidar": "^3.5.3",
         "chunkd": "^2.0.1",
-        "ci-info": "^3.7.1",
+        "ci-info": "^3.6.1",
         "ci-parallel-vars": "^1.0.1",
         "clean-yaml-object": "^0.1.0",
         "cli-truncate": "^3.1.0",
@@ -1148,7 +1148,7 @@
         "del": "^7.0.0",
         "emittery": "^1.0.1",
         "figures": "^5.0.0",
-        "globby": "^13.1.3",
+        "globby": "^13.1.2",
         "ignore-by-default": "^2.1.0",
         "indent-string": "^5.0.0",
         "is-error": "^2.2.2",
@@ -9636,9 +9636,9 @@
       }
     },
     "ava": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-5.1.1.tgz",
-      "integrity": "sha512-od1CWgWVIKZSdEc1dhQWhbsd6KBs0EYjek7eqZNGPvy+NyC9Q1bXixcadlgOXwDG9aM0zLMQZwRXfe9gMb1LQQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-5.1.0.tgz",
+      "integrity": "sha512-e5VFrSQ0WBPyZJWRXVrO7RFOizFeNM0t2PORwrPvWtApgkORI6cvGnY3GX1G+lzpd0HjqNx5Jus22AhxVnUMNA==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.1",
@@ -9648,10 +9648,10 @@
         "arrify": "^3.0.0",
         "callsites": "^4.0.0",
         "cbor": "^8.1.0",
-        "chalk": "^5.2.0",
+        "chalk": "^5.1.2",
         "chokidar": "^3.5.3",
         "chunkd": "^2.0.1",
-        "ci-info": "^3.7.1",
+        "ci-info": "^3.6.1",
         "ci-parallel-vars": "^1.0.1",
         "clean-yaml-object": "^0.1.0",
         "cli-truncate": "^3.1.0",
@@ -9663,7 +9663,7 @@
         "del": "^7.0.0",
         "emittery": "^1.0.1",
         "figures": "^5.0.0",
-        "globby": "^13.1.3",
+        "globby": "^13.1.2",
         "ignore-by-default": "^2.1.0",
         "indent-string": "^5.0.0",
         "is-error": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "ava": "5.1.1",
+    "ava": "5.1.0",
     "c8": "7.12.0",
     "clear-module": "4.1.2",
     "codecov": "3.8.3",


### PR DESCRIPTION
Reverts semantic-release/semantic-release#2676 

i think this is related to the tests not exiting correctly