### PR TITLE
Rename dependency 'read-pkg-up' -> 'read-package-up'

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -2,7 +2,7 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { castArray, isNil, isPlainObject, isString, pickBy } from "lodash-es";
-import { readPackageUp } from "read-pkg-up";
+import { readPackageUp } from "read-package-up";
 import { cosmiconfig } from "cosmiconfig";
 import importFrom from "import-from-esm";
 import debugConfig from "debug";

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "micromatch": "^4.0.2",
         "p-each-series": "^3.0.0",
         "p-reduce": "^3.0.0",
-        "read-pkg-up": "^11.0.0",
+        "read-package-up": "^11.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
         "semver-diff": "^4.0.0",
@@ -12669,6 +12669,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-package-up/node_modules/type-fest": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+      "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "micromatch": "^4.0.2",
     "p-each-series": "^3.0.0",
     "p-reduce": "^3.0.0",
-    "read-pkg-up": "^11.0.0",
+    "read-package-up": "^11.0.0",
     "resolve-from": "^5.0.0",
     "semver": "^7.3.2",
     "semver-diff": "^4.0.0",


### PR DESCRIPTION
read-pkg-up has been renamed into  read-package-up

https://github.com/sindresorhus/read-package-up/commit/1e22fad74d26bba3ea71fd34d2f9224cc5dd1b6b