### PR TITLE
fix: complete HTTPS fallback when SSH auth fails

### DIFF
--- a/lib/get-git-auth-url.js
+++ b/lib/get-git-auth-url.js
@@ -69,6 +69,7 @@ export default async (context) => {
     GITHUB_TOKEN: isNil(env.GITHUB_ACTION) ? undefined : "x-access-token:",
     GL_TOKEN: "gitlab-ci-token:",
     GITLAB_TOKEN: "gitlab-ci-token:",
+    CI_JOB_TOKEN: "gitlab-ci-token:",
     BB_TOKEN: "x-token-auth:",
     BITBUCKET_TOKEN: "x-token-auth:",
     BB_TOKEN_BASIC_AUTH: "",
@@ -91,6 +92,8 @@ export default async (context) => {
   try {
     debug("Verifying ssh auth by attempting to push to  %s", repositoryUrl);
     await verifyAuth(repositoryUrl, branch.name, { cwd, env });
+    debug("SSH key auth successful.");
+    return repositoryUrl;
   } catch {
     debug("SSH key auth failed, falling back to https.");
     const envVars = Object.keys(GIT_TOKENS).filter((envVar) => !isNil(env[envVar]));
@@ -118,9 +121,8 @@ export default async (context) => {
         return validRepositoryUrls[chosenAuthUrlIndex];
       }
     }
-  }
 
-  // Log completion of this process
-  debug("SSH key auth successful.");
-  return repositoryUrl;
+    debug("No git credentials found in environment, using https URL without embedded auth.");
+    return formatAuthUrl("https:", repositoryUrl, undefined);
+  }
 };

--- a/test/get-git-auth-url.test.js
+++ b/test/get-git-auth-url.test.js
@@ -4,7 +4,7 @@ import { gitRepo } from "./helpers/git-utils.js";
 
 const env = { GIT_ASKPASS: "echo", GIT_TERMINAL_PROMPT: 0 };
 
-test('Return the same "git" formatted URL if "gitCredentials" is not defined', async (t) => {
+test('Return the "https" formatted URL when ssh auth fails and no credentials are defined', async (t) => {
   const { cwd } = await gitRepo();
 
   t.is(
@@ -14,7 +14,7 @@ test('Return the same "git" formatted URL if "gitCredentials" is not defined', a
       branch: { name: "master" },
       options: { repositoryUrl: "git@host.null:owner/repo.git" },
     }),
-    "git@host.null:owner/repo.git"
+    "https://host.null/owner/repo.git"
   );
 });
 
@@ -46,12 +46,12 @@ test('Return the "https" formatted URL if "gitCredentials" is not defined and re
   );
 });
 
-test('Do not add trailing ".git" if not present in the origian URL', async (t) => {
+test('Return the "https" formatted URL when ssh auth fails for git URL without trailing ".git"', async (t) => {
   const { cwd } = await gitRepo();
 
   t.is(
-    await getAuthUrl({ cwd, env, vranch: { name: "master" }, options: { repositoryUrl: "git@host.null:owner/repo" } }),
-    "git@host.null:owner/repo"
+    await getAuthUrl({ cwd, env, branch: { name: "master" }, options: { repositoryUrl: "git@host.null:owner/repo" } }),
+    "https://host.null/owner/repo"
   );
 });
 
@@ -69,7 +69,7 @@ test('Handle "https" URL with group and subgroup', async (t) => {
   );
 });
 
-test('Handle "git" URL with group and subgroup', async (t) => {
+test('Handle "git" URL with group and subgroup when ssh auth fails', async (t) => {
   const { cwd } = await gitRepo();
 
   t.is(
@@ -79,7 +79,7 @@ test('Handle "git" URL with group and subgroup', async (t) => {
       branch: { name: "master" },
       options: { repositoryUrl: "git@host.null:group/subgroup/owner/repo.git" },
     }),
-    "git@host.null:group/subgroup/owner/repo.git"
+    "https://host.null/group/subgroup/owner/repo.git"
   );
 });
 
@@ -295,6 +295,20 @@ test('Return the "https" formatted URL if "gitCredentials" is defined with "GITL
     await getAuthUrl({
       cwd,
       env: { ...env, GITLAB_TOKEN: "token" },
+      branch: { name: "master" },
+      options: { repositoryUrl: "git@host.null:owner/repo.git" },
+    }),
+    "https://gitlab-ci-token:token@host.null/owner/repo.git"
+  );
+});
+
+test('Return the "https" formatted URL if "gitCredentials" is defined with "CI_JOB_TOKEN"', async (t) => {
+  const { cwd } = await gitRepo();
+
+  t.is(
+    await getAuthUrl({
+      cwd,
+      env: { ...env, CI_JOB_TOKEN: "token" },
       branch: { name: "master" },
       options: { repositoryUrl: "git@host.null:owner/repo.git" },
     }),


### PR DESCRIPTION
## Summary
- Return immediately after successful SSH verification (fixes misleading "SSH key auth successful" log after failed fallback)
- Fall back to HTTPS without embedded auth when SSH fails and no credential env vars are set
- Add `CI_JOB_TOKEN` support for GitLab CI (same prefix as `GL_TOKEN` / `GITLAB_TOKEN`)

## Problem
When SSH auth failed, semantic-release logged "falling back to https" but still returned the original SSH URL if no `GL_TOKEN`/`GITLAB_TOKEN` was set. Subsequent git commands continued using SSH and failed.

## Test plan
- [x] Updated tests for HTTPS fallback when SSH auth fails
- [x] Added test for `CI_JOB_TOKEN`
- [x] `npx ava test/get-git-auth-url.test.js` passes

Fixes #4060