### PR TITLE
fix: handle dotted prerelease ids when resolving last release

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -32,9 +32,12 @@ export default ({ branch, options: { tagFormat } }, { before } = {}) => {
       (tag) =>
         ((branch.type === "prerelease" &&
           tag.channels.some((channel) => isSameChannel(branch.channel, channel)) &&
-          semver
-            .parse(tag.version)
-            .prerelease.includes(branch.prerelease === true ? branch.name : branch.prerelease)) ||
+          (() => {
+            const branchPrerelease = branch.prerelease === true ? branch.name : branch.prerelease;
+            const tagPrerelease = semver.parse(tag.version).prerelease.map(String).join(".");
+
+            return tagPrerelease === branchPrerelease || tagPrerelease.startsWith(`${branchPrerelease}.`);
+          })()) ||
           !semver.prerelease(tag.version)) &&
         (isUndefined(before) || semver.lt(tag.version, before))
     )

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -80,6 +80,46 @@ test("Get the correct prerelease tag, when other prereleases share the same git 
   });
 });
 
+test("Get the highest prerelease valid tag when prerelease identifier contains dots", (t) => {
+  const result = getLastRelease({
+    branch: {
+      name: "lts/AS2024.10",
+      prerelease: "AS2024.10",
+      channel: "lts/AS2024.10",
+      tags: [
+        {
+          version: "1.705.3-AS2024.10.14",
+          gitTag: "v1.705.3-AS2024.10.14",
+          gitHead: "v1.705.3-AS2024.10.14",
+          channels: ["lts/AS2024.10"],
+        },
+        {
+          version: "1.705.3-AS2024.10.15",
+          gitTag: "v1.705.3-AS2024.10.15",
+          gitHead: "v1.705.3-AS2024.10.15",
+          channels: ["lts/AS2024.10"],
+        },
+        {
+          version: "1.705.3-AS2024.11.1",
+          gitTag: "v1.705.3-AS2024.11.1",
+          gitHead: "v1.705.3-AS2024.11.1",
+          channels: ["lts/AS2024.11"],
+        },
+      ],
+      type: "prerelease",
+    },
+    options: { tagFormat: `v\${version}` },
+  });
+
+  t.deepEqual(result, {
+    version: "1.705.3-AS2024.10.15",
+    gitTag: "v1.705.3-AS2024.10.15",
+    name: "v1.705.3-AS2024.10.15",
+    gitHead: "v1.705.3-AS2024.10.15",
+    channels: ["lts/AS2024.10"],
+  });
+});
+
 test("Return empty object if no valid tag is found", (t) => {
   const result = getLastRelease({
     branch: {


### PR DESCRIPTION
## Summary
- fix prerelease branch matching in `get-last-release` when `branch.prerelease` contains dots (for example `AS2024.10`)
- replace the array `.includes()` check with a string match against the parsed prerelease identifiers joined by `.`
- ensure matching is exact-or-prefix (`id` or `id.*`) so unrelated identifiers do not match
- add a regression test covering dotted prerelease identifiers and verify the highest matching tag is selected

## Testing
- `npx ava test/get-last-release.test.js`

## Related
Fixes #4067
