### PR TITLE
chore(docs): remove references to obsolete 3rd party github apps

### DIFF
--- a/docs/recipes/ci-configurations/github-actions.md
+++ b/docs/recipes/ci-configurations/github-actions.md
@@ -113,10 +113,3 @@ To trigger a release, call (with a [Personal Access Tokens](https://help.github.
 ```
 $ curl -v -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/[org-name-or-username]/[repository]/dispatches -d '{ "event_type": "semantic-release" }'
 ```
-
-### Using 3rd party apps:
-
-If you'd like to use a GitHub app to manage this instead of creating a personal access token, you could consider using a project like:
-
-- [Actions Panel](https://www.actionspanel.app/) - A declaratively configured way for triggering GitHub Actions
-- [Action Button](https://github-action-button.web.app/#details) - A simple badge based mechanism for triggering GitHub Actions


### PR DESCRIPTION
The section is obsolete.

- https://www.actionspanel.app/ points to GitHub's standard Manual Trigger
- https://github-action-button.web.app/ is dead