### PR TITLE
fix(ci): allow for publishing on allowed tag names

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ async function run(context, plugins) {
   await verify(context);
 
   options.repositoryUrl = await getGitAuthUrl({ ...context, branch: { name: ciBranch } });
-  context.branches = await getBranches(options.repositoryUrl, ciBranch, context);
+  context.branches = await getBranches(options.repositoryUrl, ciBranch, context, isCi);
   context.branch = context.branches.find(({ name }) => name === ciBranch);
 
   if (!context.branch) {

--- a/lib/branches/expand.js
+++ b/lib/branches/expand.js
@@ -2,8 +2,12 @@ import { isString, mapValues, omit, remove, template } from "lodash-es";
 import micromatch from "micromatch";
 import { getBranches } from "../git.js";
 
-export default async (repositoryUrl, { cwd }, branches) => {
+export default async (repositoryUrl, { cwd }, branches, includeTags = false) => {
   const gitBranches = await getBranches(repositoryUrl, { cwd });
+
+  if (includeTags) {
+    gitBranches.push(...(await Promise.all(gitBranches.map(gitBranch => getTags(gitBranch, { cwd })))).flat())
+  }
 
   return branches.reduce(
     (branches, branch) => [

--- a/lib/branches/index.js
+++ b/lib/branches/index.js
@@ -8,13 +8,14 @@ import expand from "./expand.js";
 import getTags from "./get-tags.js";
 import * as normalize from "./normalize.js";
 
-export default async (repositoryUrl, ciBranch, context) => {
+export default async (repositoryUrl, ciBranch, context, includeTags = false) => {
   const { cwd, env } = context;
 
   const remoteBranches = await expand(
     repositoryUrl,
     context,
-    context.options.branches.map((branch) => (isString(branch) || isRegExp(branch) ? { name: branch } : branch))
+    context.options.branches.map((branch) => (isString(branch) || isRegExp(branch) ? { name: branch } : branch)),
+    includeTags
   );
 
   await pEachSeries(remoteBranches, async ({ name }) => {


### PR DESCRIPTION
In my team we use a 2-step release, where we first commit and create the tag locally, then push the tag and run a GitLab CI job on the tag to publish to NPM and GL releases. This is currently not possible with semantic-release.

When a tag checked is out locally, env-ci.branch is the branch it is on, however, in CI environments it returns the tag name. This makes it impossible to publish from a tag, as tags will never be included in context.branches, no matter the user configuration.

This proposes adding tags to the list of possible branches in CI (locally this is not necessary and will fail for non-checked out branches), allowing for configurations like `branches: ['main', 'vx.x.x']`.