### PR TITLE
docs: Update minimal required Node version

### DIFF
--- a/docs/support/node-version.md
+++ b/docs/support/node-version.md
@@ -24,7 +24,7 @@ See [CI configuration](../usage/ci-configuration.md) and [CI configuration recip
 Use it to execute the `semantic-release` command.
 
 ```bash
-$ npx -p node@v18-lts -c "npx semantic-release"
+$ npx -p node@v24 -c "npx semantic-release"
 ```
 
 **Note**: See [What is npx](./FAQ.md#what-is-npx) for more details.


### PR DESCRIPTION
# Why

After upgrading to latest major release I have spotted that minimal required node version has been changed.

Refs:
* https://github.com/semantic-release/semantic-release/releases/tag/v25.0.0

# How

Update `node-version.md` to include correct minimal required Node version, since this doc is linked on action failure due to not matching Node version in runner.