### PR TITLE
docs: add community plugin semantic-release-pull-request-analyzer

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -198,3 +198,7 @@
   - `verifyConditions`: Verify the environment variable `HACKAGE_TOKEN`
   - `prepare`: Update the version of .cabal file and create the distribution package (.tar)
   - `publish`: Publish the release candidate to the specified repository in Hackage
+- [semantic-release-pull-request-analyzer](https://github.com/bobvanderlinden/semantic-release-pull-request-analyzer)
+  - `verifyConditions` Verify configuration options and existance of GitHub token.
+  - `analyzeCommits` Determine the type of release by analyzing merged GitHub pull requests and their labels.
+  - `generateNotes` Generates release notes using [GitHub release notes generator](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).


### PR DESCRIPTION
This plugin is for teams that like to avoid conventional commits, but do want to make use of the plugin ecosystem of semantic-release.

`semantic-release-pull-request-analyzer` replaces `analyzeCommits` and `generateNotes`, so that it can find the release-type based on merged pull request labels, instead of commit subjects.