### PR TITLE
feat: capture output of prepare plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ async function run(context, plugins) {
 
   nextRelease.notes = await plugins.generateNotes(context);
 
-  await plugins.prepare(context);
+  nextRelease.prepareOutput = await plugins.prepare(context);
 
   if (options.dryRun) {
     logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);


### PR DESCRIPTION
I would like a way to generate additional notes in my plugin that utilizes the prepare stage.

This way I can update my github plugin config like the following:

```js
releaseNameTemplate:
                    "<%= nextRelease.name %> (<%= nextRelease.prepareOutput.subscriberPackageVersionId %>)"
```

if there is a different way I can tie into that I would appreciate knowing how. I have attempted to mutate the context but it seems that the context is not a global reference one it reaches the plugin.