### PR TITLE
fix: Remove multiple SemVer incompatibilities in tagFormat

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -115,7 +115,9 @@ CLI arguments: `-t`, `--tag-format`
 
 The [Git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) format used by **semantic-release** to identify releases. The tag name is generated with [Lodash template](https://lodash.com/docs#template) and will be compiled with the `version` variable.
 
-**Note**: The `tagFormat` must contain the `version` variable exactly once and compile to a [valid Git reference](https://git-scm.com/docs/git-check-ref-format#_description).
+**Note 1**: The `tagFormat` must contain the `version` variable exactly once and compile to a [valid Git reference](https://git-scm.com/docs/git-check-ref-format#_description).
+
+**Note 2**: The `tagFormat` must compile to a [valid SemVer reference](https://semver.org). The only exception to this is the ability to have any prefix prceeding the `${version}` variable. So, `pref-1.0.0` is a valid tag even though it is not strictly valid according to SemVer. However, `pref-1.0.0a` is not a valid tag.
 
 ### plugins
 

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -8,26 +8,44 @@ const debug = debugTags("semantic-release:get-tags");
 
 export default async ({ cwd, env, options: { tagFormat } }, branches) => {
   // Generate a regex to parse tags formatted with `tagFormat`
-  // by replacing the `version` variable in the template by `([^\+]+)`.
+  // by replacing the `version` variable in the template by `(.+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
-  // It is important to read version up to the possible '+' sign to support https://semver.org/#spec-item-10
-  const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "([^+]+)")}`;
+  var temp = template(tagFormat)({ version: " " })
+  const prefix = temp.split(" ")[0];
+  temp = temp.replace(prefix, "");
 
+  const tagRegexp = `^${escapeRegExp(temp).replace(" ", "(.+)")}`;
   return pReduce(
     branches,
     async (branches, branch) => {
       const branchTags = await pReduce(
         await getTags(branch.name, { cwd, env }),
         async (branchTags, tag) => {
-          const [, version] = tag.match(tagRegexp) || [];
-          return version && semver.valid(semver.clean(version))
-            ? [...branchTags, { gitTag: tag, version, channels: (await getNote(tag, { cwd, env })).channels || [null] }]
-            : branchTags;
+          if (tag.startsWith(prefix)) {
+            // This tag's prefix is valid, continue to analyse
+            var [, version] = tag.replace(prefix, "").match(tagRegexp) || [];
+            if (version) {
+              version = semver.valid(version);
+            }
+            if (version) {
+              return [...branchTags, { gitTag: tag, version, channels: (await getNote(tag, { cwd, env })).channels || [null] }]
+            }
+          }
+          return branchTags
         },
         []
       );
-
+      
+      branchTags.sort((a, b) => {
+        if (semver.lt(a.gitTag, b.gitTag)) {
+          return -1;
+        }
+        else if (semver.gt(a.gitTag, b.gitTag)) {
+          return 1;
+        }
+        return a.gitTag < b.gitTag;
+      })
       debug("found tags for branch %s: %o", branch.name, branchTags);
       return [...branches, { ...branch, tags: branchTags }];
     },

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -11,7 +11,7 @@ export default async ({ cwd, env, options: { tagFormat } }, branches) => {
   // by replacing the `version` variable in the template by `(.+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
-  var temp = template(tagFormat)({ version: " " })
+  var temp = template(tagFormat)({ version: " " });
   const prefix = temp.split(" ")[0];
   temp = temp.replace(prefix, "");
   if (temp.indexOf(" +") != -1) {
@@ -33,23 +33,25 @@ export default async ({ cwd, env, options: { tagFormat } }, branches) => {
               version = semver.valid(version);
             }
             if (version) {
-              return [...branchTags, { gitTag: tag, version, channels: (await getNote(tag, { cwd, env })).channels || [null] }]
+              return [
+                ...branchTags,
+                { gitTag: tag, version, channels: (await getNote(tag, { cwd, env })).channels || [null] },
+              ];
             }
           }
-          return branchTags
+          return branchTags;
         },
         []
       );
-      
+
       branchTags.sort((a, b) => {
         if (semver.lt(a.gitTag, b.gitTag)) {
           return -1;
-        }
-        else if (semver.gt(a.gitTag, b.gitTag)) {
+        } else if (semver.gt(a.gitTag, b.gitTag)) {
           return 1;
         }
         return a.gitTag < b.gitTag;
-      })
+      });
       debug("found tags for branch %s: %o", branch.name, branchTags);
       return [...branches, { ...branch, tags: branchTags }];
     },

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -8,10 +8,11 @@ const debug = debugTags("semantic-release:get-tags");
 
 export default async ({ cwd, env, options: { tagFormat } }, branches) => {
   // Generate a regex to parse tags formatted with `tagFormat`
-  // by replacing the `version` variable in the template by `(.+)`.
+  // by replacing the `version` variable in the template by `([^\+]+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
-  const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "(.+)")}`;
+  // It is important to read version up to the possible '+' sign to support https://semver.org/#spec-item-10
+  const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "([^+]+)")}`;
 
   return pReduce(
     branches,

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -14,6 +14,10 @@ export default async ({ cwd, env, options: { tagFormat } }, branches) => {
   var temp = template(tagFormat)({ version: " " })
   const prefix = temp.split(" ")[0];
   temp = temp.replace(prefix, "");
+  if (temp.indexOf(" +") != -1) {
+    // tagFormat contains build metadata.
+    temp = temp.split(" +")[0] + " ";
+  }
 
   const tagRegexp = `^${escapeRegExp(temp).replace(" ", "(.+)")}`;
   return pReduce(

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -62,6 +62,17 @@ Your configuration for the \`tagFormat\` option is \`${stringify(tagFormat)}\`.`
   };
 }
 
+export function ENONSEMVERTAGFORMAT({ options: { tagFormat } }) {
+  return {
+    message: "`tagFormat` option is not SemVer compliant",
+    details: `The [tagFormat](${linkify(
+      "docs/usage/configuration.md#tagformat"
+    )}) must compile to a [valid SemVer reference](https://semver.org).
+
+Your configuration for the \`tagFormat\` option is \`${stringify(tagFormat)}\`.`,
+  };
+}
+
 export function ETAGNOVERSION({ options: { tagFormat } }) {
   return {
     message: "Invalid `tagFormat` option.",

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -2,6 +2,7 @@ import { isPlainObject, isString, template } from "lodash-es";
 import AggregateError from "aggregate-error";
 import { isGitRepo, verifyTagName } from "./git.js";
 import getError from "./get-error.js";
+import semver from "semver";
 
 export default async (context) => {
   const {
@@ -27,6 +28,15 @@ export default async (context) => {
   // The space is used as it's an invalid tag character, so it's guaranteed to no be present in the `tagFormat`.
   if ((template(tagFormat)({ version: " " }).match(/ /g) || []).length !== 1) {
     errors.push(getError("ETAGNOVERSION", context));
+  }
+
+  // Verify that the tag is a valid semver tag
+  var temp = template(tagFormat)({ version: " " });
+  const prefix = temp.split(" ")[0];
+  temp = temp.replace(prefix, "");
+  temp = temp.replace(" ", "${version}");
+  if (!semver.valid(template(temp)({ version: "0.0.0" }))) {
+    errors.push(getError("ENONSEMVERTAGFORMAT", context));
   }
 
   branches.forEach((branch) => {

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -34,6 +34,28 @@ test("Get the valid tags", async (t) => {
   ]);
 });
 
+test("Check if adding plus symbol not immediately after version works", async (t) => {
+  const { cwd } = await gitRepo();
+  const commits = await gitCommits(["First"], { cwd });
+  await gitTagVersion("v1.0.0K+abcd", undefined, { cwd });
+  commits.push(...(await gitCommits(["Second"], { cwd })));
+  await gitTagVersion("v2.0.0K+def", undefined, { cwd });
+  commits.push(...(await gitCommits(["Third"], { cwd })));
+  await gitTagVersion("v3.0.0K+abcd", undefined, { cwd });
+
+  const result = await getTags({ cwd, options: { tagFormat: `v\${version}K+abcd` } }, [{ name: "master" }]);
+
+  t.deepEqual(result, [
+    {
+      name: "master",
+      tags: [
+        { gitTag: "v1.0.0K+abcd", version: "1.0.0", channels: [null] },
+        { gitTag: "v3.0.0K+abcd", version: "3.0.0", channels: [null] }
+      ],
+    },
+  ]);
+});
+
 test("Get the valid tags from multiple branches", async (t) => {
   const { cwd } = await gitRepo();
   await gitCommits(["First"], { cwd });

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -1,22 +1,68 @@
 import test from "ava";
 import getTags from "../../lib/branches/get-tags.js";
-import { gitAddNote, gitCheckout, gitCommits, gitRepo, gitTagVersion } from "../helpers/git-utils.js";
+import { gitAddNote, gitCheckout, gitCommitAndTag, gitCommits, gitRepo, gitTagVersion } from "../helpers/git-utils.js";
 
 test("Get the valid tags", async (t) => {
   const { cwd } = await gitRepo();
-  const commits = await gitCommits(["First"], { cwd });
-  await gitTagVersion("foo", undefined, { cwd });
-  await gitTagVersion("v2.0.0", undefined, { cwd });
-  commits.push(...(await gitCommits(["Second"], { cwd })));
-  await gitTagVersion("v1.0.0", undefined, { cwd });
-  commits.push(...(await gitCommits(["Third"], { cwd })));
-  await gitTagVersion("v3.0", undefined, { cwd });
-  commits.push(...(await gitCommits(["Fourth"], { cwd })));
-  await gitTagVersion("v3.0.0-beta.1", undefined, { cwd });
-  commits.push(...(await gitCommits(["Fifth"], { cwd })));
-  await gitTagVersion("v2.0.0+abcd", undefined, { cwd });
-  commits.push(...(await gitCommits(["Sixth"], { cwd })));
-  await gitTagVersion("v3.0.0-beta.1+abcd", undefined, { cwd });
+  await gitCommitAndTag("Valid", "v0.0.4", { cwd });
+  await gitCommitAndTag("Valid", "v1.2.3", { cwd });
+  await gitCommitAndTag("Valid", "v10.20.30", { cwd });
+  await gitCommitAndTag("Valid", "v1.1.2-prerelease+meta", { cwd });
+  await gitCommitAndTag("Valid", "v1.1.2+meta", { cwd });
+  await gitCommitAndTag("Valid", "v1.1.2+meta-valid", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha+beta", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-beta", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha.beta", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha.beta.1", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha.1", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha0.valid", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha.0valid", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-rc.1+build.1", { cwd });
+  await gitCommitAndTag("Valid", "v2.0.0-rc.1+build.123", { cwd });
+  await gitCommitAndTag("Valid", "v1.2.3-beta", { cwd });
+  await gitCommitAndTag("Valid", "v10.2.3-DEV-SNAPSHOT", { cwd });
+  await gitCommitAndTag("Valid", "v1.2.3-SNAPSHOT-123", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0", { cwd });
+  await gitCommitAndTag("Valid", "v2.0.0", { cwd });
+  await gitCommitAndTag("Valid", "v1.1.7", { cwd });
+  await gitCommitAndTag("Valid", "v2.0.0+build.1848", { cwd });
+  await gitCommitAndTag("Valid", "v2.0.1-alpha.1227", { cwd });
+  await gitCommitAndTag("Valid", "v1.2.3----RC-SNAPSHOT.12.9.1--.12+788", { cwd });
+  await gitCommitAndTag("Valid", "v1.2.3----R-S.12.9.1--.12+meta", { cwd });
+  await gitCommitAndTag("Valid", "v1.2.3----RC-SNAPSHOT.12.9.1--.12", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0+0.build.1-rc.10000aaa-kk-0.1", { cwd });
+  await gitCommitAndTag("Valid", "v99999.99999.999999", { cwd });
+  await gitCommitAndTag("Valid", "v1.0.0-0A.is.legal", { cwd });
+
+  await gitCommitAndTag("Invalid", "v1", { cwd });
+  await gitCommitAndTag("Invalid", "v1.2", { cwd });
+  await gitCommitAndTag("Invalid", "v1.2.3-0123", { cwd });
+  await gitCommitAndTag("Invalid", "v1.2.3-0123.0123", { cwd });
+  await gitCommitAndTag("Invalid", "v1.1.2+.123", { cwd });
+  await gitCommitAndTag("Invalid", "v+invalid", { cwd });
+  await gitCommitAndTag("Invalid", "v-invalid", { cwd });
+  await gitCommitAndTag("Invalid", "v-invalid+invalid", { cwd });
+  await gitCommitAndTag("Invalid", "v-invalid.01", { cwd });
+  await gitCommitAndTag("Invalid", "valpha", { cwd });
+  await gitCommitAndTag("Invalid", "valpha.beta", { cwd });
+  await gitCommitAndTag("Invalid", "valpha.beta.1", { cwd });
+  await gitCommitAndTag("Invalid", "valpha.1", { cwd });
+  await gitCommitAndTag("Invalid", "valpha+beta", { cwd });
+  await gitCommitAndTag("Invalid", "valpha_beta", { cwd });
+  await gitCommitAndTag("Invalid", "vbeta", { cwd });
+  await gitCommitAndTag("Invalid", "v1.0.0-alpha_beta", { cwd });
+  await gitCommitAndTag("Invalid", "v01.1.1", { cwd });
+  await gitCommitAndTag("Invalid", "v1.01.1", { cwd });
+  await gitCommitAndTag("Invalid", "v1.1.01", { cwd });
+  await gitCommitAndTag("Invalid", "v1.2.3.DEV", { cwd });
+  await gitCommitAndTag("Invalid", "v1.2-SNAPSHOT", { cwd });
+  await gitCommitAndTag("Invalid", "v1.2-RC-SNAPSHOT", { cwd });
+  await gitCommitAndTag("Invalid", "v-1.0.3-gamma+b7718", { cwd });
+  await gitCommitAndTag("Invalid", "v+justmeta", { cwd });
+  await gitCommitAndTag("Invalid", "v9.8.7+meta+meta", { cwd });
+  await gitCommitAndTag("Invalid", "v9.8.7-whatever+meta+meta", { cwd });
 
   const result = await getTags({ cwd, options: { tagFormat: `v\${version}` } }, [{ name: "master" }]);
 
@@ -24,33 +70,37 @@ test("Get the valid tags", async (t) => {
     {
       name: "master",
       tags: [
+        { gitTag: "v0.0.4", version: "0.0.4", channels: [null] },
+        { gitTag: "v1.0.0-0A.is.legal", version: "1.0.0-0A.is.legal", channels: [null] },
+        { gitTag: "v1.0.0-alpha", version: "1.0.0-alpha", channels: [null] },
+        { gitTag: "v1.0.0-alpha+beta", version: "1.0.0-alpha", channels: [null] },
+        { gitTag: "v1.0.0-alpha.1", version: "1.0.0-alpha.1", channels: [null] },
+        { gitTag: "v1.0.0-alpha.0valid", version: "1.0.0-alpha.0valid", channels: [null] },
+        { gitTag: "v1.0.0-alpha.beta", version: "1.0.0-alpha.beta", channels: [null] },
+        { gitTag: "v1.0.0-alpha.beta.1", version: "1.0.0-alpha.beta.1", channels: [null] },
+        { gitTag: "v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay", version: "1.0.0-alpha-a.b-c-somethinglong", channels: [null] },
+        { gitTag: "v1.0.0-alpha0.valid", version: "1.0.0-alpha0.valid", channels: [null] },
+        { gitTag: "v1.0.0-beta", version: "1.0.0-beta", channels: [null] },
+        { gitTag: "v1.0.0-rc.1+build.1", version: "1.0.0-rc.1", channels: [null] },
         { gitTag: "v1.0.0", version: "1.0.0", channels: [null] },
+        { gitTag: "v1.0.0+0.build.1-rc.10000aaa-kk-0.1", version: "1.0.0", channels: [null] },
+        { gitTag: "v1.1.2-prerelease+meta", version: "1.1.2-prerelease", channels: [null] },
+        { gitTag: "v1.1.2+meta", version: "1.1.2", channels: [null] },
+        { gitTag: "v1.1.2+meta-valid", version: "1.1.2", channels: [null] },
+        { gitTag: "v1.1.7", version: "1.1.7", channels: [null] },
+        { gitTag: "v1.2.3----R-S.12.9.1--.12+meta", version: "1.2.3----R-S.12.9.1--.12", channels: [null] },
+        { gitTag: "v1.2.3----RC-SNAPSHOT.12.9.1--.12", version: "1.2.3----RC-SNAPSHOT.12.9.1--.12", channels: [null] },
+        { gitTag: "v1.2.3----RC-SNAPSHOT.12.9.1--.12+788", version: "1.2.3----RC-SNAPSHOT.12.9.1--.12", channels: [null] },
+        { gitTag: "v1.2.3-SNAPSHOT-123", version: "1.2.3-SNAPSHOT-123", channels: [null] },
+        { gitTag: "v1.2.3-beta", version: "1.2.3-beta", channels: [null] },
+        { gitTag: "v1.2.3", version: "1.2.3", channels: [null] },
+        { gitTag: "v2.0.0-rc.1+build.123", version: "2.0.0-rc.1", channels: [null] },
         { gitTag: "v2.0.0", version: "2.0.0", channels: [null] },
-        { gitTag: "v2.0.0+abcd", version: "2.0.0", channels: [null] },
-        { gitTag: "v3.0.0-beta.1", version: "3.0.0-beta.1", channels: [null] },
-        { gitTag: "v3.0.0-beta.1+abcd", version: "3.0.0-beta.1", channels: [null] },
-      ],
-    },
-  ]);
-});
-
-test("Check if adding plus symbol not immediately after version works", async (t) => {
-  const { cwd } = await gitRepo();
-  const commits = await gitCommits(["First"], { cwd });
-  await gitTagVersion("v1.0.0K+abcd", undefined, { cwd });
-  commits.push(...(await gitCommits(["Second"], { cwd })));
-  await gitTagVersion("v2.0.0K+def", undefined, { cwd });
-  commits.push(...(await gitCommits(["Third"], { cwd })));
-  await gitTagVersion("v3.0.0K+abcd", undefined, { cwd });
-
-  const result = await getTags({ cwd, options: { tagFormat: `v\${version}K+abcd` } }, [{ name: "master" }]);
-
-  t.deepEqual(result, [
-    {
-      name: "master",
-      tags: [
-        { gitTag: "v1.0.0K+abcd", version: "1.0.0", channels: [null] },
-        { gitTag: "v3.0.0K+abcd", version: "3.0.0", channels: [null] }
+        { gitTag: "v2.0.0+build.1848", version: "2.0.0", channels: [null] },
+        { gitTag: "v2.0.1-alpha.1227", version: "2.0.1-alpha.1227", channels: [null] },
+        { gitTag: "v10.2.3-DEV-SNAPSHOT", version: "10.2.3-DEV-SNAPSHOT", channels: [null] },
+        { gitTag: "v10.20.30", version: "10.20.30", channels: [null] },
+        { gitTag: "v99999.99999.999999", version: "99999.99999.999999", channels: [null] }
       ],
     },
   ]);

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -78,7 +78,11 @@ test("Get the valid tags", async (t) => {
         { gitTag: "v1.0.0-alpha.0valid", version: "1.0.0-alpha.0valid", channels: [null] },
         { gitTag: "v1.0.0-alpha.beta", version: "1.0.0-alpha.beta", channels: [null] },
         { gitTag: "v1.0.0-alpha.beta.1", version: "1.0.0-alpha.beta.1", channels: [null] },
-        { gitTag: "v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay", version: "1.0.0-alpha-a.b-c-somethinglong", channels: [null] },
+        {
+          gitTag: "v1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",
+          version: "1.0.0-alpha-a.b-c-somethinglong",
+          channels: [null],
+        },
         { gitTag: "v1.0.0-alpha0.valid", version: "1.0.0-alpha0.valid", channels: [null] },
         { gitTag: "v1.0.0-beta", version: "1.0.0-beta", channels: [null] },
         { gitTag: "v1.0.0-rc.1+build.1", version: "1.0.0-rc.1", channels: [null] },
@@ -90,7 +94,11 @@ test("Get the valid tags", async (t) => {
         { gitTag: "v1.1.7", version: "1.1.7", channels: [null] },
         { gitTag: "v1.2.3----R-S.12.9.1--.12+meta", version: "1.2.3----R-S.12.9.1--.12", channels: [null] },
         { gitTag: "v1.2.3----RC-SNAPSHOT.12.9.1--.12", version: "1.2.3----RC-SNAPSHOT.12.9.1--.12", channels: [null] },
-        { gitTag: "v1.2.3----RC-SNAPSHOT.12.9.1--.12+788", version: "1.2.3----RC-SNAPSHOT.12.9.1--.12", channels: [null] },
+        {
+          gitTag: "v1.2.3----RC-SNAPSHOT.12.9.1--.12+788",
+          version: "1.2.3----RC-SNAPSHOT.12.9.1--.12",
+          channels: [null],
+        },
         { gitTag: "v1.2.3-SNAPSHOT-123", version: "1.2.3-SNAPSHOT-123", channels: [null] },
         { gitTag: "v1.2.3-beta", version: "1.2.3-beta", channels: [null] },
         { gitTag: "v1.2.3", version: "1.2.3", channels: [null] },
@@ -100,10 +108,10 @@ test("Get the valid tags", async (t) => {
         { gitTag: "v2.0.1-alpha.1227", version: "2.0.1-alpha.1227", channels: [null] },
         { gitTag: "v10.2.3-DEV-SNAPSHOT", version: "10.2.3-DEV-SNAPSHOT", channels: [null] },
         { gitTag: "v10.20.30", version: "10.20.30", channels: [null] },
-        { gitTag: "v99999.99999.999999", version: "99999.99999.999999", channels: [null] }
-      ]
-    }
-  ]
+        { gitTag: "v99999.99999.999999", version: "99999.99999.999999", channels: [null] },
+      ],
+    },
+  ];
 
   t.deepEqual(result1, correct);
   t.deepEqual(result2, correct);

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -13,6 +13,10 @@ test("Get the valid tags", async (t) => {
   await gitTagVersion("v3.0", undefined, { cwd });
   commits.push(...(await gitCommits(["Fourth"], { cwd })));
   await gitTagVersion("v3.0.0-beta.1", undefined, { cwd });
+  commits.push(...(await gitCommits(["Fifth"], { cwd })));
+  await gitTagVersion("v2.0.0+abcd", undefined, { cwd });
+  commits.push(...(await gitCommits(["Sixth"], { cwd })));
+  await gitTagVersion("v3.0.0-beta.1+abcd", undefined, { cwd });
 
   const result = await getTags({ cwd, options: { tagFormat: `v\${version}` } }, [{ name: "master" }]);
 
@@ -22,7 +26,9 @@ test("Get the valid tags", async (t) => {
       tags: [
         { gitTag: "v1.0.0", version: "1.0.0", channels: [null] },
         { gitTag: "v2.0.0", version: "2.0.0", channels: [null] },
+        { gitTag: "v2.0.0+abcd", version: "2.0.0", channels: [null] },
         { gitTag: "v3.0.0-beta.1", version: "3.0.0-beta.1", channels: [null] },
+        { gitTag: "v3.0.0-beta.1+abcd", version: "3.0.0-beta.1", channels: [null] },
       ],
     },
   ]);
@@ -151,6 +157,20 @@ test('Get the highest valid tag corresponding to the "tagFormat"', async (t) => 
 
   await gitTagVersion("3.0.0-bar.2", undefined, { cwd });
   t.deepEqual(await getTags({ cwd, options: { tagFormat: `\${version}-bar.2` } }, [{ name: "master" }]), [
-    { name: "master", tags: [{ gitTag: "3.0.0-bar.2", version: "3.0.0", channels: [null] }] },
+    {
+      name: "master",
+      tags: [{ gitTag: "3.0.0-bar.2", version: "3.0.0", channels: [null] }],
+    },
+  ]);
+
+  await gitTagVersion("3.0.1-bar.2+buildnumber", undefined, { cwd });
+  t.deepEqual(await getTags({ cwd, options: { tagFormat: `\${version}-bar.2` } }, [{ name: "master" }]), [
+    {
+      name: "master",
+      tags: [
+        { gitTag: "3.0.0-bar.2", version: "3.0.0", channels: [null] },
+        { gitTag: "3.0.1-bar.2+buildnumber", version: "3.0.1", channels: [null] },
+      ],
+    },
   ]);
 });

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -64,9 +64,9 @@ test("Get the valid tags", async (t) => {
   await gitCommitAndTag("Invalid", "v9.8.7+meta+meta", { cwd });
   await gitCommitAndTag("Invalid", "v9.8.7-whatever+meta+meta", { cwd });
 
-  const result = await getTags({ cwd, options: { tagFormat: `v\${version}` } }, [{ name: "master" }]);
-
-  t.deepEqual(result, [
+  const result1 = await getTags({ cwd, options: { tagFormat: `v\${version}` } }, [{ name: "master" }]);
+  const result2 = await getTags({ cwd, options: { tagFormat: `v\${version}+1` } }, [{ name: "master" }]);
+  const correct = [
     {
       name: "master",
       tags: [
@@ -101,9 +101,12 @@ test("Get the valid tags", async (t) => {
         { gitTag: "v10.2.3-DEV-SNAPSHOT", version: "10.2.3-DEV-SNAPSHOT", channels: [null] },
         { gitTag: "v10.20.30", version: "10.20.30", channels: [null] },
         { gitTag: "v99999.99999.999999", version: "99999.99999.999999", channels: [null] }
-      ],
-    },
-  ]);
+      ]
+    }
+  ]
+
+  t.deepEqual(result1, correct);
+  t.deepEqual(result2, correct);
 });
 
 test("Get the valid tags from multiple branches", async (t) => {

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -85,7 +85,7 @@ export async function initBareRepo(repositoryUrl, branch = "master") {
  * @param {String} tagName The tag name to create.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  */
- export async function gitCommitAndTag(message, tagName, execaOptions) {
+export async function gitCommitAndTag(message, tagName, execaOptions) {
   await execa("git", ["commit", "-m", message, "--allow-empty", "--no-gpg-sign"], execaOptions);
   await gitTagVersion(tagName, undefined, execaOptions);
 }

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -79,6 +79,18 @@ export async function initBareRepo(repositoryUrl, branch = "master") {
 }
 
 /**
+ * Create commit on the current git repository and tags it.
+ *
+ * @param {String} message Commit message.
+ * @param {String} tagName The tag name to create.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ */
+ export async function gitCommitAndTag(message, tagName, execaOptions) {
+  await execa("git", ["commit", "-m", message, "--allow-empty", "--no-gpg-sign"], execaOptions);
+  await gitTagVersion(tagName, undefined, execaOptions);
+}
+
+/**
  * Create commits on the current git repository.
  *
  * @param {Array<string>} messages Commit messages.
@@ -157,7 +169,7 @@ export async function gitHead(execaOptions) {
 }
 
 /**
- * Create a tag on the head commit in the current git repository.
+ * Create a tag on the commit in the current git repository.
  *
  * @param {String} tagName The tag name to create.
  * @param {String} [sha] The commit on which to create the tag. If undefined the tag is created on the last commit.

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -22,9 +22,13 @@ test("Throw a AggregateError", async (t) => {
   t.truthy(errors[2].message);
   t.truthy(errors[2].details);
   t.is(errors[3].name, "SemanticReleaseError");
-  t.is(errors[3].code, "EINVALIDBRANCH");
+  t.is(errors[3].code, "ENONSEMVERTAGFORMAT");
   t.truthy(errors[3].message);
   t.truthy(errors[3].details);
+  t.is(errors[4].name, "SemanticReleaseError");
+  t.is(errors[4].code, "EINVALIDBRANCH");
+  t.truthy(errors[4].message);
+  t.truthy(errors[4].details);
 });
 
 test("Throw a SemanticReleaseError if does not run on a git repository", async (t) => {
@@ -59,6 +63,18 @@ test('Throw a SemanticReleaseError if the "tagFormat" does not contains the "ver
 
   t.is(errors[0].name, "SemanticReleaseError");
   t.is(errors[0].code, "ETAGNOVERSION");
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+});
+
+test('Throw a SemanticReleaseError if the "tagFormat" is not SemVer compliant', async (t) => {
+  const { cwd, repositoryUrl } = await gitRepo(true);
+  const options = { repositoryUrl, tagFormat: "pre${version}a", branches: [] };
+
+  const errors = [...(await t.throwsAsync(verify({ cwd, options }))).errors];
+
+  t.is(errors[0].name, "SemanticReleaseError");
+  t.is(errors[0].code, "ENONSEMVERTAGFORMAT");
   t.truthy(errors[0].message);
   t.truthy(errors[0].details);
 });


### PR DESCRIPTION
Current implementation is non SemVer compliant in many cases. For example:

- Doesn't allow passing build metadata #3308 
- Compiles `v${version}a` to a valid tag even though it is NOT a valid SemVer tag

This PR addresses this issue by making sure that when analysing tags, and when publishing them, SemVer compliance is mostly followed.

_Mostly_ because there is 1 notable exception – any prefix is allowed preceding the `${version}`. So, even though `pre-1.1.1` is not strictly SemVer compliant – it is allowed.

I would summarise this PR with the following table:

```
+-------------+------------------+-------------------+--------------+
|     tag     |    tagFormat     | version (Current) | version (PR) |
+-------------+------------------+-------------------+--------------+
| v1.1.0      | v${version}      | 1.1.0             | 1.1.0        |
| v1.1.0+abcd | v${version}      | -                 | 1.1.0        |
| v1.1.0+(3)  | v${version}      | -                 | -            |
| v1.1.0a+bcd | v${version}      | -                 | -            |
| v1.1.0a     | v${version}      | -                 | -            |
| ----------- | ---------------- | ----------------- | ------------ |
| v1.1.0      | v${version}+abcd | -                 | 1.1.0        |
| v1.1.0+abcd | v${version}+abcd | 1.1.0             | 1.1.0        |
| v1.1.0+(3)  | v${version}+abcd | -                 | -            |
| v1.1.0a+bcd | v${version}+abcd | -                 | -            |
| v1.1.0a     | v${version}+abcd | -                 | -            |
| ----------- | ---------------- | ----------------- | ------------ |
| v1.1.0      | v${version}+(3)  | -                 | error        |
| v1.1.0+abcd | v${version}+(3)  | -                 | error        |
| v1.1.0+(3)  | v${version}+(3)  | 1.1.0             | error        |
| v1.1.0a+bcd | v${version}+(3)  | -                 | error        |
| v1.1.0a     | v${version}+(3)  | -                 | error        |
| ----------- | ---------------- | ----------------- | ------------ |
| v1.1.0      | v${version}a     | -                 | error        |
| v1.1.0+abcd | v${version}a     | -                 | error        |
| v1.1.0+(3)  | v${version}a     | -                 | error        |
| v1.1.0a+bcd | v${version}a     | -                 | error        |
| v1.1.0a     | v${version}a     | 1.1.0             | error        |
+-------------+------------------+-------------------+--------------+
```

@travi please have a look. Apart from containing build meta – this PR does improve tag processing in various other ways making it more compatible with SemVer