### PR TITLE
fix(cli): preserve JSON branch objects

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,13 +3,60 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import hideSensitive from "./lib/hide-sensitive.js";
 
+const splitListValue = (value) => {
+  const values = [];
+  let current = "";
+  let depth = 0;
+  let quote;
+  let escaped = false;
+
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+
+    if (quote) {
+      current += character;
+
+      if (character === "\\") {
+        escaped = true;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      current += character;
+      quote = character;
+    } else if (character === "{" || character === "[") {
+      current += character;
+      depth += 1;
+    } else if (character === "}" || character === "]") {
+      current += character;
+      depth = Math.max(depth - 1, 0);
+    } else if (character === "," && depth === 0) {
+      values.push(current.trim());
+      current = "";
+    } else {
+      current += character;
+    }
+  }
+
+  values.push(current.trim());
+  return values;
+};
+
 const stringList = {
   type: "string",
   array: true,
   coerce: (values) =>
     values.length === 1 && values[0].trim() === "false"
       ? []
-      : values.reduce((values, value) => values.concat(value.split(",").map((value) => value.trim())), []),
+      : values.reduce((values, value) => values.concat(splitListValue(value)), []),
 };
 
 export default async () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -166,6 +166,29 @@ test.serial("Pass options to semantic-release API with alias arguments", async (
   t.is(exitCode, 0);
 });
 
+test.serial("Keep JSON objects with commas together in list options", async (t) => {
+  const argv = ["", "", "--branches", '{"name":"main"},{"name":"version-test","prerelease":"snap"}', "--dry-run"];
+  const index = await td.replaceEsm("../index.js");
+  process.argv = argv;
+  const cli = (await import("../cli.js")).default;
+
+  const exitCode = await cli();
+
+  td.verify(
+    index.default({
+      branches: ['{"name":"main"}', '{"name":"version-test","prerelease":"snap"}'],
+      b: ['{"name":"main"}', '{"name":"version-test","prerelease":"snap"}'],
+      "dry-run": true,
+      dryRun: true,
+      d: true,
+      _: [],
+      $0: "",
+    })
+  );
+
+  t.is(exitCode, 0);
+});
+
 test.serial("Pass unknown options to semantic-release API", async (t) => {
   const argv = ["", "", "--bool", "--first-option", "value1", "--second-option", "value2", "--second-option", "value3"];
   const index = await td.replaceEsm("../index.js");


### PR DESCRIPTION
Fixes #3463.

This updates CLI list option parsing so commas inside JSON-like branch objects are not treated as list separators. That lets values such as `{"name":"version-test","prerelease":"snap"}` stay intact when passed through `--branches`.

Verification:
- npm_config_cache=/tmp/semantic-release-3463-npm-cache npx ava --match="Keep JSON objects with commas together in list options" test/cli.test.js --verbose
- npm_config_cache=/tmp/semantic-release-3463-npm-cache npx ava test/cli.test.js --verbose
- npm_config_cache=/tmp/semantic-release-3463-npm-cache npx prettier --check cli.js test/cli.test.js
- git diff --check