### PR TITLE
fix: match prerelease tags when identifier contains dots

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -2,6 +2,19 @@ import { isUndefined } from "lodash-es";
 import semver from "semver";
 import { isSameChannel, makeTag } from "./utils.js";
 
+function matchesPrereleaseIdentifier(branch, version) {
+  const prereleaseId = branch.prerelease === true ? branch.name : branch.prerelease;
+  const parsed = semver.parse(version);
+
+  if (!parsed || parsed.prerelease.length === 0) {
+    return false;
+  }
+
+  const tagPrerelease = parsed.prerelease.map(String).join(".");
+
+  return tagPrerelease === prereleaseId || tagPrerelease.startsWith(`${prereleaseId}.`);
+}
+
 /**
  * Last release.
  *
@@ -32,9 +45,7 @@ export default ({ branch, options: { tagFormat } }, { before } = {}) => {
       (tag) =>
         ((branch.type === "prerelease" &&
           tag.channels.some((channel) => isSameChannel(branch.channel, channel)) &&
-          semver
-            .parse(tag.version)
-            .prerelease.includes(branch.prerelease === true ? branch.name : branch.prerelease)) ||
+          matchesPrereleaseIdentifier(branch, tag.version)) ||
           !semver.prerelease(tag.version)) &&
         (isUndefined(before) || semver.lt(tag.version, before))
     )

--- a/test/get-last-release.test.js
+++ b/test/get-last-release.test.js
@@ -80,6 +80,47 @@ test("Get the correct prerelease tag, when other prereleases share the same git 
   });
 });
 
+test("Get the highest prerelease valid tag when prerelease identifier contains dots", (t) => {
+  const result = getLastRelease({
+    branch: {
+      name: "lts/AS2024.10",
+      prerelease: "AS2024.10",
+      channel: "lts-as2024.10",
+      tags: [
+        { version: "1.705.2", gitTag: "v1.705.2", gitHead: "v1.705.2", channels: ["latest"] },
+        {
+          version: "1.705.3-AS2024.10.1",
+          gitTag: "v1.705.3-AS2024.10.1",
+          gitHead: "v1.705.3-AS2024.10.1",
+          channels: ["lts-as2024.10"],
+        },
+        {
+          version: "1.705.3-AS2024.10.15",
+          gitTag: "v1.705.3-AS2024.10.15",
+          gitHead: "v1.705.3-AS2024.10.15",
+          channels: ["lts-as2024.10"],
+        },
+        {
+          version: "1.705.3-AS2024.11.1",
+          gitTag: "v1.705.3-AS2024.11.1",
+          gitHead: "v1.705.3-AS2024.11.1",
+          channels: ["lts-as2024.11"],
+        },
+      ],
+      type: "prerelease",
+    },
+    options: { tagFormat: `v\${version}` },
+  });
+
+  t.deepEqual(result, {
+    version: "1.705.3-AS2024.10.15",
+    gitTag: "v1.705.3-AS2024.10.15",
+    name: "v1.705.3-AS2024.10.15",
+    gitHead: "v1.705.3-AS2024.10.15",
+    channels: ["lts-as2024.10"],
+  });
+});
+
 test("Return empty object if no valid tag is found", (t) => {
   const result = getLastRelease({
     branch: {


### PR DESCRIPTION
## Summary
- Replace `semver.parse().prerelease.includes()` with prefix matching on joined prerelease components
- Add `matchesPrereleaseIdentifier()` helper in `get-last-release.js`

## Problem
Prerelease config values containing dots (e.g. `AS2024.10`) were split by semver into `['AS2024', 10, 15]`, causing `.includes('AS2024.10')` to return false and ignore existing prerelease tags.

## Test plan
- [x] Added regression test for dotted prerelease identifiers
- [x] Existing get-last-release tests pass (`npx ava test/get-last-release.test.js`)

Fixes #4067