### PR TITLE
fix(deps): raise the minimum of the defined range for `marked-terminal`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "import-from-esm": "^2.0.0",
         "lodash-es": "^4.17.21",
         "marked": "^15.0.0",
-        "marked-terminal": "^7.0.0",
+        "marked-terminal": "^7.3.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^3.0.0",
         "p-reduce": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "import-from-esm": "^2.0.0",
     "lodash-es": "^4.17.21",
     "marked": "^15.0.0",
-    "marked-terminal": "^7.0.0",
+    "marked-terminal": "^7.3.0",
     "micromatch": "^4.0.2",
     "p-each-series": "^3.0.0",
     "p-reduce": "^3.0.0",


### PR DESCRIPTION
to a version that declares peer-deendency compatibility with `marked` v15

this will force an update of `marked-terminal` in projects with stale lockfiles, like #3725 or #3726