### PR TITLE
Add feature to skip git push operations

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -36,6 +36,7 @@ Usage:
     .option("fail", { ...stringList, group: "Plugins" })
     .option("debug", { describe: "Output debugging information", type: "boolean", group: "Options" })
     .option("d", { alias: "dry-run", describe: "Skip publishing", type: "boolean", group: "Options" })
+    .option("s", { alias: "skip-push", describe: "Skip git push operations", type: "boolean", group: "Options" })
     .option("h", { alias: "help", group: "Options" })
     .strict(false)
     .exitProcess(false);

--- a/docs/usage/ci-configuration.md
+++ b/docs/usage/ci-configuration.md
@@ -20,7 +20,7 @@ See [CI configuration recipes](../recipes/ci-configurations/README.md) for more 
 
 ### Push access to the remote repository
 
-**semantic-release** requires push access to the project Git repository in order to create [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging). The Git authentication can be set with one of the following environment variables:
+**semantic-release** requires push access to the project Git repository (unless the [skipPush](configuration.md#skippush) option is enabled) in order to create [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging). The Git authentication can be set with one of the following environment variables:
 
 | Variable                                              | Description                                                                                                                                                                                                                  |
 | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -150,6 +150,18 @@ The objective of the dry-run mode is to get a preview of the pending release. Dr
 
 **Note**: The Dry-run mode verifies the repository push permission, even though nothing will be pushed. The verification is done to help user to figure out potential configuration issues.
 
+### skipPush
+
+Type: `Boolean`<br>
+Default: `false`<br>
+CLI arguments: `-s`, `--skip-push`
+
+Set to `true` to skip the push of the release tag to the remote repository via git, and associated push permission checks.
+This allows for the release tag to be published via other means where repository push permissions may not be required
+(i.e. GitLab Releases)
+
+**Note**: Some plug-ins (i.e. GitHub) may require that the tag exists in the remote repository before publishing. Use with caution.
+
 ### ci
 
 Type: `Boolean`<br>

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -160,7 +160,10 @@ Set to `true` to skip the push of the release tag to the remote repository via g
 This allows for the release tag to be published via other means where repository push permissions may not be required
 (i.e. GitLab Releases)
 
-**Note**: Some plug-ins (i.e. GitHub) may require that the tag exists in the remote repository before publishing. Use with caution.
+Repository pull permissions are still required.
+
+**Note**: Some plug-ins (i.e. GitHub) may require that the tag exists in the remote repository before publishing.
+Use with caution.
 
 ### ci
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -668,6 +668,12 @@ declare module "semantic-release" {
     dryRun?: boolean | undefined;
 
     /**
+     * Skip pushing release tags and notes to the remote repository
+     * This allows plug-ins to manage release tags (i.e. GitLab releases)
+     */
+    skipPush?: boolean | undefined;
+
+    /**
      * Set to false to skip Continuous Integration environment verifications.
      * This allows for making releases from a local machine.
      */

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ import {
   addNote,
   getGitHead,
   getTagHead,
+  isBranchInSync,
   isBranchUpToDate,
   push,
   pushNotes,
@@ -106,9 +107,11 @@ async function run(context, plugins) {
       `The local branch ${context.branch.name} is behind the remote one, therefore a new version won't be published.`
     );
     return false;
+  } else if (options.skipPush && !(await isBranchInSync(options.repositoryUrl, context.branch.name, { cwd, env }))) {
+    logger.warn(`The local branch ${context.branch.name} is ahead of the remote and skipPush is enabled`);
+  } else {
+    logger.success(`Local branch is up to date with the remote repository`);
   }
-
-  logger.success(`Local branch is up to date with the remote repository`);
 
   if (!options.skipPush) {
     try {

--- a/index.js
+++ b/index.js
@@ -77,31 +77,29 @@ async function run(context, plugins) {
     return false;
   }
 
-  logger[options.dryRun ? "warn" : "success"](
-    `Run automated release from branch ${ciBranch} on repository ${options.originalRepositoryURL}${
-      options.dryRun ? " in dry-run mode" : ""
-    }`
-  );
+  if (!(await isBranchUpToDate(options.repositoryUrl, context.branch.name, { cwd, env }))) {
+    logger.log(
+      `The local branch ${context.branch.name} is behind the remote one, therefore a new version won't be published.`
+    );
+    return false;
+  }
+
+  logger.success(`Local branch is up to date with the remote repository`);
 
   try {
-    try {
-      await verifyPush(options.repositoryUrl, context.branch.name, { cwd, env });
-    } catch (error) {
-      if (!(await isBranchUpToDate(options.repositoryUrl, context.branch.name, { cwd, env }))) {
-        logger.log(
-          `The local branch ${context.branch.name} is behind the remote one, therefore a new version won't be published.`
-        );
-        return false;
-      }
-
-      throw error;
-    }
+    await verifyPush(options.repositoryUrl, context.branch.name, { cwd, env });
   } catch (error) {
     logger.error(`The command "${error.command}" failed with the error message ${error.stderr}.`);
     throw getError("EGITNOPERMISSION", context);
   }
 
   logger.success(`Allowed to push to the Git repository`);
+
+  logger[options.dryRun ? "warn" : "success"](
+    `Run automated release from branch ${ciBranch} on repository ${options.originalRepositoryURL}${
+      options.dryRun ? " in dry-run mode" : ""
+    }`
+  );
 
   await plugins.verifyConditions(context);
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ import { extractErrors, makeTag } from "./lib/utils.js";
 import getGitAuthUrl from "./lib/get-git-auth-url.js";
 import getBranches from "./lib/branches/index.js";
 import getLogger from "./lib/get-logger.js";
-import { addNote, getGitHead, getTagHead, isBranchUpToDate, push, pushNotes, tag, verifyAuth } from "./lib/git.js";
+import { addNote, getGitHead, getTagHead, isBranchUpToDate, push, pushNotes, tag, verifyPush } from "./lib/git.js";
 import getError from "./lib/get-error.js";
 import { COMMIT_EMAIL, COMMIT_NAME } from "./lib/definitions/constants.js";
 
@@ -85,7 +85,7 @@ async function run(context, plugins) {
 
   try {
     try {
-      await verifyAuth(options.repositoryUrl, context.branch.name, { cwd, env });
+      await verifyPush(options.repositoryUrl, context.branch.name, { cwd, env });
     } catch (error) {
       if (!(await isBranchUpToDate(options.repositoryUrl, context.branch.name, { cwd, env }))) {
         logger.log(

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -37,7 +37,7 @@ Please make sure to add the \`repositoryUrl\` to the [semantic-release configura
   };
 }
 
-export function EGITNOPERMISSION({ options: { repositoryUrl }, branch: { name } }) {
+export function EGITNOWRITEPERMISSION({ options: { repositoryUrl }, branch: { name } }) {
   return {
     message: "Cannot push to the Git repository.",
     details: `**semantic-release** cannot push the version tag to the branch \`${name}\` on the remote Git repository with URL \`${repositoryUrl}\`.
@@ -46,6 +46,20 @@ This can be caused by:
  - a misconfiguration of the [repositoryUrl](${linkify("docs/usage/configuration.md#repositoryurl")}) option
  - the repository being unavailable
  - or missing push permission for the user configured via the [Git credentials on your CI environment](${linkify(
+   "docs/usage/ci-configuration.md#authentication"
+ )})`,
+  };
+}
+
+export function EGITNOREADPERMISSION({ options: { repositoryUrl } }) {
+  return {
+    message: "Cannot connect to the Git repository.",
+    details: `**semantic-release** cannot access the remote Git repository with URL \`${repositoryUrl}\`.
+
+This can be caused by:
+ - a misconfiguration of the [repositoryUrl](${linkify("docs/usage/configuration.md#repositoryurl")}) option
+ - the repository being unavailable
+ - or missing permission for the user configured via the [Git credentials on your CI environment](${linkify(
    "docs/usage/ci-configuration.md#authentication"
  )})`,
   };

--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -2,7 +2,7 @@ import { format, parse } from "node:url";
 import { isNil } from "lodash-es";
 import hostedGitInfo from "hosted-git-info";
 import debugAuthUrl from "debug";
-import { verifyAuth } from "./git.js";
+import { verifyPush } from "./git.js";
 
 const debug = debugAuthUrl("semantic-release:get-git-auth-url");
 
@@ -40,7 +40,7 @@ function formatAuthUrl(protocol, repositoryUrl, gitCredentials) {
  */
 async function ensureValidAuthUrl({ cwd, env, branch }, authUrl) {
   try {
-    await verifyAuth(authUrl, branch.name, { cwd, env });
+    await verifyPush(authUrl, branch.name, { cwd, env });
     return authUrl;
   } catch (error) {
     debug(error);
@@ -90,7 +90,7 @@ export default async (context) => {
   // Test if push is allowed without transforming the URL (e.g. is ssh keys are set up)
   try {
     debug("Verifying ssh auth by attempting to push to  %s", repositoryUrl);
-    await verifyAuth(repositoryUrl, branch.name, { cwd, env });
+    await verifyPush(repositoryUrl, branch.name, { cwd, env });
   } catch {
     debug("SSH key auth failed, falling back to https.");
     const envVars = Object.keys(GIT_TOKENS).filter((envVar) => !isNil(env[envVar]));

--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -2,7 +2,7 @@ import { format, parse } from "node:url";
 import { isNil } from "lodash-es";
 import hostedGitInfo from "hosted-git-info";
 import debugAuthUrl from "debug";
-import { verifyPush } from "./git.js";
+import { verifyLsRemote, verifyPush } from "./git.js";
 
 const debug = debugAuthUrl("semantic-release:get-git-auth-url");
 
@@ -38,9 +38,13 @@ function formatAuthUrl(protocol, repositoryUrl, gitCredentials) {
  *
  * @return {String} The authUrl as is if the connection was successful, null otherwise
  */
-async function ensureValidAuthUrl({ cwd, env, branch }, authUrl) {
+async function ensureValidAuthUrl({ cwd, env, branch, options }, authUrl) {
   try {
-    await verifyPush(authUrl, branch.name, { cwd, env });
+    if (options.skipPush) {
+      await verifyLsRemote(authUrl, { cwd, env });
+    } else {
+      await verifyPush(authUrl, branch.name, { cwd, env });
+    }
     return authUrl;
   } catch (error) {
     debug(error);
@@ -60,7 +64,7 @@ async function ensureValidAuthUrl({ cwd, env, branch }, authUrl) {
  * @return {String} The formatted Git repository URL.
  */
 export default async (context) => {
-  const { cwd, env, branch } = context;
+  const { cwd, env, branch, options } = context;
   const GIT_TOKENS = {
     GIT_CREDENTIALS: undefined,
     GH_TOKEN: undefined,
@@ -89,8 +93,13 @@ export default async (context) => {
 
   // Test if push is allowed without transforming the URL (e.g. is ssh keys are set up)
   try {
-    debug("Verifying ssh auth by attempting to push to  %s", repositoryUrl);
-    await verifyPush(repositoryUrl, branch.name, { cwd, env });
+    if (options.skipPush) {
+      debug("Verifying ssh auth by attempting to ls-remote on  %s", repositoryUrl);
+      await verifyLsRemote(repositoryUrl, { cwd, env });
+    } else {
+      debug("Verifying ssh auth by attempting to push to  %s", repositoryUrl);
+      await verifyPush(repositoryUrl, branch.name, { cwd, env });
+    }
   } catch {
     debug("SSH key auth failed, falling back to https.");
     const envVars = Object.keys(GIT_TOKENS).filter((envVar) => !isNil(env[envVar]));

--- a/lib/git.js
+++ b/lib/git.js
@@ -203,7 +203,24 @@ export async function isGitRepo(execaOptions) {
  */
 export async function verifyPush(repositoryUrl, branch, execaOptions) {
   try {
-    await execa("git", ["push", "--dry-run", "--no-verify", repositoryUrl, `HEAD:${branch}`], execaOptions);
+    await execa("git", ["push", "--dry-run", "--no-verify", "--force", repositoryUrl, `HEAD:${branch}`], execaOptions);
+  } catch (error) {
+    debug(error);
+    throw error;
+  }
+}
+
+/**
+ * Verify the read access authorization to remote repository with ls-remote.
+ *
+ * @param {String} repositoryUrl The remote repository URL.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @throws {Error} if not authorized.
+ */
+export async function verifyLsRemote(repositoryUrl, execaOptions) {
+  try {
+    await execa("git", ["ls-remote", repositoryUrl], execaOptions);
   } catch (error) {
     debug(error);
     throw error;

--- a/lib/git.js
+++ b/lib/git.js
@@ -286,13 +286,29 @@ export async function verifyBranchName(branch, execaOptions) {
  * @param {String} branch The repository branch for which to verify status.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
- * @return {Boolean} `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
+ * @return {Boolean} `true` if the HEAD of the remote branch is an ancestor to the HEAD of the local branch, falsy otherwise.
  */
 export async function isBranchUpToDate(repositoryUrl, branch, execaOptions) {
-  return (
-    (await getGitHead(execaOptions)) ===
-    (await execa("git", ["ls-remote", "--heads", repositoryUrl, branch], execaOptions)).stdout.match(/^(?<ref>\w+)?/)[1]
-  );
+  try {
+    return (
+      (
+        await execa(
+          "git",
+          [
+            "merge-base",
+            "--is-ancestor",
+            (await execa("git", ["ls-remote", "--heads", repositoryUrl, branch], execaOptions)).stdout.match(
+              /^(?<ref>\w+)?/
+            )[1],
+            "HEAD",
+          ],
+          execaOptions
+        )
+      ).exitCode === 0
+    );
+  } catch (error) {
+    debug(error);
+  }
 }
 
 /**

--- a/lib/git.js
+++ b/lib/git.js
@@ -329,6 +329,22 @@ export async function isBranchUpToDate(repositoryUrl, branch, execaOptions) {
 }
 
 /**
+ * Verify the local branch is in sync with the remote one.
+ *
+ * @param {String} repositoryUrl The remote repository URL.
+ * @param {String} branch The repository branch for which to verify status.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @return {Boolean} `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
+ */
+export async function isBranchInSync(repositoryUrl, branch, execaOptions) {
+  return (
+    (await getGitHead(execaOptions)) ===
+    (await execa("git", ["ls-remote", "--heads", repositoryUrl, branch], execaOptions)).stdout.match(/^(?<ref>\w+)?/)[1]
+  );
+}
+
+/**
  * Get and parse the JSON note of a given reference.
  *
  * @param {String} ref The Git reference for which to retrieve the note.

--- a/lib/git.js
+++ b/lib/git.js
@@ -201,7 +201,7 @@ export async function isGitRepo(execaOptions) {
  *
  * @throws {Error} if not authorized to push.
  */
-export async function verifyAuth(repositoryUrl, branch, execaOptions) {
+export async function verifyPush(repositoryUrl, branch, execaOptions) {
   try {
     await execa("git", ["push", "--dry-run", "--no-verify", repositoryUrl, `HEAD:${branch}`], execaOptions);
   } catch (error) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -72,6 +72,7 @@ test.serial("Pass options to semantic-release API", async (t) => {
     "fail2",
     "--debug",
     "-d",
+    "-s",
   ];
   const index = await td.replaceEsm("../index.js");
   process.argv = argv;
@@ -96,6 +97,9 @@ test.serial("Pass options to semantic-release API", async (t) => {
       "dry-run": true,
       dryRun: true,
       d: true,
+      "skip-push": true,
+      skipPush: true,
+      s: true,
       verifyConditions: ["condition1", "condition2"],
       "verify-conditions": ["condition1", "condition2"],
       analyzeCommits: "analyze",
@@ -134,6 +138,7 @@ test.serial("Pass options to semantic-release API with alias arguments", async (
     "config1",
     "config2",
     "--dry-run",
+    "--skip-push",
   ];
   const index = await td.replaceEsm("../index.js");
   process.argv = argv;
@@ -158,6 +163,9 @@ test.serial("Pass options to semantic-release API with alias arguments", async (
       "dry-run": true,
       dryRun: true,
       d: true,
+      "skip-push": true,
+      skipPush: true,
+      s: true,
       _: [],
       $0: "",
     })
@@ -214,6 +222,8 @@ test.serial("Do not set properties in option for which arg is not in command lin
   t.false("ci" in run.args[0][0]);
   t.false("d" in run.args[0][0]);
   t.false("dry-run" in run.args[0][0]);
+  t.false("s" in run.args[0][0]);
+  t.false("skip-push" in run.args[0][0]);
   t.false("debug" in run.args[0][0]);
   t.false("r" in run.args[0][0]);
   t.false("t" in run.args[0][0]);

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -646,7 +646,7 @@ test.serial("Exit with 1 if missing permission to push to the remote repository"
     { env: { ...env, GH_TOKEN: "user:wrong_pass" }, cwd, reject: false, extendEnv: false }
   );
   // Verify the type and message are logged
-  t.regex(stderr, /EGITNOPERMISSION/);
+  t.regex(stderr, /EGITNOWRITEPERMISSION/);
   t.is(exitCode, 1);
 });
 

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -412,3 +412,17 @@ test("Do not add git credential to repositoryUrl if push is allowed", async (t) 
     repositoryUrl
   );
 });
+
+test("Do not add git credential to repositoryUrl if ls-remote is allowed with skipPush", async (t) => {
+  const { cwd, repositoryUrl } = await gitRepo(true);
+
+  t.is(
+    await getAuthUrl({
+      cwd,
+      env: { ...env, GIT_CREDENTIALS: "user:pass" },
+      branch: { name: "master" },
+      options: { repositoryUrl, skipPush: true },
+    }),
+    repositoryUrl
+  );
+});

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -301,6 +301,15 @@ test('Return "true" if repository is up to date', async (t) => {
   t.true(await isBranchUpToDate(repositoryUrl, "master", { cwd }));
 });
 
+test('Return "true" if repository is ahead of remote', async (t) => {
+  const { cwd, repositoryUrl } = await gitRepo(true);
+  await gitCommits(["First"], { cwd });
+  await gitPush(repositoryUrl, "master", { cwd });
+  await gitCommits(["Second"], { cwd });
+
+  t.true(await isBranchUpToDate(repositoryUrl, "master", { cwd }));
+});
+
 test("Return falsy if repository is not up to date", async (t) => {
   const { cwd, repositoryUrl } = await gitRepo(true);
   await gitCommits(["First"], { cwd });

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -9,6 +9,7 @@ import {
   getNote,
   getTagHead,
   getTags,
+  isBranchInSync,
   isBranchUpToDate,
   isGitRepo,
   isRefExists,
@@ -335,6 +336,23 @@ test("Return falsy if detached head repository is not up to date", async (t) => 
   await fetch(repositoryUrl, "master", "master", { cwd });
 
   t.falsy(await isBranchUpToDate(repositoryUrl, "master", { cwd }));
+});
+
+test('Return "true" if repository is in sync', async (t) => {
+  const { cwd, repositoryUrl } = await gitRepo(true);
+  await gitCommits(["First"], { cwd });
+  await gitPush(repositoryUrl, "master", { cwd });
+
+  t.true(await isBranchInSync(repositoryUrl, "master", { cwd }));
+});
+
+test("Return falsy if repository is ahead of remote", async (t) => {
+  const { cwd, repositoryUrl } = await gitRepo(true);
+  await gitCommits(["First"], { cwd });
+  await gitPush(repositoryUrl, "master", { cwd });
+  await gitCommits(["Second"], { cwd });
+
+  t.falsy(await isBranchInSync(repositoryUrl, "master", { cwd }));
 });
 
 test("Get a commit note", async (t) => {


### PR DESCRIPTION
This PR adds a configuration property, "skipPush", which skips git push operations (and access checks), but otherwise executes the lifecycle as normal.

Why would anyone want to do this?

My primary motivation is the ability to use short lived job tokens provided by Gitlab CI, which *do* have permissions to create repository tags, but lack permissions to push to the git remote. There is a feature flagged capability on GitLab, to allow git push permissions to job tokens: https://docs.gitlab.com/ci/jobs/ci_job_token/#allow-git-push-requests-to-your-project-repository. However... in larger enterprises and highly regulated industries, there can often be trepidation in enabling these types of features.

This has been discussed extensively here, it appears: https://github.com/semantic-release/semantic-release/issues/1729

I did consider a more significant refactor, which could potentially fully delegate the git tag creation (and verification steps) to a plugin, by introducing the git tag creation step as a plugin lifecycle phase. However, this would be a significant architectural change, difficult to do in non-breaking way, and potentially confusing for users.

In the end, it seemed a simple, well documented config flag would suffice. So users who wish to utilize this feature, are explicitly utilizing it.

There are likely other edge scenarios that this feature would be useful for. Perhaps someone wants to effectively do a "dry run", but still exercise the publish steps of various plugins. Ultimately the goal here is to provide flexibility to the user, while still maintaining the core constructs of the architecture.

I've opened a pull request for the gitlab plugin as well, which addresses the ability for that plug-in to properly accommodate the use of job tokens: https://github.com/semantic-release/gitlab/pull/859

There does not appear to be any regression of any existing functionality.