### PR TITLE
fix: support windows absolute extends

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,10 +1,10 @@
-import { dirname, extname } from "node:path";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { castArray, isNil, isPlainObject, isString, pickBy } from "lodash-es";
 import { readPackageUp } from "read-pkg-up";
 import { cosmiconfig } from "cosmiconfig";
-import resolveFrom from "resolve-from";
+import importFrom from "import-from-esm";
 import debugConfig from "debug";
 import { repoUrl } from "./git.js";
 import PLUGINS_DEFINITIONS from "./definitions/plugins.js";
@@ -33,17 +33,7 @@ export default async (context, cliOptions) => {
     options = {
       ...(await castArray(extendPaths).reduce(async (eventualResult, extendPath) => {
         const result = await eventualResult;
-        const resolvedPath = resolveFrom.silent(__dirname, extendPath) || resolveFrom(cwd, extendPath);
-        const importAssertions =
-          extname(resolvedPath) === ".json"
-            ? {
-                assert: {
-                  type: "json",
-                },
-              }
-            : undefined;
-
-        const { default: extendsOptions } = await import(resolvedPath, importAssertions);
+        const extendsOptions = (await importFrom.silent(__dirname, extendPath)) || (await importFrom(cwd, extendPath));
 
         // For each plugin defined in a shareable config, save in `pluginsPath` the extendable config path,
         // so those plugin will be loaded relative to the config file

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "git-log-parser": "^1.2.0",
         "hook-std": "^3.0.0",
         "hosted-git-info": "^7.0.0",
-        "import-from-esm": "^1.2.1",
+        "import-from-esm": "^1.3.1",
         "lodash-es": "^4.17.21",
         "marked": "^9.0.0",
         "marked-terminal": "^6.0.0",
@@ -5928,10 +5928,11 @@
       }
     },
     "node_modules/import-from-esm": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.2.1.tgz",
-      "integrity": "sha512-Nly5Ab75rWZmOwtMa0B0NQNnHGcHOQ2zkU/bVENwK2lbPq+kamPDqNKNJ0hF7w7lR/ETD5nGgJq0XbofsZpYCA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.1.tgz",
+      "integrity": "sha512-YltaeDglQ6wDZOC8ZAY2I8vK1Ag4XVbs4GhlvNALWz0ee5V+CMkcBhAKbs1iuJZ3fmfgrKFCDRwliM3OxyQMLA==",
       "dependencies": {
+        "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "git-log-parser": "^1.2.0",
         "hook-std": "^3.0.0",
         "hosted-git-info": "^7.0.0",
+        "import-from-esm": "^1.2.1",
         "lodash-es": "^4.17.21",
         "marked": "^9.0.0",
         "marked-terminal": "^6.0.0",
@@ -5904,6 +5905,26 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/import-from-esm": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.2.1.tgz",
+      "integrity": "sha512-Nly5Ab75rWZmOwtMa0B0NQNnHGcHOQ2zkU/bVENwK2lbPq+kamPDqNKNJ0hF7w7lR/ETD5nGgJq0XbofsZpYCA==",
+      "dependencies": {
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.20"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+      "integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/import-from-esm": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "git-log-parser": "^1.2.0",
     "hook-std": "^3.0.0",
     "hosted-git-info": "^7.0.0",
+    "import-from-esm": "^1.2.1",
     "lodash-es": "^4.17.21",
     "marked": "^9.0.0",
     "marked-terminal": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "git-log-parser": "^1.2.0",
     "hook-std": "^3.0.0",
     "hosted-git-info": "^7.0.0",
-    "import-from-esm": "^1.2.1",
+    "import-from-esm": "^1.3.1",
     "lodash-es": "^4.17.21",
     "marked": "^9.0.0",
     "marked-terminal": "^6.0.0",


### PR DESCRIPTION
### Description

Restore support for Windows absolute path in the `extends` configuration option by using `import-from-esm` to load the referenced module.

### Context

Following the changes in #3037, [a user encountered an `ERR_UNSUPPORTED_ESM_URL_SCHEME` error](https://github.com/semantic-release/commit-analyzer/pull/537#issuecomment-1800309172) because [using `resolve-from`](https://github.com/semantic-release/semantic-release/pull/3037/files#diff-3d464ef33ea10184a2faab420f7980eaedb53ad4c88aeb788fbc5a932eeebf16R36) [does not return an URL](https://github.com/sindresorhus/resolve-from/blob/main/index.js#L29C2-L33C5), and `import` then considers `C:/` to be an URL scheme (like `file://`) and returns the encountered error.

### How has this been tested

Since there are no Windows-specific tests on this repository and the test pipeline doesn't run on Windows, we can rely on `import-from-esm` solid test suite to guarantee this works:
- all tests importing local files [are run against both relative & absolute paths](https://github.com/sheerlox/import-from-esm/blob/844fe7a2a67a0a5a76ee8dc25f143acc45127516/tests/helpers/test.helpers.js#L6-L11), and the test pipeline [runs on Ubuntu, Windows & MacOS](https://github.com/sheerlox/import-from-esm/blob/844fe7a2a67a0a5a76ee8dc25f143acc45127516/.github/workflows/test.yml#L32)
- importing extensionless / `index.json` & package main entry point JSON modules [is now supported](https://github.com/sheerlox/import-from-esm/pull/51) and [covered by tests](https://github.com/sheerlox/import-from-esm/commit/f5486fd5f1f18dac5dfa8a18b175aced1e72710d#diff-89d4dfba2eff941d8fa499a7d143f20c559539b0c334b1cce67f52f25310ff0e)

### Related issues

- https://github.com/semantic-release/semantic-release/pull/3037#issuecomment-1800417078
- https://github.com/semantic-release/commit-analyzer/pull/537#issuecomment-1800309172
- https://github.com/sheerlox/import-from-esm/pull/40
- https://github.com/sheerlox/import-from-esm/pull/51