### PR TITLE
docs: update broken link to gitlab pipelines

### DIFF
--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -9,7 +9,7 @@ Here are a few examples of the CI services that can be used to achieve this:
 - [CircleCI Workflows](https://circleci.com/docs/2.0/workflows)
 - [GitHub Actions](https://github.com/features/actions)
 - [Codeship Deployment Pipelines](https://documentation.codeship.com/basic/builds-and-configuration/deployment-pipelines)
-- [GitLab Pipelines](https://docs.gitlab.com/ce/ci/introduction/)
+- [GitLab Pipelines](https://docs.gitlab.com/ee/ci/pipelines/)
 - [Codefresh Pipelines](https://codefresh.io/docs/docs/configure-ci-cd-pipeline/introduction-to-codefresh-pipelines)
 - [Wercker Workflows](http://devcenter.wercker.com/docs/workflows)
 - [GoCD Pipelines](https://docs.gocd.org/current/introduction/concepts_in_go.html#pipeline).


### PR DESCRIPTION
Link to Gitlab documentation is broken, a little PR to fix it :)