### PR TITLE
fix: anchor tagFormat regex with end-of-string marker (#4138)

### DIFF
--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -11,7 +11,7 @@ export default async ({ cwd, env, options: { tagFormat } }, branches) => {
   // by replacing the `version` variable in the template by `(.+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
-  const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "(.+)")}`;
+  const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "(.+)")}$`;
 
   // Get the tags notes for all the tags in the repository
   const tagsNotesMap = await getTagsNotes({ cwd, env });


### PR DESCRIPTION
## Description

Fixes #4138

The `tagRegexp` in `lib/branches/get-tags.js` was not end-anchored with `$`, causing shorter `tagFormat` patterns to incorrectly match longer tags that share the same prefix.

### Problem Example

Given these two `tagFormat` values:
- `v${version}-sonar-dotnet-10`
- `v${version}-sonar-dotnet-10-action`

The shorter regex `^v(.+)-sonar-dotnet-10` would incorrectly match the longer tag `v1.0.0-sonar-dotnet-10-action`, producing an incorrect version number or causing releases to be halted.

### Solution

Add `$` (end-of-string anchor) to the tagRegexp pattern, ensuring exact tagFormat matching.

**Before:**
```js
const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "(.+)")}`;
```

**After:**
```js
const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "(.+)")}$`;
```

### Testing

- [ ] Existing tests continue to pass
- [ ] Manually verified the regex now correctly rejects partial matches

*This contribution was AI-assisted.*
