### PR TITLE
feat: Add support for a single config file in a monorepo

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -36,6 +36,11 @@ Usage:
     .option("fail", { ...stringList, group: "Plugins" })
     .option("debug", { describe: "Output debugging information", type: "boolean", group: "Options" })
     .option("d", { alias: "dry-run", describe: "Skip publishing", type: "boolean", group: "Options" })
+    .option("stopDir", {
+      describe: "Sets the stop path for recursive search of release config files",
+      type: "string",
+      group: "Options",
+    })
     .option("h", { alias: "help", group: "Options" })
     .strict(false)
     .exitProcess(false);

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -157,6 +157,14 @@ Output debugging information. This can also be enabled by setting the `DEBUG` en
 
 **Note**: The `debug` is used only supported via CLI argument. To enable debug mode from the [JS API](../developer-guide/js-api.md#javascript-api) use `require('debug').enable('semantic-release:*')`.
 
+### stopDir
+
+Type: `string`<br>
+Default: `cwd`<br>
+CLI argument: `--stopDir`
+
+Sets the stop path for recursive search of release config files.
+
 ## Git environment variables
 
 | Variable              | Description                                                                                                                                                                                                                    | Default                              |

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -18,7 +18,8 @@ const CONFIG_NAME = "release";
 
 export default async (context, cliOptions) => {
   const { cwd, env } = context;
-  const { config, filepath } = (await cosmiconfig(CONFIG_NAME).search(cwd)) || {};
+  const { config, filepath } =
+    (await cosmiconfig(CONFIG_NAME, { stopDir: cliOptions.stopDir ?? cwd }).search(cwd)) || {};
 
   debug("load config from: %s", filepath);
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -18,8 +18,7 @@ const CONFIG_NAME = "release";
 
 export default async (context, cliOptions) => {
   const { cwd, env } = context;
-  const { config, filepath } =
-    (await cosmiconfig(CONFIG_NAME, { stopDir: cliOptions.stopDir ?? cwd }).search(cwd)) || {};
+  const { config, filepath } = (await cosmiconfig(CONFIG_NAME, { stopDir: cliOptions.stopDir }).search(cwd)) || {};
 
   debug("load config from: %s", filepath);
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -72,6 +72,8 @@ test.serial("Pass options to semantic-release API", async (t) => {
     "fail2",
     "--debug",
     "-d",
+    "--stopDir",
+    "/home/",
   ];
   const index = await td.replaceEsm("../index.js");
   process.argv = argv;
@@ -109,6 +111,7 @@ test.serial("Pass options to semantic-release API", async (t) => {
       success: ["success1", "success2"],
       fail: ["fail1", "fail2"],
       debug: true,
+      stopDir: "/home/",
       _: [],
       $0: "",
     })


### PR DESCRIPTION
# Issue

The new version of `cosmiconfig` defaults the `searchStrategy` to `none`, which breaks support for a single root config file for monorepos, when running semantic-release on individual packages, because it no longer recursively looks for the file on parent folders.

# Solution

`cosmiconfig` still allows for  a `stopDir` path to be set, wich will set the `searchStrategy` to `global` and allow for the config to be searched on parent folders, we just need a way to pass that through `semantic-release` cli first, so its then passed as an option to `cosmiconfig`