### PR TITLE
fix(deps): update `@semantic-release/github` to `v11.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
-        "@semantic-release/github": "^10.0.0",
+        "@semantic-release/github": "^11.0.0",
         "@semantic-release/npm": "^12.0.0",
         "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
         "aggregate-error": "^5.0.0",
@@ -1307,10 +1307,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.1.4.tgz",
-      "integrity": "sha512-dg+JTNp1XHazwAx9HgIuVewStfpv5g7QqwBF09aZVqwVkdTXw4agR/nhWSD0yxDbsx0YCeJTcjUOj92gf8/0Jw==",
-      "license": "MIT",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.0.tgz",
+      "integrity": "sha512-Uon6G6gJD8U1JNvPm7X0j46yxNRJ8Ui6SgK4Zw5Ktu8RgjEft3BGn+l/RX1TTzhhO3/uUcKuqM+/9/ETFxWS/Q==",
       "dependencies": {
         "@octokit/core": "^6.0.0",
         "@octokit/plugin-paginate-rest": "^11.0.0",
@@ -1333,7 +1332,7 @@
         "node": ">=20.8.1"
       },
       "peerDependencies": {
-        "semantic-release": ">=20.1.0"
+        "semantic-release": ">=24.1.0"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -12782,10 +12781,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.0.0.tgz",
-      "integrity": "sha512-v46CRPw+9eI3ZuYGF2oAjqPqsfbnfFTwLBgQsv/lch4goD09ytwOTESMN4QIrx/wPLxUGey60/NMx+ANQtWRsA==",
-      "license": "MIT",
+      "version": "24.1.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.1.1.tgz",
+      "integrity": "sha512-4Ax2GxD411jUe9IdhOjMLuN+6wAj+aKjvOGngByrpD/iKL+UKN/2puQglhyI4gxNyy9XzEBMzBwbqpnEwbXGEg==",
       "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
@@ -12803,7 +12801,7 @@
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
         "hook-std": "^3.0.0",
-        "hosted-git-info": "^7.0.0",
+        "hosted-git-info": "^8.0.0",
         "import-from-esm": "^1.3.1",
         "lodash-es": "^4.17.21",
         "marked": "^12.0.0",
@@ -12825,17 +12823,34 @@
         "node": ">=20.8.1"
       }
     },
-    "node_modules/semantic-release/node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-      "license": "ISC",
+    "node_modules/semantic-release/node_modules/@semantic-release/github": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.3.5.tgz",
+      "integrity": "sha512-svvRglGmvqvxjmDgkXhrjf0lC88oZowFhOfifTldbgX9Dzj0inEtMLaC+3/MkDEmxmaQjWmF5Q/0CMIvPNSVdQ==",
       "peer": true,
       "dependencies": {
-        "lru-cache": "^10.0.1"
+        "@octokit/core": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
+        "@octokit/plugin-retry": "^7.0.0",
+        "@octokit/plugin-throttling": "^9.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "debug": "^4.3.4",
+        "dir-glob": "^3.0.1",
+        "globby": "^14.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "issue-parser": "^7.0.0",
+        "lodash-es": "^4.17.21",
+        "mime": "^4.0.0",
+        "p-filter": "^4.0.0",
+        "url-join": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=20.1.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
     "@semantic-release/error": "^4.0.0",
-    "@semantic-release/github": "^10.0.0",
+    "@semantic-release/github": "^11.0.0",
     "@semantic-release/npm": "^12.0.0",
     "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
     "aggregate-error": "^5.0.0",

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -87,7 +87,7 @@ test.serial("Release patch, minor and major versions", async (t) => {
   let verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   t.log("Commit a chore");
   await gitCommits(["chore: Init repository"], { cwd });
@@ -142,7 +142,7 @@ test.serial("Release patch, minor and major versions", async (t) => {
   verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
@@ -183,7 +183,7 @@ test.serial("Release patch, minor and major versions", async (t) => {
   verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
@@ -224,7 +224,7 @@ test.serial("Release patch, minor and major versions", async (t) => {
   verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
@@ -269,7 +269,7 @@ test.serial("Release patch, minor and major versions", async (t) => {
   verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   const getReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases/tags/v2.0.0`,

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -391,7 +391,7 @@ test.serial("Dry-run", async (t) => {
   const verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   const version = "1.0.0";
   t.log("Commit a feature");
@@ -430,7 +430,7 @@ test.serial('Allow local releases with "noCi" option', async (t) => {
   const verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   const createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,
@@ -541,7 +541,7 @@ test.serial("Run via JS API", async (t) => {
   const verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   const createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -101,7 +101,7 @@ test.serial("Release patch, minor and major versions", async (t) => {
   verifyMock = await mockServer.mock(
     `/repos/${owner}/${packageName}`,
     { headers: [{ name: "Authorization", values: [`token ${env.GH_TOKEN}`] }] },
-    { body: { permissions: { push: true } }, method: "GET" }
+    { body: { permissions: { push: true }, clone_url: repositoryUrl }, method: "GET" }
   );
   let createReleaseMock = await mockServer.mock(
     `/repos/${owner}/${packageName}/releases`,


### PR DESCRIPTION
This PR updates the minimum version bound of the `@semantic-release/github` plugin from `v10.0.0` to [v11.0.0](https://github.com/semantic-release/github/releases/tag/v11.0.0) 