### PR TITLE
Draft: Add config to provide git push options

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,8 +127,8 @@ async function run(context, plugins) {
           cwd,
           env,
         });
-        await push(options.repositoryUrl, { cwd, env });
-        await pushNotes(options.repositoryUrl, nextRelease.gitTag, {
+        await push(options.repositoryUrl, options.gitPushOptions, { cwd, env });
+        await pushNotes(options.repositoryUrl, options.gitPushOptions, nextRelease.gitTag, {
           cwd,
           env,
         });
@@ -207,8 +207,8 @@ async function run(context, plugins) {
     // Create the tag before calling the publish plugins as some require the tag to exists
     await tag(nextRelease.gitTag, nextRelease.gitHead, { cwd, env });
     await addNote({ channels: [nextRelease.channel] }, nextRelease.gitTag, { cwd, env });
-    await push(options.repositoryUrl, { cwd, env });
-    await pushNotes(options.repositoryUrl, nextRelease.gitTag, { cwd, env });
+    await push(options.repositoryUrl, options.gitPushOptions, { cwd, env });
+    await pushNotes(options.repositoryUrl, options.gitPushOptions, nextRelease.gitTag, { cwd, env });
     logger.success(`Created tag ${nextRelease.gitTag}`);
   }
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -77,6 +77,7 @@ export default async (context, cliOptions) => {
       "@semantic-release/npm",
       "@semantic-release/github",
     ],
+    gitPushOptions: [],
     // Remove `null` and `undefined` options, so they can be replaced with default ones
     ...pickBy(options, (option) => !isNil(option)),
     ...(options.branches ? { branches: castArray(options.branches) } : {}),

--- a/lib/git.js
+++ b/lib/git.js
@@ -233,8 +233,8 @@ export async function tag(tagName, ref, execaOptions) {
  */
 export async function push(repositoryUrl, gitPushOptions, execaOptions) {
   let localGitPushOptions = [];
-  if (gitPushOptions.length) {
-    localGitPushOptions = ["-o", ...gitPushOptions];
+  for (let gitPushOption of gitPushOptions) {
+    localGitPushOptions.push('-o', gitPushOption);
   }
   await execa("git", ["push", "--tags", ...localGitPushOptions, repositoryUrl], execaOptions);
 }
@@ -247,10 +247,10 @@ export async function push(repositoryUrl, gitPushOptions, execaOptions) {
  *
  * @throws {Error} if the push failed.
  */
-export async function pushNotes(repositoryUrl, ref, execaOptions) {
+export async function pushNotes(repositoryUrl, gitPushOptions, ref, execaOptions) {
   let localGitPushOptions = [];
-  if (gitPushOptions.length) {
-    localGitPushOptions = ["-o", ...gitPushOptions];
+  for (let gitPushOption of gitPushOptions) {
+    localGitPushOptions.push('-o', gitPushOption);
   }
   await execa("git", ["push", ...localGitPushOptions, repositoryUrl, `refs/notes/${GIT_NOTE_REF}-${ref}`], execaOptions);
 }

--- a/lib/git.js
+++ b/lib/git.js
@@ -231,8 +231,12 @@ export async function tag(tagName, ref, execaOptions) {
  *
  * @throws {Error} if the push failed.
  */
-export async function push(repositoryUrl, execaOptions) {
-  await execa("git", ["push", "--tags", repositoryUrl], execaOptions);
+export async function push(repositoryUrl, gitPushOptions, execaOptions) {
+  let localGitPushOptions = [];
+  if (gitPushOptions.length) {
+    localGitPushOptions = ["-o", ...gitPushOptions];
+  }
+  await execa("git", ["push", "--tags", ...localGitPushOptions, repositoryUrl], execaOptions);
 }
 
 /**
@@ -244,7 +248,11 @@ export async function push(repositoryUrl, execaOptions) {
  * @throws {Error} if the push failed.
  */
 export async function pushNotes(repositoryUrl, ref, execaOptions) {
-  await execa("git", ["push", repositoryUrl, `refs/notes/${GIT_NOTE_REF}-${ref}`], execaOptions);
+  let localGitPushOptions = [];
+  if (gitPushOptions.length) {
+    localGitPushOptions = ["-o", ...gitPushOptions];
+  }
+  await execa("git", ["push", ...localGitPushOptions, repositoryUrl, `refs/notes/${GIT_NOTE_REF}-${ref}`], execaOptions);
 }
 
 /**


### PR DESCRIPTION
I've created this change for myself (currently in testing) and created the PR to see if you believe it would be useful.

The rational behind this:
 * I use Gitlab primarily but replicate to Github.
 * Some projects use both Gitlab CI/CD and Github actions (mainly for testing/tagging etc. in Gitlab and then producing artifacts in Github).

When I merge into Gitlab, semantic release runs on main and performs the release. The release commit, by default, uses `[skip ci]`, which is appropriate for Gitlab. Unfortunately, when the release commit is replicated to Github, it _also_ respects this and skips Github actions.

This change means that I change the commit message, removing [skip ci] and use a git push option `ci.skip` (see https://docs.gitlab.com/ee/user/project/push_options.html), which will only skip the CI/CD pipeline in Gitlab.

I'm creating this PR to get feedback if it's a feature that you believe would be useful and, if so, I can tidy it up after testing, add tests etc. ready for proper review :)

Many thanks
Matt