### PR TITLE
ci: set test workflow timeout to 10 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - 19
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Issues are preventing ci jobs from completing.  This patch reduces the timeout from the default timeout of six hours.  The logs are not always viewable until the timeout so this should help in problem examination.