### PR TITLE
docs(plugins): add semantic-release-uv community plugin in plugins list

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -213,6 +213,10 @@
 - [sr-uv-plugin](https://github.com/Artessan-Devs/sr-uv-plugin)
   - `verifyConditions`: Ensures `pyproject.toml` exists and contains a `[project]` section.
   - `prepare`: Updates the `[project].version` field in `pyproject.toml` to match the release version.
+- [semantic-release-uv](https://github.com/Deltamir/semantic-release-uv)
+  - `verifyConditions`: Verify the presence and validity of a `PYPI_TOKEN` and validate the `pyproject.toml` structure
+  - `prepare`: Update the version in `pyproject.toml`, locking and build the distribution with `uv`
+  - `publish`: Publish the package to PyPI or a custom index using `uv publish`
 - [@jno21/semantic-release-github-commit](https://github.com/Jno21/semantic-release-github-commit)
   - **Notes**: This plugin creates a commit on GitHub using the GitHub API, enabling signed commits via a GitHub App.
   - `verifyConditions`: Verify GitHub authentication and configuration.


### PR DESCRIPTION
Add semantic-release-uv to the official plugin list in the repository documentation.

This is a documentation-only change: it adds a new plugin entry to [plugins-list.md](https://github.com/semantic-release/semantic-release/blob/master/docs/extending/plugins-list.md) and does not modify runtime code.

## Summary of changes
docs: update [plugins-list.md](https://github.com/semantic-release/semantic-release/blob/master/docs/extending/plugins-list.md) to include a new entry for semantic-release-uv.

## Plugin details
- Plugin name: semantic-release-uv
- [GitLab](https://gitlab.com/open-resources/semantic-release-uv) (CI is handled on GitLab)
- [npm package](https://www.npmjs.com/package/@open_resources/semantic-release-uv)
- Public reports and artifacts (SBOM, SAST, Quality, NPM reports): available via the [project's releases page](https://gitlab.com/open-resources/semantic-release-uv/-/releases)
- Maintenance: The plugin is kept up-to-date via Renovate
- Test coverage: current and maintained at 100%
