### PR TITLE
docs(ci-configurations): update github token URL

### DIFF
--- a/docs/recipes/ci-configurations/github-actions.md
+++ b/docs/recipes/ci-configurations/github-actions.md
@@ -4,7 +4,7 @@
 
 The [Authentication](../../usage/ci-configuration.md#authentication) environment variables can be configured with [Secret Variables](https://docs.github.com/en/actions/reference/encrypted-secrets).
 
-In this example a publish type [`NPM_TOKEN`](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) is required to publish a package to the npm registry. GitHub Actions [automatically populate](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret) a [`GITHUB_TOKEN`](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) environment variable which can be used in Workflows.
+In this example a publish type [`NPM_TOKEN`](https://docs.npmjs.com/creating-and-viewing-authentication-tokens) is required to publish a package to the npm registry. GitHub Actions [automatically populate](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) a [`GITHUB_TOKEN`](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) environment variable which can be used in Workflows.
 
 ## npm provenance
 


### PR DESCRIPTION
Updated a URL for `GITHUB_TOKEN` documentation (which no longer describes how tokens are auto-generated for CI), and replaced it with another appropriate GitHub documentation URL.