### PR TITLE
fix(exports): removed the `exports` definition for the time being

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   "engines": {
     "node": "^18.17 || >=20.6.1"
   },
-  "exports": "./index.js",
   "files": [
     "bin",
     "docs",


### PR DESCRIPTION
closes #2968

since this was added as a cleanup item to a major release that was primarily intended to unblock folks seeing incompatibilities with the latest conventional-changelog presets, we didnt intend for this to break potentially legitimate extension of semantic-release in the process. 

we want to use what we learned from this to more intentionally define this programatic API in a future breaking release through https://github.com/semantic-release/semantic-release/issues/2978 instead.