### PR TITLE
test(integration): fix package name conflict

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -716,7 +716,7 @@ test("Use the repository URL as is if none of the given git credentials are vali
 });
 
 test("ESM Plugin with named exports", async (t) => {
-  const packageName = "log-secret";
+  const packageName = "plugin-exports";
   // Create a git repository, set the current working directory at the root of the repo
   t.log("Create git repository");
   const { cwd, repositoryUrl } = await gitbox.createRepo(packageName);


### PR DESCRIPTION
Two tests had the same package name, causing random concurrency failures during CI testing.

An example of the conflict is in [this](https://github.com/semantic-release/semantic-release/actions/runs/4191434175/jobs/7265855238) CI run.