### PR TITLE
fix(deps): upgraded `release-notes-generator` and `commit-analyzer` plugins to stable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@semantic-release/commit-analyzer": "^11.0.0-beta.3",
+        "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^9.0.0",
         "@semantic-release/npm": "^11.0.0",
-        "@semantic-release/release-notes-generator": "^12.0.0-beta.2",
+        "@semantic-release/release-notes-generator": "^12.0.0",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^8.0.0",
         "debug": "^4.0.0",
@@ -461,9 +461,9 @@
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "11.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.0.0-beta.4.tgz",
-      "integrity": "sha512-K6HkgFadJ+imAc0n2P9sLjrEw+xAPqigsu6RS+wCUqc6et2J7ig8uJ4hqujXsXHZLtsKQt/5yjw0t3FjcvseIA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.0.0.tgz",
+      "integrity": "sha512-uEXyf4Z0AWJuxI9TbSQP5kkIYqus1/E1NcmE7pIv6d6/m/5EJcNWAGR4FOo34vrV26FhEaRVkxFfYzp/M7BKIg==",
       "dependencies": {
         "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-filter": "^4.0.0",
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "12.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.0.0-beta.3.tgz",
-      "integrity": "sha512-87tr1FqBTCDIyfiqPTJrRU/aANzaekmhtgBV/nm2D3WCDp6Wr9PydsFOTSTL+H7LZZKDZANsRv9UGRSBEPvtRQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.0.0.tgz",
+      "integrity": "sha512-m7Ds8ComP1KJgA2Lke2xMwE1TOOU40U7AzP4lT8hJ2tUAeicziPz/1GeDFmRkTOkMFlfHvE6kuvMkvU+mIzIDQ==",
       "dependencies": {
         "conventional-changelog-angular": "^7.0.0",
         "conventional-changelog-writer": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "Matt Travi <npm@travi.org> (https://matt.travi.org/)"
   ],
   "dependencies": {
-    "@semantic-release/commit-analyzer": "^11.0.0-beta.3",
+    "@semantic-release/commit-analyzer": "^11.0.0",
     "@semantic-release/error": "^4.0.0",
     "@semantic-release/github": "^9.0.0",
     "@semantic-release/npm": "^11.0.0",
-    "@semantic-release/release-notes-generator": "^12.0.0-beta.2",
+    "@semantic-release/release-notes-generator": "^12.0.0",
     "aggregate-error": "^5.0.0",
     "cosmiconfig": "^8.0.0",
     "debug": "^4.0.0",


### PR DESCRIPTION
follow up to #2934