### PR TITLE
feat: add `warn` type to global `context.logger`

### DIFF
--- a/lib/get-logger.js
+++ b/lib/get-logger.js
@@ -14,5 +14,6 @@ export default ({ stdout, stderr }) =>
       error: { badge: figures.cross, color: "red", label: "", stream: [stderr] },
       log: { badge: figures.info, color: "magenta", label: "", stream: [stdout] },
       success: { badge: figures.tick, color: "green", label: "", stream: [stdout] },
+      warn: { badge: figures.warning, color: "yellow", label: "", stream: [stderr] },
     },
   });


### PR DESCRIPTION
This Pull request adds the `warn` type to the `semantic-release` global `context.logger` instance. 

**Changes Made**

- Added new property `warn` to the `Signale` instantication config property `types` in `get-logger.js` script

```js
export default ({ stdout, stderr }) =>
  new Signale({
    config: { displayTimestamp: true, underlineMessage: false, displayLabel: false },
    disabled: false,
    interactive: false,
    scope: "semantic-release",
    stream: [stdout],
    types: {
      error: { badge: figures.cross, color: "red", label: "", stream: [stderr] },
      log: { badge: figures.info, color: "magenta", label: "", stream: [stdout] },
      success: { badge: figures.tick, color: "green", label: "", stream: [stdout] },
      warn: { badge: figures.warning, color: "yellow", label: "", stream: [stderr] }, // 👈 👈 👈 👈  HERE
    },
  });
```

### Related Issue

Fixes #3422 