### PR TITLE
fix(docs): Fix broken GitHub Actions link

### DIFF
--- a/docs/recipes/ci-configurations/github-actions.md
+++ b/docs/recipes/ci-configurations/github-actions.md
@@ -20,7 +20,7 @@ Find more detail about configuring npm to publish with provenance through semant
 ### `.github/workflows/release.yml` configuration for Node projects
 
 The following is a minimal configuration for [`semantic-release`](https://github.com/semantic-release/semantic-release) with a build running on the latest LTS version of Node when a new commit is pushed to a `master/main` branch.
-See [Configuring a Workflow](https://help.github.com/en/articles/configuring-a-workflow) for additional configuration options.
+See the [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions) for additional configuration options.
 
 ```yaml
 name: Release


### PR DESCRIPTION
I noticed the existing link to the ["Configuring a Workflow"](https://help.github.com/en/articles/configuring-a-workflow) page 404's. I have replaced it with the ["Workflow syntax for GitHub Actions"](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions) page, which has all possible configuration options for a GHA workflow.