### PR TITLE
docs: Update README.md with npm package provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This removes the immediate connection between human emotions and version numbers
 - Avoid potential errors associated with manual releases
 - Support any [package managers and languages](docs/recipes/release-workflow/README.md#package-managers-and-languages) via [plugins](docs/usage/plugins.md)
 - Simple and reusable configuration via [shareable configurations](docs/usage/shareable-configurations.md)
+- Support for [npm package provenance](https://github.com/semantic-release/npm#npm-provenance) that promotes increased supply-chain security via signed attestations on GitHub Actions
 
 ## How does it work?
 


### PR DESCRIPTION
# What
npm package provenance is a big thing for open-source supply chain security and should receive increased awareness and promotion to help secure the ecosystem of 3rd-party packages.

# Why
The npm package provenance setup exists in the [semantic-release/npm package readme](https://github.com/semantic-release/npm#npm-provenance) but it's easily missed out on when someone searches the main project's README.

# The change
This PR updates the list of supported features to make the feature easily accessible and promote it for users.