### PR TITLE
ref: Remove usage of aggregate-error library

### DIFF
--- a/docs/developer-guide/plugin.md
+++ b/docs/developer-guide/plugin.md
@@ -54,8 +54,6 @@ module.exports = { verifyConditions };
 Then, in your `src` folder, create a file called `verify.js` and add the following
 
 ```javascript
-const AggregateError = require("aggregate-error");
-
 /**
  * A method to verify that the user has given us a slack webhook url to post to
  */

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ import * as marked from "marked";
 import envCi from "env-ci";
 import { hookStd } from "hook-std";
 import semver from "semver";
-import AggregateError from "aggregate-error";
 import hideSensitive from "./lib/hide-sensitive.js";
 import getConfig from "./lib/get-config.js";
 import verify from "./lib/verify.js";

--- a/lib/branches/index.js
+++ b/lib/branches/index.js
@@ -1,5 +1,4 @@
 import { isRegExp, isString } from "lodash-es";
-import AggregateError from "aggregate-error";
 import pEachSeries from "p-each-series";
 import * as DEFINITIONS from "../definitions/branches.js";
 import getError from "../get-error.js";

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,5 +1,4 @@
 import { castArray, identity, isNil, isPlainObject, isString, omit } from "lodash-es";
-import AggregateError from "aggregate-error";
 import getError from "../get-error.js";
 import PLUGINS_DEFINITIONS from "../definitions/plugins.js";
 import { loadPlugin, parseConfig, validatePlugin, validateStep } from "./utils.js";

--- a/lib/plugins/pipeline.js
+++ b/lib/plugins/pipeline.js
@@ -1,6 +1,5 @@
 import { identity } from "lodash-es";
 import pReduce from "p-reduce";
-import AggregateError from "aggregate-error";
 import { extractErrors } from "../utils.js";
 
 /**

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,5 +1,4 @@
 import { isPlainObject, isString, template } from "lodash-es";
-import AggregateError from "aggregate-error";
 import { isGitRepo, verifyTagName } from "./git.js";
 import getError from "./get-error.js";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@semantic-release/github": "^10.0.0",
         "@semantic-release/npm": "^12.0.0",
         "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
-        "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
         "debug": "^4.0.0",
         "env-ci": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@semantic-release/github": "^10.0.0",
     "@semantic-release/npm": "^12.0.0",
     "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
-    "aggregate-error": "^5.0.0",
     "cosmiconfig": "^9.0.0",
     "debug": "^4.0.0",
     "env-ci": "^11.0.0",

--- a/test/fixtures/plugin-errors.js
+++ b/test/fixtures/plugin-errors.js
@@ -1,5 +1,3 @@
-import AggregateError from "aggregate-error";
-
 export default () => {
   throw new AggregateError([new Error("a"), new Error("b")]);
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -3,7 +3,6 @@ import { escapeRegExp, isString, omit, sortBy } from "lodash-es";
 import * as td from "testdouble";
 import { spy, stub } from "sinon";
 import { WritableStreamBuffer } from "stream-buffers";
-import AggregateError from "aggregate-error";
 import SemanticReleaseError from "@semantic-release/error";
 import { COMMIT_EMAIL, COMMIT_NAME, SECRET_REPLACEMENT } from "../lib/definitions/constants.js";
 import {

--- a/test/plugins/pipeline.test.js
+++ b/test/plugins/pipeline.test.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import { stub } from "sinon";
-import AggregateError from "aggregate-error";
 import pipeline from "../../lib/plugins/pipeline.js";
 
 test("Execute each function in series passing the same input", async (t) => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,4 @@
 import test from "ava";
-import AggregateError from "aggregate-error";
 import {
   extractErrors,
   getEarliestVersion,


### PR DESCRIPTION
ref https://github.com/semantic-release/semantic-release/discussions/3376
ref https://github.com/es-tooling/module-replacements/issues/80

As per the `package.json` `engines` of this package, `semantic-release` supports Node.js `>=20.8.1`.

As per https://github.com/sindresorhus/aggregate-error

> Note: With [Node.js 15](https://medium.com/@nodejs/node-js-v15-0-0-is-here-deb00750f278), there's now a built-in [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) type.

This means we can remove the usage of this package and use the JavaScript built-in `AggregateError`.