### PR TITLE
perf: Improve getTags to only return latest

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -31,10 +31,16 @@ export async function getTagHead(tagName, execaOptions) {
  * @throws {Error} If the `git` command fails.
  */
 export async function getTags(branch, execaOptions) {
-  return (await execa("git", ["tag", "--merged", branch], execaOptions)).stdout
-    .split("\n")
-    .map((tag) => tag.trim())
-    .filter(Boolean);
+    try {
+        const { stdout } = await execa("git", ["describe", "--abbrev=0", "--tags", branch], execaOptions);
+        return [stdout.trim()]; // Returns an array containing the latest tag or an empty array if no tags
+    } catch (error) {
+        // Handle the case where no tags are found
+        if (error.message.includes("No names found, cannot describe anything.")) {
+            return []; // Return an empty array if no tags are found
+        }
+        throw error; // Re-throw the error if it's not a "no tags" error
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes #3594 

If a repo has hundreds, or even thousands of tags, it can take whole minutes for getTags to return.

In our case, two minutes and eight seconds (2:08) was reduced to 2 seconds (0:02):

**Before:**
2025-04-21T**10:14:00**.822Z semantic-release:get-git-auth-url SSH key auth failed, falling back to https.
2025-04-21T**10:16:08**.388Z semantic-release:get-tags found tags for branch master:

**After:**
2025-04-24T**03:01:30**.865Z semantic-release:get-git-auth-url SSH key auth successful.
2025-04-24T**03:01:32**.892Z semantic-release:get-tags found tags for branch master: