### PR TITLE
ci(release): pinned the version of semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: lts/*
       - run: npm clean-install
       - run: npm audit signatures
-      - run: npx semantic-release
+      - run: npx semantic-release@21.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_BOT_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
           node-version: lts/*
       - run: npm clean-install
       - run: npm audit signatures
+      # pinned version updated automatically by Renovate.
+      # details at https://semantic-release.gitbook.io/semantic-release/usage/installation#global-installation
       - run: npx semantic-release@21.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
the goal with this is to make releases more deterministic based on commit rather than a point in time. in combination with https://github.com/semantic-release/.github/pull/18, we should continue to release with the latest version, but without that dependence on time.