### PR TITLE
feat(plugins): add support for loading ESM plugins

### DIFF
--- a/lib/plugins/utils.js
+++ b/lib/plugins/utils.js
@@ -52,14 +52,18 @@ export async function loadPlugin({cwd}, name, pluginsPath) {
     ? dirname(resolveFrom.silent(__dirname, pluginsPath[name]) || resolveFrom(cwd, pluginsPath[name]))
     : __dirname;
 
-  if (!isFunction(name)) {
-    const file = resolveFrom.silent(basePath, name) || resolveFrom(cwd, name);
-    // See https://github.com/mysticatea/eslint-plugin-node/issues/250
-    // eslint-disable-next-line node/no-unsupported-features/es-syntax
-    name = (await import(`file://${file}`)).default;
+  if (isFunction(name)) {
+    return name;
   }
 
-  return name;
+  const file = resolveFrom.silent(basePath, name) || resolveFrom(cwd, name);
+  const { default: cjsExport, ...esmNamedExports } = await import(`file://${file}`);
+
+  if (cjsExport) {
+    return cjsExport;
+  }
+
+  return esmNamedExports;
 }
 
 export function parseConfig(plugin) {

--- a/test/fixtures/plugin-esm-named-exports.js
+++ b/test/fixtures/plugin-esm-named-exports.js
@@ -1,0 +1,3 @@
+export async function verifyConditions(pluginConfig, context) {
+  context.logger.log("verifyConditions called");
+}

--- a/test/plugins/utils.test.js
+++ b/test/plugins/utils.test.js
@@ -199,7 +199,18 @@ test('loadPlugin', async (t) => {
     await loadPlugin({cwd}, './plugin-noop.cjs', {'./plugin-noop.cjs': './test/fixtures'}),
     'From a shareable config context'
   );
-  t.is(func, await loadPlugin({cwd}, func, {}), 'Defined as a function');
+  t.is(
+    (await import("../fixtures/plugin-noop.cjs")).default,
+    await loadPlugin({ cwd }, "./plugin-noop.cjs", { "./plugin-noop.cjs": "./test/fixtures" }),
+    "From a shareable config context"
+  );
+  const { ...namedExports } = await import("../fixtures/plugin-esm-named-exports.js");
+  const plugin = await loadPlugin({ cwd }, "./plugin-esm-named-exports.js", {
+    "./plugin-esm-named-exports.js": "./test/fixtures",
+  });
+
+  t.deepEqual(namedExports, plugin, "ESM with named exports");
+  t.is(func, await loadPlugin({ cwd }, func, {}), "Defined as a function");
 });
 
 test('parseConfig', (t) => {


### PR DESCRIPTION
this cherry-picks commits that originally landed in the current beta branch in order to backport the esm plugin loading capability into the mainline ahead of the beta branch landing.