### PR TITLE
docs(configuration): add micromatch note for branches configuration key

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -89,6 +89,8 @@ The branches on which releases should happen. By default **semantic-release** wi
 - pre-releases to the `beta` distribution channel from the branch `beta` if it exists
 - pre-releases to the `alpha` distribution channel from the branch `alpha` if it exists
 
+**Note**: Branches configuration key accepts [**micromatch**](https://github.com/micromatch/micromatch?tab=readme-ov-file#matching-features) globs.
+
 **Note**: If your repository does not have a release branch, then **semantic-release** will fail with an `ERELEASEBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `master` branch.
 
 **Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://docs.github.com/github/administering-a-repository/about-protected-branches).


### PR DESCRIPTION
**Context**

Following this [discussion](https://github.com/semantic-release/semantic-release/discussions/2439) last year, documentation note hasn't been added.