### PR TITLE
fix(deps): remove `tempy` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "publint": "0.3.12",
         "sinon": "20.0.0",
         "stream-buffers": "3.0.3",
-        "tempy": "3.1.0",
         "testdouble": "3.20.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "publint": "0.3.12",
     "sinon": "20.0.0",
     "stream-buffers": "3.0.3",
-    "tempy": "3.1.0",
     "testdouble": "3.20.2"
   },
   "engines": {

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -1,5 +1,7 @@
 import test from "ava";
-import { temporaryDirectory } from "tempy";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { sep } from "path";
 import {
   addNote,
   fetch,
@@ -268,7 +270,8 @@ test('Return "true" if in a Git repository', async (t) => {
 });
 
 test("Return falsy if not in a Git repository", async (t) => {
-  const cwd = temporaryDirectory();
+  const tmpDir = tmpdir();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
 
   t.falsy(await isGitRepo({ cwd }));
 });
@@ -288,7 +291,8 @@ test("Return falsy for invalid tag names", async (t) => {
 });
 
 test("Throws error if obtaining the tags fails", async (t) => {
-  const cwd = temporaryDirectory();
+  const tmpDir = tmpdir();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
 
   await t.throwsAsync(getTags("master", { cwd }));
 });

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -1,4 +1,6 @@
-import { temporaryDirectory } from "tempy";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { sep } from "path";
 import { execa } from "execa";
 import fileUrl from "file-url";
 import pEachSeries from "p-each-series";
@@ -15,6 +17,7 @@ import { GIT_NOTE_REF } from "../../lib/definitions/constants.js";
  * @property {String} message The commit message.
  */
 
+const tmpDir = tmpdir();
 /**
  * Initialize git repository
  * If `withRemote` is `true`, creates a bare repository and initialize it.
@@ -24,7 +27,7 @@ import { GIT_NOTE_REF } from "../../lib/definitions/constants.js";
  * @return {String} The path of the repository
  */
 export async function initGit(withRemote) {
-  const cwd = temporaryDirectory();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
   const args = withRemote ? ["--bare", "--initial-branch=master"] : ["--initial-branch=master"];
 
   await execa("git", ["init", ...args], { cwd }).catch(() => {
@@ -71,7 +74,7 @@ export async function gitRepo(withRemote, branch = "master") {
  * @param {String} [branch='master'] the branch to initialize.
  */
 export async function initBareRepo(repositoryUrl, branch = "master") {
-  const cwd = temporaryDirectory();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
   await execa("git", ["clone", "--no-hardlinks", repositoryUrl, cwd], { cwd });
   await gitCheckout(branch, true, { cwd });
   await gitCommits(["Initial commit"], { cwd });
@@ -177,7 +180,7 @@ export async function gitTagVersion(tagName, sha, execaOptions) {
  * @return {String} The path of the cloned repository.
  */
 export async function gitShallowClone(repositoryUrl, branch = "master", depth = 1) {
-  const cwd = temporaryDirectory();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
 
   await execa("git", ["clone", "--no-hardlinks", "--no-tags", "-b", branch, "--depth", depth, repositoryUrl, cwd], {
     cwd,
@@ -193,7 +196,7 @@ export async function gitShallowClone(repositoryUrl, branch = "master", depth = 
  * @return {String} The path of the new repository.
  */
 export async function gitDetachedHead(repositoryUrl, head) {
-  const cwd = temporaryDirectory();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
 
   await execa("git", ["init"], { cwd });
   await execa("git", ["remote", "add", "origin", repositoryUrl], { cwd });
@@ -203,7 +206,7 @@ export async function gitDetachedHead(repositoryUrl, head) {
 }
 
 export async function gitDetachedHeadFromBranch(repositoryUrl, branch, head) {
-  const cwd = temporaryDirectory();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
 
   await execa("git", ["init"], { cwd });
   await execa("git", ["remote", "add", "origin", repositoryUrl], { cwd });

--- a/test/plugins/plugins.test.js
+++ b/test/plugins/plugins.test.js
@@ -1,12 +1,15 @@
 import path from "path";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
 import test from "ava";
 import { copy, outputFile } from "fs-extra";
 import { stub } from "sinon";
-import { temporaryDirectory } from "tempy";
 import getPlugins from "../../lib/plugins/index.js";
 
 // Save the current working directory
 const cwd = process.cwd();
+
+const tmpDir = tmpdir();
 
 test.beforeEach((t) => {
   // Stub the logger functions
@@ -137,7 +140,7 @@ test('Unknown steps of plugins configured in "plugins" are ignored', async (t) =
 });
 
 test("Export plugins loaded from the dependency of a shareable config module", async (t) => {
-  const cwd = temporaryDirectory();
+  const cwd = mkdtempSync(`${tmpDir}${path.sep}`);
   await copy(
     "./test/fixtures/plugin-noop.cjs",
     path.resolve(cwd, "node_modules/shareable-config/node_modules/custom-plugin/index.js")
@@ -170,7 +173,7 @@ test("Export plugins loaded from the dependency of a shareable config module", a
 });
 
 test("Export plugins loaded from the dependency of a shareable config file", async (t) => {
-  const cwd = temporaryDirectory();
+  const cwd = mkdtempSync(`${tmpDir}${path.sep}`);
   await copy("./test/fixtures/plugin-noop.cjs", path.resolve(cwd, "plugin/plugin-noop.cjs"));
   await outputFile(path.resolve(cwd, "shareable-config.js"), "");
 

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -1,5 +1,7 @@
 import test from "ava";
-import { temporaryDirectory } from "tempy";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { sep } from "path";
 import verify from "../lib/verify.js";
 import { gitRepo } from "./helpers/git-utils.js";
 
@@ -28,7 +30,8 @@ test("Throw a AggregateError", async (t) => {
 });
 
 test("Throw a SemanticReleaseError if does not run on a git repository", async (t) => {
-  const cwd = temporaryDirectory();
+  const tmpDir = tmpdir();
+  const cwd = mkdtempSync(`${tmpDir}${sep}`);
   const options = { branches: [] };
 
   const errors = [...(await t.throwsAsync(verify({ cwd, options }))).errors];


### PR DESCRIPTION
Replaces `tempy` with built-in Node.js `fs.mkdtempSync` that is available since Node.js 10. temporary directory generation is performed as recommended by Node.js docs.