### PR TITLE
fix(git.js): skip parsing empty notes

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -342,6 +342,11 @@ export async function getTagsNotes(execaOptions) {
       continue;
     }
 
+    if (notePart === undefined) {
+      // No note associated with the tag, skip to the next line
+      continue;
+    }
+
     try {
       const parsed = JSON.parse(notePart);
       tags.forEach((tag) => {


### PR DESCRIPTION
This pull request introduces a small improvement to the `getTagsNotes` function in `lib/git.js`. The change ensures that lines without an associated note are skipped, preventing unnecessary parsing attempts.

Here is what I see currently in the log when debug is enabled

```
2026-04-15T11:10:55.617Z semantic-release:git SyntaxError: "undefined" is not valid JSON
    at JSON.parse (<anonymous>)
    at getTagsNotes (file:///home/runner/work/project/.github/node_modules/semantic-release/lib/git.js:346:27)
    at async default (file:///home/runner/work/project/.github/node_modules/semantic-release/lib/branches/get-tags.js:17:24)
    at async default (file:///home/runner/work/project/.github/node_modules/semantic-release/lib/branches/index.js:26:20)
    at async run (file:///home/runner/work/project/.github/node_modules/semantic-release/index.js:68:22)
    at async Module.default (file:///home/runner/work/project/.github/node_modules/semantic-release/index.js:278:22)
    at async default (file:///home/runner/work/project/.github/node_modules/semantic-release/cli.js:55:5)
```