### PR TITLE
fix: mask sensitive environment variables and improve commit handling

### DIFF
--- a/lib/branches/expand.js
+++ b/lib/branches/expand.js
@@ -10,7 +10,9 @@ export default async (repositoryUrl, { cwd }, branches) => {
       ...branches,
       ...remove(gitBranches, (name) => micromatch(gitBranches, branch.name).includes(name)).map((name) => ({
         name,
-        ...mapValues(omit(branch, "name"), (value) => (isString(value) ? template(value)({ name }) : value)),
+        ...mapValues(omit(branch, "name"), (value) =>
+          isString(value) ? template(value, { evaluate: false, escape: false })({ name }) : value
+        ),
       })),
     ],
     []

--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -11,7 +11,10 @@ export default async ({ cwd, env, options: { tagFormat } }, branches) => {
   // by replacing the `version` variable in the template by `(.+)`.
   // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
   // so it's guaranteed to no be present in the `tagFormat`.
-  const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "(.+)")}`;
+  const tagRegexp = `^${escapeRegExp(template(tagFormat, { evaluate: false, escape: false })({ version: " " })).replace(
+    " ",
+    "(.+)"
+  )}`;
 
   // Get the tags notes for all the tags in the repository
   const tagsNotesMap = await getTagsNotes({ cwd, env });

--- a/lib/git.js
+++ b/lib/git.js
@@ -54,7 +54,11 @@ export async function getCommits(from, to, execaOptions) {
         { cwd: execaOptions.cwd, env: { ...process.env, ...execaOptions.env } }
       )
     )
-  ).map(({ message, gitTags, ...commit }) => ({ ...commit, message: message.trim(), gitTags: gitTags.trim() }));
+  ).map(({ message, gitTags, ...commit }) => ({
+    ...commit,
+    message: (message ?? "").trim(),
+    gitTags: (gitTags ?? "").trim(),
+  }));
 }
 
 /**

--- a/lib/hide-sensitive.js
+++ b/lib/hide-sensitive.js
@@ -8,7 +8,10 @@ export default (env) => {
       return false;
     }
 
-    return /token|password|credential|secret|private/i.test(envVar) && size(env[envVar].trim()) >= SECRET_MIN_SIZE;
+    return (
+      /token|password|credential|secret|private|key|auth|webhook/i.test(envVar) &&
+      size(env[envVar].trim()) >= SECRET_MIN_SIZE
+    );
   });
 
   const regexp = new RegExp(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,7 @@ export function getRange(min, max) {
 }
 
 export function makeTag(tagFormat, version) {
-  return template(tagFormat)({ version });
+  return template(tagFormat, { evaluate: false, escape: false })({ version });
 }
 
 export function isSameChannel(channel, otherChannel) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -22,14 +22,14 @@ export default async (context) => {
   }
 
   // Verify that compiling the `tagFormat` produce a valid Git tag
-  if (!(await verifyTagName(template(tagFormat)({ version: "0.0.0" })))) {
+  if (!(await verifyTagName(template(tagFormat, { evaluate: false, escape: false })({ version: "0.0.0" })))) {
     errors.push(getError("EINVALIDTAGFORMAT", context));
   }
 
   // Verify the `tagFormat` contains the variable `version` by compiling the `tagFormat` template
   // with a space as the `version` value and verify the result contains the space.
   // The space is used as it's an invalid tag character, so it's guaranteed to no be present in the `tagFormat`.
-  if ((template(tagFormat)({ version: " " }).match(/ /g) || []).length !== 1) {
+  if ((template(tagFormat, { evaluate: false, escape: false })({ version: " " }).match(/ /g) || []).length !== 1) {
     errors.push(getError("ETAGNOVERSION", context));
   }
 

--- a/test/branches/expand.test.js
+++ b/test/branches/expand.test.js
@@ -52,3 +52,18 @@ test("Expand branches defined with globs", async (t) => {
     { name: "beta", channel: "channel-beta", prerelease: true },
   ]);
 });
+
+test("Expand branch string fields without executing template evaluation syntax", async (t) => {
+  const { cwd, repositoryUrl } = await gitRepo(true);
+  await gitCommits(["First"], { cwd });
+  await gitPush(repositoryUrl, "master", { cwd });
+  await gitCheckout("release", true, { cwd });
+  await gitCommits(["Second"], { cwd });
+  await gitPush(repositoryUrl, "release", { cwd });
+
+  const branches = [{ name: "release", channel: `channel-\${name}<% process.env.TEST = "x" %>`, prerelease: true }];
+
+  t.deepEqual(await expand(repositoryUrl, { cwd }, branches), [
+    { name: "release", channel: `channel-release<% process.env.TEST = "x" %>`, prerelease: true },
+  ]);
+});

--- a/test/branches/get-tags.test.js
+++ b/test/branches/get-tags.test.js
@@ -154,3 +154,21 @@ test('Get the highest valid tag corresponding to the "tagFormat"', async (t) => 
     { name: "master", tags: [{ gitTag: "3.0.0-bar.2", version: "3.0.0", channels: [null] }] },
   ]);
 });
+
+test.serial('Do not execute template evaluation syntax in "tagFormat" when building the tag regexp', async (t) => {
+  const { cwd } = await gitRepo();
+  await gitCommits(["First"], { cwd });
+
+  delete process.env.GET_TAGS_TEMPLATE_PWNED;
+
+  const result = await getTags(
+    {
+      cwd,
+      options: { tagFormat: `v\${version}<% process.env.GET_TAGS_TEMPLATE_PWNED = "yes" %>` },
+    },
+    [{ name: "master" }]
+  );
+
+  t.is(process.env.GET_TAGS_TEMPLATE_PWNED, undefined);
+  t.deepEqual(result, [{ name: "master", tags: [] }]);
+});

--- a/test/hide-sensitive.test.js
+++ b/test/hide-sensitive.test.js
@@ -150,3 +150,47 @@ test("Mask multiple occurrences of encoded credentials", (t) => {
     `url1: https://${SECRET_REPLACEMENT}@host.com/owner/repo.git url2: https://${SECRET_REPLACEMENT}@host.com/owner/repo.git`
   );
 });
+
+test("Mask API_KEY values", (t) => {
+  const env = { API_KEY: "SUPER-SECRET-VALUE-API_KEY" };
+  t.is(hideSensitive(env)(`leaked value: ${env.API_KEY}`), `leaked value: ${SECRET_REPLACEMENT}`);
+});
+
+test("Mask AUTH values", (t) => {
+  const env = { BASIC_AUTH: "SUPER-SECRET-VALUE-BASIC_AUTH" };
+  t.is(hideSensitive(env)(`leaked value: ${env.BASIC_AUTH}`), `leaked value: ${SECRET_REPLACEMENT}`);
+});
+
+test("Mask WEBHOOK values", (t) => {
+  const env = { SLACK_WEBHOOK: "SUPER-SECRET-VALUE-SLACK_WEBHOOK" };
+  t.is(hideSensitive(env)(`leaked value: ${env.SLACK_WEBHOOK}`), `leaked value: ${SECRET_REPLACEMENT}`);
+});
+
+test("Mask AWS_ACCESS_KEY_ID values", (t) => {
+  const env = { AWS_ACCESS_KEY_ID: "SUPER-SECRET-VALUE-AWS_ACCESS_KEY_ID" };
+  t.is(hideSensitive(env)(`leaked value: ${env.AWS_ACCESS_KEY_ID}`), `leaked value: ${SECRET_REPLACEMENT}`);
+});
+
+test("Mask fully percent-encoded API_KEY values", (t) => {
+  const env = { API_KEY: "user:pass@word-secret" };
+  t.is(hideSensitive(env)(`key=${encodeURIComponent(env.API_KEY)}`), `key=${SECRET_REPLACEMENT}`);
+});
+
+test("Mask common key/auth/webhook env-var names from advisory", (t) => {
+  for (const name of [
+    "API_KEY",
+    "DEPLOY_KEY",
+    "SIGNING_KEY",
+    "SSH_KEY",
+    "ENCRYPTION_KEY",
+    "AUTH",
+    "BASIC_AUTH",
+    "SLACK_WEBHOOK",
+    "DOCKER_AUTH",
+    "AWS_ACCESS_KEY_ID",
+  ]) {
+    const secretValue = `SUPER-SECRET-VALUE-${name}`;
+    const env = { [name]: secretValue };
+    t.false(hideSensitive(env)(`leaked value: ${secretValue}`).includes(secretValue), `${name} should be masked`);
+  }
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -179,6 +179,7 @@ test("getRange", (t) => {
 
 test("makeTag", (t) => {
   t.is(makeTag(`v\${version}`, "1.0.0"), "v1.0.0");
+  t.is(makeTag(`v\${version}<% process.env.TEST = "x" %>`, "1.0.0"), `v1.0.0<% process.env.TEST = "x" %>`);
 });
 
 test("isSameChannel", (t) => {

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -75,6 +75,22 @@ test('Throw a SemanticReleaseError if the "tagFormat" contains multiple "version
   t.truthy(errors[0].details);
 });
 
+test('Throw a SemanticReleaseError if the "tagFormat" contains template evaluation syntax', async (t) => {
+  const { cwd, repositoryUrl } = await gitRepo(true);
+  const options = {
+    repositoryUrl,
+    tagFormat: `v\${version}<% process.env.EXFILTRATED = "yes" %>`,
+    branches: [],
+  };
+
+  const errors = [...(await t.throwsAsync(verify({ cwd, options }))).errors];
+
+  t.is(errors[0].name, "SemanticReleaseError");
+  t.is(errors[0].code, "EINVALIDTAGFORMAT");
+  t.truthy(errors[0].message);
+  t.truthy(errors[0].details);
+});
+
 test("Throw a SemanticReleaseError for each invalid branch", async (t) => {
   const { cwd, repositoryUrl } = await gitRepo(true);
   const options = {


### PR DESCRIPTION
This pull request strengthens security and reliability by ensuring that template strings used for branch names and tag formats are rendered without evaluating potentially unsafe code. It also expands the detection and masking of sensitive environment variables, and improves robustness in commit parsing. Comprehensive tests have been added to verify these changes.

**Security improvements:**

* All uses of the `template` function for branch names and tag formats now disable evaluation and escaping, preventing unintended code execution when rendering templates in `lib/branches/expand.js`, `lib/branches/get-tags.js`, `lib/utils.js`, and `lib/verify.js`.
* The detection of sensitive environment variables in `lib/hide-sensitive.js` is expanded to include common names such as `key`, `auth`, and `webhook`, increasing the likelihood of masking secrets in logs.

**Bug fixes and robustness:**

* Commit parsing in `lib/git.js` now safely trims `message` and `gitTags` fields, even if they are `undefined`, preventing runtime errors.

**Testing improvements:**

* New and expanded tests confirm that template evaluation syntax is not executed in branch and tag formats, and that a wide range of sensitive environment variables are properly masked. 