### PR TITLE
ci(ossf-scorecard): added workflow calculating scorecard metrics

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: OpenSSF Scorecard
+"on":
+  schedule:
+    - cron: 31 2 * * 1
+  push:
+    branches:
+      - master
+permissions: read-all
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.1.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v2.2.4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   <a href="https://github.com/semantic-release/semantic-release/actions?query=workflow%3ATest+branch%3Amaster">
     <img alt="Build states" src="https://github.com/semantic-release/semantic-release/workflows/Test/badge.svg">
   </a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/semantic-release/semantic-release">
+    <img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/semantic-release/semantic-release/badge">
+  </a>
   <a href="#badge">
     <img alt="semantic-release: angular" src="https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release">
   </a>


### PR DESCRIPTION
the changes to detect semantic-release in github actions workflows was [released yesterday](https://github.com/ossf/scorecard/releases/tag/v4.11.0), so it feels like the right time to add this to our workflows. 

our [current score is 7.7](https://securityscorecards.dev/viewer/?uri=github.com/semantic-release/semantic-release), but i expect that to go up once this is merged and the score is recalculated with the new detection for semantic-release. i'm hopeful that the failure to detect our license might also be fixed, but i haven't dug in to confirm that one 🤞🏼 