### PR TITLE
feat: clarify branch existence requirement in error messages

### DIFF
--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -227,7 +227,7 @@ export function EMAINTENANCEBRANCHES({ branches }) {
     message: "The maintenance branches are invalid in the `branches` configuration.",
     details: `Each maintenance branch in the [branches configuration](${linkify(
       "docs/usage/configuration.md#branches"
-    )}) must have a unique \`range\` property.
+    )}) must have a unique \`range\` property and must exist on the remote repository.
 
 Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
   };
@@ -238,7 +238,7 @@ export function ERELEASEBRANCHES({ branches }) {
     message: "The release branches are invalid in the `branches` configuration.",
     details: `A minimum of 1 and a maximum of 3 release branches are required in the [branches configuration](${linkify(
       "docs/usage/configuration.md#branches"
-    )}).
+    )}). These branches must exist on the remote repository.
 
 This may occur if your repository does not have a release branch, such as \`master\` or \`main\`.
 
@@ -251,7 +251,7 @@ export function EPRERELEASEBRANCH({ branch }) {
     message: "A pre-release branch configuration is invalid in the `branches` configuration.",
     details: `Each pre-release branch in the [branches configuration](${linkify(
       "docs/usage/configuration.md#branches"
-    )}) must have a \`prerelease\` property valid per the [Semantic Versioning Specification](https://semver.org/#spec-item-9). If the \`prerelease\` property is set to \`true\`, then the \`name\` property is used instead.
+    )}) must have a \`prerelease\` property valid per the [Semantic Versioning Specification](https://semver.org/#spec-item-9). If the \`prerelease\` property is set to \`true\`, then the \`name\` property is used instead. Additionally, each pre-release branch must exist on the remote repository.
 
 Your configuration for the problematic branch is \`${stringify(branch)}\`.`,
   };


### PR DESCRIPTION
Updated error messages in `EMAINTENANCEBRANCHES`, `ERELEASEBRANCHES`, and `EPRERELEASEBRANCH` to explicitly state that branches must exist on the remote repository.

This change is necessary because it was confusing for developers configuring semantic-release who had not yet created the remote branches. By clearly stating that the branches must exist on the remote, we help prevent misconfigurations and improve the user experience.

There was an issue for this and also a stale PR, but maybe now is finally the time where we can merge this to improve the developer experience.