### PR TITLE
fix(git): merge multi-line tag notes from multiple refs

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -8,6 +8,32 @@ import { extractGitLogTags } from "./utils.js";
 
 const debug = debugGit("semantic-release:git");
 
+function parseTagsNote(notePart) {
+  const noteLines = notePart.split("\n").filter((line) => line.trim() !== "");
+
+  if (noteLines.length === 1) {
+    return JSON.parse(noteLines[0]);
+  }
+
+  const mergedChannels = new Set();
+  let parsed = {};
+
+  for (const line of noteLines) {
+    const lineParsed = JSON.parse(line.trim());
+    parsed = merge({}, parsed, lineParsed);
+
+    if (lineParsed.channels) {
+      lineParsed.channels.forEach((channel) => mergedChannels.add(channel));
+    }
+  }
+
+  if (mergedChannels.size > 0) {
+    parsed.channels = [...mergedChannels];
+  }
+
+  return parsed;
+}
+
 Object.assign(gitLogParser.fields, { hash: "H", message: "B", gitTags: "d", committerDate: { key: "ci", type: Date } });
 
 /**
@@ -331,19 +357,43 @@ export async function getTagsNotes(execaOptions) {
   // drop empty lines
   const lines = stdout.split("\n").filter((line) => line.trim() !== "");
 
-  // parse and create a map of tags to notes
-  const tagNotesMap = new Map();
+  // Git concatenates notes from multiple refs with newlines in %N, which can span stdout lines.
+  const entries = [];
 
   for (const line of lines) {
-    const [tagPart, notePart] = line.trim().split("\t"); // tab separator is defined in the git command above (%x09)
+    const trimmedLine = line.trim();
+    const tabIndex = trimmedLine.indexOf("\t");
+
+    if (tabIndex === -1) {
+      const previousEntry = entries.at(-1);
+
+      if (previousEntry) {
+        previousEntry.notePart = `${previousEntry.notePart}\n${trimmedLine}`;
+      } else {
+        debug(`Cannot parse tags from line: ${line}`);
+      }
+
+      continue;
+    }
+
+    const tagPart = trimmedLine.slice(0, tabIndex);
+    const notePart = trimmedLine.slice(tabIndex + 1);
     const tags = extractGitLogTags(tagPart);
+
     if (tags.length === 0) {
       debug(`Cannot parse tags from line: ${line}`);
       continue;
     }
 
+    entries.push({ tags, notePart });
+  }
+
+  // parse and create a map of tags to notes
+  const tagNotesMap = new Map();
+
+  for (const { tags, notePart } of entries) {
     try {
-      const parsed = JSON.parse(notePart);
+      const parsed = parseTagsNote(notePart);
       tags.forEach((tag) => {
         tagNotesMap.set(tag, parsed);
       });

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -367,6 +367,21 @@ test("Return undefined if a commit note is invalid", async (t) => {
   t.deepEqual(tagsNotes.get("v1.0.0"), undefined);
 });
 
+test("Merge channels when multiple tag notes exist on the same commit", async (t) => {
+  const { cwd } = await gitRepo();
+  const [commit] = await gitCommits(["First"], { cwd });
+
+  await gitTagVersion("v2.9.0-beta.13", commit.hash, { cwd });
+  await gitTagVersion("v2.9.0-alpha.1", commit.hash, { cwd });
+  await gitAddNote(JSON.stringify({ channels: ["staging"] }), "v2.9.0-beta.13", { cwd });
+  await gitAddNote(JSON.stringify({ channels: ["develop"] }), "v2.9.0-alpha.1", { cwd });
+
+  const tagsNotes = await getTagsNotes({ cwd });
+
+  t.deepEqual(tagsNotes.get("v2.9.0-beta.13"), { channels: ["develop", "staging"] });
+  t.deepEqual(tagsNotes.get("v2.9.0-alpha.1"), { channels: ["develop", "staging"] });
+});
+
 test("Add a commit note", async (t) => {
   // Create a git repository, set the current working directory at the root of the repo
   const { cwd } = await gitRepo();


### PR DESCRIPTION
## Summary

Fixes #4073

When two tags on the same commit each have a git note under a different `refs/notes/semantic-release-*` ref, `git log ... --format=%d%x09%N` concatenates the JSON notes with newlines. The previous implementation assumed a single JSON object per line and silently dropped tags when `JSON.parse` failed.

This PR:
- Merges continuation stdout lines (note JSON without a tag prefix) into the previous entry
- Parses multi-line `notePart` values and merges `channels` arrays across note objects

## Test plan

- [x] Added regression test: `"Merge channels when multiple tag notes exist on the same commit"`
- [x] `npx ava test/git.test.js` — 33 tests passed