### PR TITLE
docs(plugins): add semantic-release-linear-issue-status to community plugins list

### DIFF
--- a/docs/extending/plugins-list.md
+++ b/docs/extending/plugins-list.md
@@ -225,3 +225,6 @@
   - `verifyConditions`: Verify that all needed configuration is present.
   - `prepare`: Convert different types of CurseForge game versions to their corresponding IDs.
   - `publish`: Publish the Minecraft project to CurseForge and Modrinth.
+- [semantic-release-linear-issue-status](https://github.com/noahlaux/semantic-release-linear-issue-status)
+  - `verifyConditions`: Verify the presence of the `LINEAR_API_KEY` environment variable and required configuration options (`teamKey`, `issuePrefixes`).
+  - `success`: Move linked [Linear](https://linear.app) issues to a completed workflow state after a successful release, based on issue identifiers found in release commits.


### PR DESCRIPTION
## Summary

Adds [`semantic-release-linear-issue-status`](https://github.com/noahlaux/semantic-release-linear-issue-status) to the community plugins list.

**Plugin:** https://github.com/noahlaux/semantic-release-linear-issue-status
**npm:** https://www.npmjs.com/package/semantic-release-linear-issue-status

### What it does

Linear flows doesn't really have a way to move issues to `done` or `completed` when a release has been actually made (not just merging into the main branch), so I created a semantic release plugin that does exactly that.

- `verifyConditions`: Validates `teamKey`, `issuePrefixes`, and the Linear API key environment variable at release start — fails fast before any publish steps run.
- `success`: Scans release commits for [Linear](https://linear.app) issue identifiers (e.g. `NEU-123`) and moves each linked issue to a completed workflow state after a successful release. Issues already completed or canceled are skipped.

### Checklist

- [x] Published on npm as `semantic-release-linear-issue-status@1.1.0`
- [x] MIT licensed
- [x] 33 unit tests, 100% line and function coverage across `lib/`
- [x] Prettier formatted (with `lint:prettier` script)
- [x] README documents all options, steps, and behavior
- [x] CI: test matrix across Node 18/20/22 on Ubuntu, macOS, and Windows
- [x] Automated releases via semantic-release itself