### PR TITLE
fix: make engine version exception for Bun

### DIFF
--- a/bin/semantic-release.js
+++ b/bin/semantic-release.js
@@ -14,7 +14,7 @@ const { satisfies, lt } = semver;
 
 const MIN_GIT_VERSION = "2.7.1";
 
-if (!satisfies(process.version, engines.node)) {
+if (!satisfies(process.version, engines.node) && typeof Bun === "undefined") {
   console.error(
     `[semantic-release]: node version ${engines.node} is required. Found ${process.version}.
 


### PR DESCRIPTION
I've tested this and it works fine, and semantic-release can run (as far as I can tell) with no issues in a Bun-only environment (no Node). [Example -- running on CircleCI](https://app.circleci.com/pipelines/github/jamonholmgren/bluebun/34/workflows/742b2662-d60f-4ff2-8f97-ab9b93d9b70c/jobs/39).

However, Bun reports its Node version as 18.15. So, when you try to run semantic-release without this change, you get this error:

```
 ~/Code/ bunx --bun semantic-release --version
[semantic-release]: node version ^18.17 || >=20.6.1 is required. Found v18.15.0.

See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.
```

Given that semantic-release works fine with Bun, we should not exit if we are running in the Bun runtime. This tiny PR allows semantic-release to do that.
