### PR TITLE
docs(plugin): add @covage/semantic-release-poetry-plugin

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -133,6 +133,9 @@
   - `verifyConditions`: Verify the environment variable `PYPI_TOKEN` and installation of build tools
   - `prepare`: Update the version in `setup.cfg` and create the distribution packages
   - `publish`: Publish the python package to a repository (default: pypi)
+- [@covage/semantic-release-poetry-plugin](https://github.com/covage/semantic-release-poetry-plugin)
+  - `verifyConditions`: Verify the presence and validity of `pyproject.toml` file.
+  - `prepare`: Update the version in `pyproject.toml`.
 - [semantic-release-codeartifact](https://github.com/ryansonshine/semantic-release-codeartifact)
   - `verifyConditions`: Validate configuration, get AWS CodeArtifact authentication and repository, validate `publishConfig` or `.npmrc` (if they exist), then pass the configuration to the associated plugins.
 - [semantic-release-telegram](https://github.com/pustovitDmytro/semantic-release-telegram)


### PR DESCRIPTION
Hi,

We (at Covage) created a new plugin for semantic-release to better fit internal use-case of Poetry.
The sole purpose of this plugin is to update the version field inside the `pyproject.toml`.

The benefits of this plugin over [semantic-release-pypi](https://github.com/abichinger/semantic-release-pypi) : 
- More fitted and focused to the use-case of a private package registry. 
- It only depend on Node.js and does not require Python in the CI pipeline container.

Please see the details and source code of this plugin : https://github.com/covage/semantic-release-poetry-plugin 

This plugin is published on NPM : https://www.npmjs.com/package/@covage/semantic-release-poetry-plugin

We now use this plugin instead of a bumpversion.sh script in our private code repositories.  