### PR TITLE
fix: skip `prepare` hooks/methods execution in dry-run

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,11 +199,11 @@ async function run(context, plugins) {
 
   nextRelease.notes = await plugins.generateNotes(context);
 
-  await plugins.prepare(context);
-
   if (options.dryRun) {
     logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
   } else {
+    await plugins.prepare(context);
+
     // Create the tag before calling the publish plugins as some require the tag to exists
     await tag(nextRelease.gitTag, nextRelease.gitHead, { cwd, env });
     await addNote({ channels: [nextRelease.channel] }, nextRelease.gitTag, { cwd, env });

--- a/index.js
+++ b/index.js
@@ -202,8 +202,6 @@ async function run(context, plugins) {
   if (options.dryRun) {
     logger.warn(`Skip ${nextRelease.gitTag} tag creation in dry-run mode`);
   } else {
-    await plugins.prepare(context);
-
     // Create the tag before calling the publish plugins as some require the tag to exists
     await tag(nextRelease.gitTag, nextRelease.gitHead, { cwd, env });
     await addNote({ channels: [nextRelease.channel] }, nextRelease.gitTag, { cwd, env });
@@ -211,6 +209,8 @@ async function run(context, plugins) {
     await pushNotes(options.repositoryUrl, nextRelease.gitTag, { cwd, env });
     logger.success(`Created tag ${nextRelease.gitTag}`);
   }
+
+  await plugins.prepare(context);
 
   const releases = await plugins.publish(context);
   context.releases.push(...releases);


### PR DESCRIPTION
This pull request updates the release process in `index.js` to ensure that the `prepare` plugin is only called during an actual release and not during a dry run. This change prevents unnecessary side effects when running in dry-run mode.

Release process update:

* Moved the call to `plugins.prepare(context)` to occur only when not in dry-run mode, ensuring that preparation steps are skipped during dry runs.

## Related Issue

- #984