### PR TITLE
fix: trim repositoryUrl returned from `getAuthUrl`

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -27,7 +27,7 @@ function formatAuthUrl(protocol, repositoryUrl, gitCredentials) {
     auth: gitCredentials,
     host: `${hostname}${protocol === "ssh:" ? "" : port ? `:${port}` : ""}`,
     protocol: protocol && /http[^s]/.test(protocol) ? "http" : "https",
-  });
+  }).trim();
 }
 
 /**
@@ -120,5 +120,5 @@ export default async (context) => {
     }
   }
 
-  return repositoryUrl;
+  return repositoryUrl.trim();
 };

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -412,3 +412,17 @@ test("Do not add git credential to repositoryUrl if push is allowed", async (t) 
     repositoryUrl
   );
 });
+
+test("Return the url trimmed", async (t) => {
+  const { cwd } = await gitRepo();
+
+  t.is(
+    await getAuthUrl({
+      cwd,
+      env,
+      branch: { name: "master" },
+      options: { repositoryUrl: "https://host.null/owner/repo.git\n" },
+    }),
+    "https://host.null/owner/repo.git"
+  );
+});


### PR DESCRIPTION
If repository url is not trimmed by some reasons, it causes error like this.

```
[6:59:15 AM] [semantic-release] › ✘  An error occurred while running semantic-release: Error: Command failed with exit code 128: git ls-remote --heads https://x-access-token:[secure]@github.com/mj-studio-library/react-native-styled-system
warning: url contains a newline in its password component: https://x-access-token:[secure]@github.com/mj-studio-library/react-native-styled-system/
fatal: credential url cannot be parsed: https://x-access-token:[secure]@github.com/mj-studio-library/react-native-styled-system/
    at makeError (file:///home/runner/work/_actions/cycjimmy/semantic-release-action/v4/node_modules/semantic-release/node_modules/execa/lib/error.js:60:11)
    at handlePromise (file:///home/runner/work/_actions/cycjimmy/semantic-release-action/v4/node_modules/semantic-release/node_modules/execa/index.js:124:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getBranches (file:///home/runner/work/_actions/cycjimmy/semantic-release-action/v4/node_modules/semantic-release/lib/git.js:68:11)
    at async default (file:///home/runner/work/_actions/cycjimmy/semantic-release-action/v4/node_modules/semantic-release/lib/branches/expand.js:6:23)
    at async default (file:///home/runner/work/_actions/cycjimmy/semantic-release-action/v4/node_modules/semantic-release/lib/branches/index.js:14:26)
    at async run (file:///home/runner/work/_actions/cycjimmy/semantic-release-action/v4/node_modules/semantic-release/index.js:68:22)
    at async Module.default (file:///home/runner/work/_actions/cycjimmy/semantic-release-action/v4/node_modules/semantic-release/index.js:275:22)
    at async release (/home/runner/work/_actions/cycjimmy/semantic-release-action/v4/src/index.js:30:18) {
```

This is an issue that can be easily managed within this package itself.