### PR TITLE
fix: get-last-release matches prerelease tags with dots in config

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -34,7 +34,8 @@ export default ({ branch, options: { tagFormat } }, { before } = {}) => {
           tag.channels.some((channel) => isSameChannel(branch.channel, channel)) &&
           semver
             .parse(tag.version)
-            .prerelease.includes(branch.prerelease === true ? branch.name : branch.prerelease)) ||
+            .prerelease.join(".")
+            .startsWith(branch.prerelease === true ? branch.name : branch.prerelease)) ||
           !semver.prerelease(tag.version)) &&
         (isUndefined(before) || semver.lt(tag.version, before))
     )


### PR DESCRIPTION
Fixes #4067

The .includes() check fails when prerelease config contains dots (e.g., AS2024.10) because semver.parse() splits the prerelease portion on dots per semver spec. For example: semver.parse('1.705.3-AS2024.10.15').prerelease returns ['AS2024', 10, 15] and ['AS2024', 10, 15].includes('AS2024.10') returns false.

This fix joins the prerelease components and uses startsWith() instead, which correctly handles multi-component prerelease identifiers.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*