### PR TITLE
docs: update example to use NODE_AUTH_TOKEN env

### DIFF
--- a/docs/recipes/ci-configurations/github-actions.md
+++ b/docs/recipes/ci-configurations/github-actions.md
@@ -57,7 +57,7 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 ```
 


### PR DESCRIPTION
The example shows the wrong env key in the release job. It says `NPM_TOKEN`, but it should be `NODE_AUTH_TOKEN`. 

See: https://github.com/semantic-release/semantic-release/issues/2313