### PR TITLE
docs: replace GlobalConfig with Options

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -44,7 +44,7 @@ The following three examples are the same. Use main instead of master if your de
 
 ```js
 /**
- * @type {import('semantic-release').GlobalConfig}
+ * @type {import('semantic-release').Options}
  */
 module.exports = {
   branches: ["master", "next"],
@@ -55,7 +55,7 @@ module.exports = {
 
 ```js
 /**
- * @type {import('semantic-release').GlobalConfig}
+ * @type {import('semantic-release').Options}
  */
 export default {
   branches: ["master", "next"],


### PR DESCRIPTION
GlobalConfig requires options that are actually optional in the config as they are documented to have default values

Errors with `GlobalConfig`:

<img width="717" height="309" alt="image" src="https://github.com/user-attachments/assets/05f3abb4-0fc1-4267-b1d1-570a2ccbdc4a" />

No errors with `Options`:

<img width="392" height="76" alt="image" src="https://github.com/user-attachments/assets/ac4ee7c0-7124-4574-8cc2-70b734d8169a" />
