### PR TITLE
docs(plugins): change to new repo and package name

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -107,7 +107,7 @@
   - `verifyConditions`: Verify the presence and the validity of the authentication and the assets option configuration.
   - `publish`: Publish a Gitea release, optionally uploading file assets.
   - `addChannel`: Update a Gitea release's pre-release field.
-- [@google/semantic-release-replace-plugin](https://github.com/google/semantic-release-replace-plugin)
+- [semantic-release-replace-plugin](https://github.com/jpoehnelt/semantic-release-replace-plugin)
   - `prepare`: Replace version strings in files using regex and glob.
 - [semantic-release-rubygem](https://github.com/Gusto/semantic-release-rubygem)
   - `verifyConditions`: Locate and validate a `.gemspec` file, locate and validate a `lib/**/version.rb` file, verify the presence of the `GEM_HOST_API_KEY` environment variable, and create a credentials file with the API key.


### PR DESCRIPTION
https://www.npmjs.com/package/@google/semantic-release-replace-plugin now points to `semantic-release-replace-plugin`.

![Screenshot 2023-07-05 at 7 13 04 PM](https://github.com/semantic-release/semantic-release/assets/3392975/c8602bf5-4a45-44a9-8b15-790d29232389)
