### PR TITLE
feat: support Node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.0.0
-          - 19
+          - 16
+          - 18
+          - 20
 
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "testdouble": "3.18.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "files": [
     "bin",


### PR DESCRIPTION
It's not clear to me that there's any code here that won't run on Node 16 in which case the engines requirement is simply a headache for users without benefit. I understand that Node 16 is no longer supported and we are looking to drop it eventually. However, dropping support for Node 16 in our projects would be a breaking change and so we're waiting for the next major version before making that change. I believe a tool like `semantic-release` should be slightly more generous in the versions it supports to allow projects in the ecosystem time to gradually phase out old versions of Node.js