### PR TITLE
test: Windows support in integration tests

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -598,7 +598,7 @@ test("Log unexpected errors from plugins and exit with 1", async (t) => {
   // Verify the type and message are logged
   t.regex(stderr, /Error: a/);
   // Verify the the stacktrace is logged
-  t.regex(stderr, new RegExp(pluginError));
+  t.regex(stderr, new RegExp(process.platform != "win32" ? pluginError : pluginError.replace(/\\/g, "\\\\")));
   // Verify the Error properties are logged
   t.regex(stderr, /errorProperty: 'errorProperty'/);
   t.is(exitCode, 1);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -598,7 +598,7 @@ test("Log unexpected errors from plugins and exit with 1", async (t) => {
   // Verify the type and message are logged
   t.regex(stderr, /Error: a/);
   // Verify the the stacktrace is logged
-  t.regex(stderr, new RegExp(process.platform != "win32" ? pluginError : pluginError.replace(/\\/g, "\\\\")));
+  t.regex(stderr, new RegExp(process.platform === "win32" ? pluginError.replace(/\\/g, "\\\\") : pluginError));
   // Verify the Error properties are logged
   t.regex(stderr, /errorProperty: 'errorProperty'/);
   t.is(exitCode, 1);
@@ -687,6 +687,7 @@ test("Use the valid git credentials when multiple are provided", async (t) => {
         BB_TOKEN_BASIC_AUTH: gitbox.gitCredential,
         GIT_ASKPASS: "echo",
         GIT_TERMINAL_PROMPT: 0,
+        GIT_CONFIG_PARAMETERS: "'credential.helper='",
       },
       branch: { name: "master" },
       options: { repositoryUrl: "http://toto@localhost:2080/git/test-auth.git" },
@@ -707,6 +708,7 @@ test("Use the repository URL as is if none of the given git credentials are vali
         GITLAB_TOKEN: "trash",
         GIT_ASKPASS: "echo",
         GIT_TERMINAL_PROMPT: 0,
+        GIT_CONFIG_PARAMETERS: "'credential.helper='",
       },
       branch: { name: "master" },
       options: { repositoryUrl: dummyUrl },


### PR DESCRIPTION
A pair of patches to the integration tests. 

1. ci: win32 escape slash as doubleslash for test
    Pathing in stderr output has double backslash in the filename.  The test will now use double backslash in the existence test.

2. ci: avoid Windows pop-up in credential tests
    Windows uses a `credential.helper` that will open a pop-up for credentials if they are missing.  A git config parameter will now be set in the environment to avoid the pop-up.