### PR TITLE
feat(config): add tagReleaseAfter to config

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -37,6 +37,7 @@ Usage:
     .option("debug", { describe: "Output debugging information", type: "boolean", group: "Options" })
     .option("d", { alias: "dry-run", describe: "Skip publishing", type: "boolean", group: "Options" })
     .option("h", { alias: "help", group: "Options" })
+    .option("tag-release-after", { describe: "After when to apply the release tag", type: "string", group: "Options" })
     .strict(false)
     .exitProcess(false);
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -115,6 +115,19 @@ The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) format used by 
 
 **Note**: The `tagFormat` must contain the `version` variable exactly once and compile to a [valid Git reference](https://git-scm.com/docs/git-check-ref-format#_description).
 
+### tagReleaseAfter
+
+Type: `prepare | publish`<br>
+Default: `prepare`<br>
+CLI arguments: `--tag-release-after`
+
+After which [lifecycle](plugins.md) to apply this git tag to the commit that is being released. Keep in mind, that once a tag has been applied to a commit, it means that
+semantic-relesae will not re-run for that commit.
+
+Note, the default behavior is in line with a legacy pattern that was made to accomodate for some plugins that assumed the tag would already
+be there before their publish call. It is recommended that you set this to be after 'publish' to ensure that you do not create false positives
+for your releases, but will require you to confirm that your plugins' publish methods work.
+
 ### plugins
 
 Type: `Array`<br>

--- a/index.d.ts
+++ b/index.d.ts
@@ -638,6 +638,17 @@ declare module "semantic-release" {
     tagFormat?: string | undefined;
 
     /**
+     * When to tag our commit with the version tag.  Keep in mind, that tagging
+     * this commit means that semantic-release will not re-run on that commit.
+     * 
+     * By default, we tag right after prepare due to a legacy consideration for plugins
+     * that were publishing based off of the tag being there.  It is recommended 
+     * that you set this to 'publish' however, so that you can be sure that all appropriate
+     * actions were taken effectively.
+     */
+    tagReleaseAfter?: 'prepare' | 'publish'
+
+    /**
      * Define the list of plugins to use. Plugins will run in series, in
      * the order defined, for each [step](https://semantic-release.gitbook.io/semantic-release/#release-steps)
      * if they implement it.

--- a/lib/definitions/constants.js
+++ b/lib/definitions/constants.js
@@ -15,3 +15,22 @@ export const SECRET_REPLACEMENT = "[secure]";
 export const SECRET_MIN_SIZE = 5;
 
 export const GIT_NOTE_REF = "semantic-release";
+
+// Lifecycles
+export const VERIFY_CONDITIONS_LIFECYCLE = "verifyConditions";
+
+export const ANALYZE_COMMITS_LIFECYCLE = "analyzeCommits";
+
+export const VERIFY_RELEASE_LIFECYCLE = "verifyRelease";
+
+export const GENERATE_NOTES_LIFECYCLE = "generateNotes";
+
+export const ADD_CHANNLE_LIFECYCLE = "addChannel";
+
+export const PREPARE_LIFECYCLE = "prepare";
+
+export const PUBLISH_LIFECYCLE = "publish";
+
+export const SUCCESS_LIFECYCLE = "success";
+
+export const FAIL_LIFECYCLE = "fail";

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -62,6 +62,17 @@ Your configuration for the \`tagFormat\` option is \`${stringify(tagFormat)}\`.`
   };
 }
 
+export function EINVALIDTAGRELEASEAFTER(context) {
+  return {
+    message: "Invalid `tagReleaseAfter` option.",
+    details: `The [tagReleaseAfter](${linkify(
+      "docs/usage/configuration.md#tagreleaseafter"
+    )}) must specify an allowed lifecycle phase.
+
+Your configuration for the \`tagReleaseAfter\` option is \`${context.options.tagReleaseAfter}\`.`,
+  };
+}
+
 export function ETAGNOVERSION({ options: { tagFormat } }) {
   return {
     message: "Invalid `tagFormat` option.",

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -10,6 +10,7 @@ import { repoUrl } from "./git.js";
 import PLUGINS_DEFINITIONS from "./definitions/plugins.js";
 import plugins from "./plugins/index.js";
 import { parseConfig, validatePlugin } from "./plugins/utils.js";
+import { PREPARE_LIFECYCLE } from "./definitions/constants.js";
 
 const debug = debugConfig("semantic-release:config");
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -71,6 +72,7 @@ export default async (context, cliOptions) => {
     ],
     repositoryUrl: (await pkgRepoUrl({ normalize: false, cwd })) || (await repoUrl({ cwd, env })),
     tagFormat: `v\${version}`,
+    tagReleaseAfter: cliOptions?.tagReleaseAfter || PREPARE_LIFECYCLE,
     plugins: [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -2,12 +2,13 @@ import { isPlainObject, isString, template } from "lodash-es";
 import AggregateError from "aggregate-error";
 import { isGitRepo, verifyTagName } from "./git.js";
 import getError from "./get-error.js";
+import { PREPARE_LIFECYCLE, PUBLISH_LIFECYCLE } from "./definitions/constants.js";
 
 export default async (context) => {
   const {
     cwd,
     env,
-    options: { repositoryUrl, tagFormat, branches },
+    options: { repositoryUrl, tagFormat, branches, tagReleaseAfter },
   } = context;
   const errors = [];
 
@@ -36,6 +37,11 @@ export default async (context) => {
       errors.push(getError("EINVALIDBRANCH", { branch }));
     }
   });
+
+  // Verify that we can add tag after valid phase
+  if (tagReleaseAfter !== PREPARE_LIFECYCLE && tagReleaseAfter !== PUBLISH_LIFECYCLE) {
+    errors.push(getError("EINVALIDTAGRELEASEAFTER", context));
+  }
 
   if (errors.length > 0) {
     throw new AggregateError(errors);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -72,6 +72,8 @@ test.serial("Pass options to semantic-release API", async (t) => {
     "fail2",
     "--debug",
     "-d",
+    "--tag-release-after",
+    "publish",
   ];
   const index = await td.replaceEsm("../index.js");
   process.argv = argv;
@@ -111,6 +113,8 @@ test.serial("Pass options to semantic-release API", async (t) => {
       debug: true,
       _: [],
       $0: "",
+      "tag-release-after": "publish",
+      tagReleaseAfter: "publish",
     })
   );
 

--- a/test/get-config.test.js
+++ b/test/get-config.test.js
@@ -6,6 +6,7 @@ import { omit } from "lodash-es";
 import * as td from "testdouble";
 import yaml from "js-yaml";
 import { gitAddConfig, gitCommits, gitRepo, gitShallowClone, gitTagVersion } from "./helpers/git-utils.js";
+import { PREPARE_LIFECYCLE, PUBLISH_LIFECYCLE } from "../lib/definitions/constants.js";
 
 const { outputJson, writeFile } = fsExtra;
 const pluginsConfig = { foo: "bar", baz: "qux" };
@@ -118,6 +119,7 @@ test.serial("Read options from package.json", async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Verify the plugins module is called with the plugin options from package.json
@@ -139,6 +141,7 @@ test.serial("Read options from .releaserc.yml", async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create package.json in repository root
@@ -160,6 +163,7 @@ test.serial("Read options from .releaserc.json", async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create package.json in repository root
@@ -181,6 +185,7 @@ test.serial("Read options from .releaserc.js", async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create package.json in repository root
@@ -202,6 +207,7 @@ test.serial("Read options from .releaserc.cjs", async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create .releaserc.cjs in repository root
@@ -223,6 +229,7 @@ test.serial("Read options from release.config.js", async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PREPARE_LIFECYCLE,
     plugins: false,
   };
   // Create package.json in repository root
@@ -244,6 +251,7 @@ test.serial("Read options from release.config.cjs", async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Verify the plugins module is called with the plugin options from release.config.cjs
@@ -266,12 +274,14 @@ test.serial("Prioritise CLI/API parameters over file configuration and git repo"
   const pkgOptions = {
     analyzeCommits: { path: "analyzeCommits", param: "analyzeCommits_pkg" },
     branches: ["branch_pkg"],
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
   };
   const options = {
     analyzeCommits: { path: "analyzeCommits", param: "analyzeCommits_cli" },
     branches: ["branch_cli"],
     repositoryUrl: "http://cli-url.com/owner/package",
     tagFormat: `cli\${version}`,
+    tagReleaseAfter: PREPARE_LIFECYCLE,
     plugins: false,
   };
   // Verify the plugins module is called with the plugin options from CLI/API
@@ -296,6 +306,7 @@ test.serial('Read configuration from file path in "extends"', async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: ["plugin-1", ["plugin-2", { plugin2Opt: "value" }]],
   };
   // Create package.json and shareable.json in repository root
@@ -330,6 +341,7 @@ test.serial('Read configuration from module path in "extends"', async (t) => {
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create package.json and shareable.json in repository root
@@ -362,6 +374,7 @@ test.serial('Read configuration from an array of paths in "extends"', async (t) 
     analyzeCommits: { path: "analyzeCommits2", param: "analyzeCommits_param2" },
     branches: ["test_branch"],
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create package.json and shareable.json in repository root
@@ -405,6 +418,7 @@ test.serial('Read configuration from an array of CJS files in "extends"', async 
     analyzeCommits: { path: "analyzeCommits2", param: "analyzeCommits_param2" },
     branches: ["test_branch"],
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create package.json and shareable.json in repository root
@@ -448,6 +462,7 @@ test.serial('Read configuration from an array of ESM files in "extends"', async 
     analyzeCommits: { path: "analyzeCommits2", param: "analyzeCommits_param2" },
     branches: ["test_branch"],
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
     plugins: false,
   };
   // Create package.json and shareable.json in repository root
@@ -483,6 +498,7 @@ test.serial('Prioritize configuration from config file over "extends"', async (t
     branches: ["test_pkg"],
     generateNotes: "generateNotes",
     publish: [{ path: "publishPkg", param: "publishPkg_param" }],
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
   };
   const options1 = {
     analyzeCommits: "analyzeCommits",
@@ -491,6 +507,7 @@ test.serial('Prioritize configuration from config file over "extends"', async (t
     branches: ["test_branch"],
     repositoryUrl: "https://host.null/owner/module.git",
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PREPARE_LIFECYCLE,
     plugins: false,
   };
   // Create package.json and shareable.json in repository root
@@ -523,12 +540,14 @@ test.serial('Prioritize configuration from cli/API options over "extends"', asyn
     branches: ["branch_opts"],
     publish: [{ path: "publishOpts", param: "publishOpts_param" }],
     repositoryUrl: "https://host.null/owner/module.git",
+    tagReleaseAfter: PUBLISH_LIFECYCLE,
   };
   const pkgOptions = {
     extends: "./shareable1.json",
     branches: ["branch_pkg"],
     generateNotes: "generateNotes",
     publish: [{ path: "publishPkg", param: "publishPkg_param" }],
+    tagReleaseAfter: PREPARE_LIFECYCLE,
   };
   const options1 = {
     analyzeCommits: "analyzeCommits1",
@@ -577,6 +596,7 @@ test.serial('Allow to unset properties defined in shareable config with "null"',
     generateNotes: "generateNotes",
     analyzeCommits: { path: "analyzeCommits", param: "analyzeCommits_param" },
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PREPARE_LIFECYCLE,
     plugins: ["test-plugin"],
   };
   // Create package.json and shareable.json in repository root
@@ -627,6 +647,7 @@ test.serial('Allow to unset properties defined in shareable config with "undefin
     generateNotes: "generateNotes",
     analyzeCommits: { path: "analyzeCommits", param: "analyzeCommits_param" },
     tagFormat: `v\${version}`,
+    tagReleaseAfter: PREPARE_LIFECYCLE,
     plugins: false,
   };
   // Create release.config.js and shareable.json in repository root

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -258,10 +258,10 @@ export async function gitRemoteTagHead(repositoryUrl, tagName, execaOptions) {
  * @param {String} gitHead The commit sha for which to retrieve the associated tag.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
- * @return {String} The tag associatedwith the sha in parameter or `null`.
+ * @return {String} The tag associatedwith the sha in parameter or ''.
  */
 export async function gitCommitTag(gitHead, execaOptions) {
-  return (await execa("git", ["describe", "--tags", "--exact-match", gitHead], execaOptions)).stdout;
+  return (await execa("git", ["tag", "--contains", gitHead], execaOptions)).stdout;
 }
 
 /**


### PR DESCRIPTION
# Summary

This allows the configurers of semantic-release to determine after which lifecycle, the tag for a release should get added.

Addresses: https://github.com/semantic-release/semantic-release/issues/3144

* introduces a '--tag-release-after' and 'tagReleaseAfter' config parameter.
* Defaults to the legacy 'prepare' stage
* Provides documentation with a suggestion to not use prepare for the sake of replay but with an acknowledgement that some plugins may not play nice
* Creates a new Error State for verification
* Adds some constants for lifecycle methods