### PR TITLE
docs: Remove 3rd party apps section from GitHub Actions docs

### DIFF
--- a/docs/recipes/ci-configurations/github-actions.md
+++ b/docs/recipes/ci-configurations/github-actions.md
@@ -134,4 +134,3 @@ To trigger a release, call (with a [Personal Access Tokens](https://help.github.
 ```
 $ curl -v -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/[org-name-or-username]/[repository]/dispatches -d '{ "event_type": "semantic-release" }'
 ```
-


### PR DESCRIPTION
Removed section about using 3rd party apps for GitHub Actions. Neither of these links actually brought you to a working project. First one looks like maybe GitHub acquired them/integrated it and the second one says it's archived.