### PR TITLE
feat: add config file field for "git log" CLI options

### DIFF
--- a/lib/get-commits.js
+++ b/lib/get-commits.js
@@ -16,6 +16,7 @@ export default async ({
   lastRelease: { gitHead: from },
   nextRelease: { gitHead: to = "HEAD" } = {},
   logger,
+  options,
 }) => {
   if (from) {
     debug("Use from: %s", from);
@@ -23,7 +24,7 @@ export default async ({
     logger.log("No previous release found, retrieving all commits");
   }
 
-  const commits = await getCommits(from, to, { cwd, env });
+  const commits = await getCommits(from, to, { cwd, env }, options["git-log"]);
 
   logger.log(`Found ${commits.length} commits since last release`);
   debug("Parsed commits: %o", commits);

--- a/lib/git.js
+++ b/lib/git.js
@@ -43,13 +43,14 @@ export async function getTags(branch, execaOptions) {
  * @param {String} from to includes all commits made after this sha (does not include this sha).
  * @param {String} to to includes all commits made before this sha (also include this sha).
  * @param {Object} [execaOpts] Options to pass to `execa`.
+ * @param {Object} [gitLogOpts] Options to pass to `git log`. Defaults to `{}`.
  * @return {Promise<Array<Object>>} The list of commits between `from` and `to`.
  */
-export async function getCommits(from, to, execaOptions) {
+export async function getCommits(from, to, execaOptions, gitLogOpts={}) {
   return (
     await getStream.array(
       gitLogParser.parse(
-        { _: `${from ? from + ".." : ""}${to}` },
+        merge({ _: `${from ? from + ".." : ""}${to}` }, gitLogOpts),
         { cwd: execaOptions.cwd, env: { ...process.env, ...execaOptions.env } }
       )
     )


### PR DESCRIPTION
The current version of `semantic-release` is biased to the default outputs of `git log` as determined by the default parameters of `git-log-parser`. This prevents `semantic-release` from the required robustness for some workflows, the most glaring workflow being the following:

1. Create a feature branch (e.g., `feat/add-my-feature-to-object`).
2. Add commits to the feature branch.
3. Create a pull request to merge the feature branch into the main branch.
4. Merge the pull request using the default merge option on GitHub with the title "feat: add my feature to object".

### How does "Merge pull request" merge a PR?

Per GitHub merge docs:

> When you click the default Merge pull request option on a pull request, all commits from the feature branch are added to the base branch in a merge commit. The pull request is merged using [the --no-ff option](https://git-scm.com/docs/git-merge#_fast_forward_merge).

### What is the benefit of using "Merge pull request"?

Individual commits (specifically, the atomic-style commits associated with conventional commits) are left untouched in the log history. Should a bug be found downstream, it's possible to identify the exact commit that caused it quickly and efficiently, leading to a faster fix.

### What benefit does "Squash and merge" have over "Merge pull request"?

A clean history! Especially in conjunction with `semantic-release`, changes made to a repository are clear and concise. Documenting the changes added to each release is simple and automated.

### What does any of this have to do with this PR?

We can have the best of both workflows. This PR is designed to be robust, but intended to solve one thing: a compromise where developers can automate documentation via `semantic-release` AND maintain atomic commit history for an easier debugging experience.

Note that this addition only adds customization to `semantic-release`. For those interested, the commits that `semantic-release` uses to produce a new release can be configured with all options available to `git log`. This includes the option `--merges`, a.k.a. `--min-parents=2`, which, if included in the `semantic-release` configuration file, enables the workflow described at the top of this PR.

### Example Usage

```
{
  "branches": ["main"],
  "plugins": [ ... ],
  "git-log": {
    "min-parents": 2
  }
}
```
This example results in all of the expected functionality of `semantic-release`, except it now operates on only merge commits using conventional commit syntax.