### PR TITLE
test: update docker config for windows support (#2721

### DIFF
--- a/test/helpers/gitbox.js
+++ b/test/helpers/gitbox.js
@@ -23,7 +23,10 @@ export async function start() {
   container = await docker.createContainer({
     Tty: true,
     Image: IMAGE,
-    PortBindings: {[`${SERVER_PORT}/tcp`]: [{HostPort: `${HOST_PORT}`}]},
+    HostConfig: {
+        PortBindings: {[`${SERVER_PORT}/tcp`]: [{HostPort: `${HOST_PORT}`}]}
+    },
+    ExposedPorts: {[`${SERVER_PORT}/tcp`]: {}}
   });
   await container.start();
 

--- a/test/helpers/mockserver.js
+++ b/test/helpers/mockserver.js
@@ -19,7 +19,10 @@ export async function start() {
   container = await docker.createContainer({
     Tty: true,
     Image: IMAGE,
-    PortBindings: {[`${MOCK_SERVER_PORT}/tcp`]: [{HostPort: `${MOCK_SERVER_PORT}`}]},
+    HostConfig: {
+        PortBindings: {[`${MOCK_SERVER_PORT}/tcp`]: [{HostPort: `${MOCK_SERVER_PORT}`}]}
+    },
+    ExposedPorts: {[`${MOCK_SERVER_PORT}/tcp`]: {}}
   });
   await container.start();
 

--- a/test/helpers/npm-registry.js
+++ b/test/helpers/npm-registry.js
@@ -25,8 +25,11 @@ export async function start() {
   container = await docker.createContainer({
     Tty: true,
     Image: IMAGE,
-    PortBindings: {[`${REGISTRY_PORT}/tcp`]: [{HostPort: `${REGISTRY_PORT}`}]},
-    Binds: [`${path.join(__dirname, 'config.yaml')}:/verdaccio/conf/config.yaml`],
+    HostConfig: {
+        PortBindings: {[`${REGISTRY_PORT}/tcp`]: [{HostPort: `${REGISTRY_PORT}`}]},
+        Binds: [`${path.join(__dirname, 'config.yaml')}:/verdaccio/conf/config.yaml`],
+    },
+    ExposedPorts: {[`${REGISTRY_PORT}/tcp`]: {}}
   });
 
   await container.start();


### PR DESCRIPTION
There is legacy support for PortBindings and Binds at the root level of the config.  Currently (including Windows) these reside under the HostConfig.  ExposedPorts is now used to identify the externally available ports.

Tests run when sideloaded for Linux testing [here](https://github.com/webstech/testteeny/actions/runs/4290352828/jobs/7474281208).  On Windows, it runs locally  but fails on GitHub server with a `docker image not found` error (not related to config change).  Researching the Windows error.