### PR TITLE
feat(branches): allow no release branches to be configured

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -102,7 +102,7 @@ The branches on which releases should happen. By default **semantic-release** wi
 
 **Note**: Branches configuration key accepts [**micromatch**](https://github.com/micromatch/micromatch?tab=readme-ov-file#matching-features) globs.
 
-**Note**: If your repository does not have a release branch, then **semantic-release** will fail with an `ERELEASEBRANCHES` error message. If you are using the default configuration, you can fix this error by pushing a `master` or `main` branch.
+**Note**: If your repository does not have a release branch, then **semantic-release** will log a warning message. If you are using the default configuration, you can fix this error by pushing a `master` or `main` branch.
 
 **Note**: Once **semantic-release** is configured, any user with the permission to push commits on one of those branches will be able to publish a release. It is recommended to protect those branches, for example with [GitHub protected branches](https://docs.github.com/github/administering-a-repository/about-protected-branches).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -465,8 +465,8 @@ declare module "semantic-release" {
      *    `alpha` if it exists
      *
      * **Note**: If your repository does not have a release branch, then
-     * **semantic-release** will fail with an `ERELEASEBRANCHES` error
-     * message. If you are using the default configuration, you can fix
+     * **semantic-release** will log a warning message.
+     * If you are using the default configuration, you can fix
      * this error by pushing a `master`/`main branch.
      *
      * **Note**: Once **semantic-release** is configured, any user with the
@@ -607,8 +607,8 @@ declare module "semantic-release" {
      *    `alpha` if it exists
      *
      * **Note**: If your repository does not have a release branch, then
-     * **semantic-release** will fail with an `ERELEASEBRANCHES` error
-     * message. If you are using the default configuration, you can fix
+     * **semantic-release** will log a warning message.
+     * If you are using the default configuration, you can fix
      * this error by pushing a `master`/`main` branch.
      *
      * **Note**: Once **semantic-release** is configured, any user with the

--- a/lib/branches/index.js
+++ b/lib/branches/index.js
@@ -7,6 +7,7 @@ import { fetch, fetchNotes, verifyBranchName } from "../git.js";
 import expand from "./expand.js";
 import getTags from "./get-tags.js";
 import * as normalize from "./normalize.js";
+import getLogger from "../get-logger.js";
 
 export default async (repositoryUrl, ciBranch, context) => {
   const { cwd, env } = context;
@@ -26,13 +27,14 @@ export default async (repositoryUrl, ciBranch, context) => {
   const branches = await getTags(context, remoteBranches);
 
   const errors = [];
+  const logger = getLogger(context);
   const branchesByType = Object.entries(DEFINITIONS).reduce(
     // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
     (branchesByType, [type, { filter }]) => ({ [type]: branches.filter(filter), ...branchesByType }),
     {}
   );
 
-  const result = Object.entries(DEFINITIONS).reduce((result, [type, { branchesValidator, branchValidator }]) => {
+  const result = Object.entries(DEFINITIONS).reduce((result, [type, { branchesValidator, branchValidator, branchesWarningMessage }]) => {
     branchesByType[type].forEach((branch) => {
       if (branchValidator && !branchValidator(branch)) {
         errors.push(getError(`E${type.toUpperCase()}BRANCH`, { branch }));
@@ -43,6 +45,13 @@ export default async (repositoryUrl, ciBranch, context) => {
 
     if (!branchesValidator(branchesOfType)) {
       errors.push(getError(`E${type.toUpperCase()}BRANCHES`, { branches: branchesOfType }));
+    }
+
+    if (branchesWarningMessage) {
+      const warning = branchesWarningMessage(branchesOfType);
+      if (warning) {
+        logger.warn(warning);
+      }
     }
 
     return { ...result, [type]: branchesOfType };

--- a/lib/definitions/branches.js
+++ b/lib/definitions/branches.js
@@ -18,5 +18,6 @@ export const prerelease = {
 export const release = {
   // eslint-disable-next-line unicorn/no-fn-reference-in-iterator
   filter: (branch) => !maintenance.filter(branch) && !prerelease.filter(branch),
-  branchesValidator: (branches) => branches.length <= 3 && branches.length > 0,
+  branchesValidator: (branches) => branches.length <= 3,
+  branchesWarningMessage: (branches) =>  branches.length === 0 ? "No release branch found, semantic-release will not publish any release." : null,
 };

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -236,11 +236,9 @@ Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
 export function ERELEASEBRANCHES({ branches }) {
   return {
     message: "The release branches are invalid in the `branches` configuration.",
-    details: `A minimum of 1 and a maximum of 3 release branches are required in the [branches configuration](${linkify(
+    details: `A maximum of 3 release branches are allowed in the [branches configuration](${linkify(
       "docs/usage/configuration.md#branches"
     )}). These branches must exist on the remote repository.
-
-This may occur if your repository does not have a release branch, such as \`master\` or \`main\`.
 
 Your configuration for the problematic branches is \`${stringify(branches)}\`.`,
   };

--- a/test/branches/branches.test.js
+++ b/test/branches/branches.test.js
@@ -13,11 +13,13 @@ const merge = (branches, source, target, tag) => {
 };
 const remoteBranches = [];
 const repositoryUrl = "repositoryUrl";
-let expand, getTags, getBranches;
+let expand, getTags, getBranches, getLogger;
 
 test.beforeEach(async (t) => {
   getTags = (await td.replaceEsm("../../lib/branches/get-tags.js")).default;
   expand = (await td.replaceEsm("../../lib/branches/expand.js")).default;
+  getLogger = (await td.replaceEsm("../../lib/get-logger.js")).default;
+  td.when(getLogger(td.matchers.anything())).thenReturn({ warn: () => {} });
   getBranches = (await import("../../lib/branches/index.js")).default;
 });
 
@@ -213,7 +215,7 @@ test.serial("Throw SemanticReleaseError for invalid configurations", async (t) =
   td.when(getTags(context, remoteBranches)).thenResolve(branches);
 
   const error = await t.throwsAsync(getBranches(repositoryUrl, "master", context));
-  const errors = [...error.errors];
+  const errors = error?.errors ? [...error.errors] : [error];
 
   t.is(errors[0].name, "SemanticReleaseError");
   t.is(errors[0].code, "EMAINTENANCEBRANCH");
@@ -231,10 +233,19 @@ test.serial("Throw SemanticReleaseError for invalid configurations", async (t) =
   t.is(errors[3].code, "EPRERELEASEBRANCHES");
   t.truthy(errors[3].message);
   t.truthy(errors[3].details);
-  t.is(errors[4].name, "SemanticReleaseError");
-  t.is(errors[4].code, "ERELEASEBRANCHES");
-  t.truthy(errors[4].message);
-  t.truthy(errors[4].details);
+});
+
+test.serial("Log a warning message when no release branch is configured", async (t) => {
+  const branches = [{ name: "1.x", range: "1.x", tags: [] }];
+  const context = { options: { branches } };
+  const warn = td.function();
+  td.when(expand(repositoryUrl, context, branches)).thenResolve(remoteBranches);
+  td.when(getTags(context, remoteBranches)).thenResolve(branches);
+  td.when(getLogger(context)).thenReturn({ warn });
+
+  await t.notThrowsAsync(getBranches(repositoryUrl, "master", context));
+
+  td.verify(warn(td.matchers.contains("No release branch found, semantic-release will not publish any release.")));
 });
 
 test.serial("Throw a SemanticReleaseError if there is duplicate branches", async (t) => {

--- a/test/definitions/branches.test.js
+++ b/test/definitions/branches.test.js
@@ -83,12 +83,12 @@ test('A "release" branch is identified by not havin a "range" or "prerelease" pr
   /* eslint-enable unicorn/no-fn-reference-in-iterator */
 });
 
-test("There must be between 1 and 3 release branches", (t) => {
+test("There must be between 0 and 3 release branches", (t) => {
+  t.true(release.branchesValidator([]));
   t.true(release.branchesValidator([{ name: "branch1" }]));
   t.true(release.branchesValidator([{ name: "branch1" }, { name: "branch2" }]));
   t.true(release.branchesValidator([{ name: "branch1" }, { name: "branch2" }, { name: "branch3" }]));
 
-  t.false(release.branchesValidator([]));
   t.false(
     release.branchesValidator([{ name: "branch1" }, { name: "branch2" }, { name: "branch3" }, { name: "branch4" }])
   );


### PR DESCRIPTION
Not specifying any release branches is now allowed in the `branches` configuration. If no release branches are configured, a warning will be logged to inform users that releases will not be published until at least one release branch is added.

This change has been made to:
- Not require a release branch to be available when you start a new application.
- Allow publishing pre-releases in the same branch as a release branch via `npx semantic-release --branches '[{"name":"master","prerelease":"rc"}]'`. This allows for regular development packages to be made whilst still allowing full releases to be maintained on the trunk via a manual trigger.

closes #1706