### PR TITLE
fix: correct control flow for git SSH authentication fallback

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -91,6 +91,9 @@ export default async (context) => {
   try {
     debug("Verifying ssh auth by attempting to push to  %s", repositoryUrl);
     await verifyAuth(repositoryUrl, branch.name, { cwd, env });
+    // Log completion of this process
+    debug("SSH key auth successful.");
+    return repositoryUrl;
   } catch {
     debug("SSH key auth failed, falling back to https.");
     const envVars = Object.keys(GIT_TOKENS).filter((envVar) => !isNil(env[envVar]));
@@ -120,7 +123,5 @@ export default async (context) => {
     }
   }
 
-  // Log completion of this process
-  debug("SSH key auth successful.");
   return repositoryUrl;
 };


### PR DESCRIPTION
## Summary

When SSH authentication fails, the code attempts to fall back to HTTPS. However, a logic error caused an incorrect 'SSH key auth successful' message to be logged if the fallback also failed. This would cause the process to continue with the invalid SSH URL, leading to a crash in a later step.

This fix adjusts the control flow to ensure the success message is only logged on successful SSH authentication. If both SSH and the HTTPS fallback fail, the original (failing) URL is returned without a success message, allowing the process to fail as expected but with clearer cause.

## Changes

- **lib/get-git-auth-url.js**: The success log message and return statement for successful SSH authentication have been moved inside the `try` block. This corrects the control flow, preventing an incorrect success message from being logged when both SSH and the HTTPS fallback fail.

## Related Issue

Closes #4060

