### PR TITLE
test(integration): properly waited for the image pulls to complete

### DIFF
--- a/test/helpers/gitbox.js
+++ b/test/helpers/gitbox.js
@@ -1,5 +1,4 @@
 import Docker from "dockerode";
-import getStream from "get-stream";
 import pRetry from "p-retry";
 import { gitShallowClone, initBareRepo } from "./git-utils.js";
 
@@ -15,11 +14,20 @@ let container;
 export const gitCredential = `${GIT_USERNAME}:${GIT_PASSWORD}`;
 
 /**
- * Download the `gitbox` Docker image, create a new container and start it.
+ * Download the `gitbox` Docker image
+ */
+export function pull() {
+  return docker.pull(IMAGE).then((stream) => {
+    return new Promise((resolve, reject) => {
+      docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
+    });
+  });
+}
+
+/**
+ * create a new container and start it.
  */
 export async function start() {
-  await getStream(await docker.pull(IMAGE));
-
   container = await docker.createContainer({
     Tty: true,
     Image: IMAGE,

--- a/test/helpers/mockserver.js
+++ b/test/helpers/mockserver.js
@@ -1,5 +1,4 @@
 import Docker from "dockerode";
-import getStream from "get-stream";
 import got from "got";
 import pRetry from "p-retry";
 import { mockServerClient } from "mockserver-client";
@@ -11,11 +10,20 @@ const docker = new Docker();
 let container;
 
 /**
- * Download the `mockserver` Docker image, create a new container and start it.
+ * Download the `mockserver` Docker image,
+ */
+export function pull() {
+  return docker.pull(IMAGE).then((stream) => {
+    return new Promise((resolve, reject) => {
+      docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
+    });
+  });
+}
+
+/**
+ * create a new container and start it.
  */
 export async function start() {
-  await getStream(await docker.pull(IMAGE));
-
   container = await docker.createContainer({
     Tty: true,
     Image: IMAGE,

--- a/test/helpers/npm-registry.js
+++ b/test/helpers/npm-registry.js
@@ -2,7 +2,6 @@ import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { setTimeout } from "node:timers/promises";
 import Docker from "dockerode";
-import getStream from "get-stream";
 import got from "got";
 import pRetry from "p-retry";
 
@@ -17,11 +16,20 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 let container, npmToken;
 
 /**
- * Download the `npm-registry-docker` Docker image, create a new container and start it.
+ * Download the `npm-registry-docker` Docker image
+ */
+export function pull() {
+  return docker.pull(IMAGE).then((stream) => {
+    return new Promise((resolve, reject) => {
+      docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
+    });
+  });
+}
+
+/**
+ * create a new container and start it.
  */
 export async function start() {
-  await getStream(await docker.pull(IMAGE));
-
   container = await docker.createContainer({
     Tty: true,
     Image: IMAGE,

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -47,6 +47,7 @@ const pluginLogEnv = path.resolve("./test/fixtures/plugin-log-env");
 const pluginEsmNamedExports = path.resolve("./test/fixtures/plugin-esm-named-exports");
 
 test.before(async () => {
+  await Promise.all([gitbox.pull(), npmRegistry.pull(), mockServer.pull()]);
   await Promise.all([gitbox.start(), npmRegistry.start(), mockServer.start()]);
 
   env = {


### PR DESCRIPTION
this uses the technique for waiting for the pull to complete [from the dockerode readme](https://github.com/apocas/dockerode/tree/edf29ccb2c2c7bfcdd1cf3cacbe861bd0f4bc87a#helper-functions) and mostly gets rid of our dependence on get-stream.

the [remaining get-stream usage](https://github.com/semantic-release/semantic-release/blob/45eb11ae9cb46e6167ecfa255ae5c62ab0d016ff/lib/git.js#L49) is the `.array()` that is [removed in v7](https://github.com/sindresorhus/get-stream/releases/tag/v7.0.0). i suggest we deal with that usage separately from this PR