### PR TITLE
fix: clarify non-release branch message

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,9 @@ async function run(context, plugins) {
 
   if (!context.branch) {
     logger.log(
-      `This test run was triggered on the branch ${ciBranch}, while semantic-release is configured to only publish from ${context.branches
+      `This test run was triggered on the branch ${ciBranch}, while semantic-release is configured to publish from ${options.branches
+        .map((branch) => branch.name || branch)
+        .join(", ")}. The configured branches that are present on the remote are ${context.branches
         .map(({ name }) => name)
         .join(", ")}, therefore a new version won’t be published.`
     );

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1627,11 +1627,11 @@ test.serial("Returns false value if triggered on an outdated clone", async (t) =
   ]);
 });
 
-test.serial("Returns false if not running from the configured branch", async (t) => {
+test.serial("Reports configured and remote branches when not on a release branch", async (t) => {
   // Create a git repository, set the current working directory at the root of the repo
   const { cwd, repositoryUrl } = await gitRepo(true);
   const options = {
-    branches: ["master"],
+    branches: ["master", "next"],
     repositoryUrl,
     verifyConditions: stub().resolves(),
     analyzeCommits: stub().resolves(),
@@ -1658,7 +1658,7 @@ test.serial("Returns false if not running from the configured branch", async (t)
   );
   t.is(
     t.context.log.args[1][0],
-    "This test run was triggered on the branch other-branch, while semantic-release is configured to only publish from master, therefore a new version won’t be published."
+    "This test run was triggered on the branch other-branch, while semantic-release is configured to publish from master, next. The configured branches that are present on the remote are master, therefore a new version won’t be published."
   );
 });
 


### PR DESCRIPTION
## Summary

- report configured branch entries alongside matching branches found on the remote
- make the distinction clear when configured patterns have no remote match
- add a focused integration regression

Closes #1443

## Validation

- lint:prettier, lint:lockfile, lint:engines, and lint:publish passed
- test:unit: 267 tests passed
- test:integration: 36 tests passed, including the new regression
- npm test reached test:e2e, whose before hook could not start because testcontainers found no working container runtime on this machine
- git diff --check passed

## AI assistance

This contribution was prepared with OpenAI Codex assistance. I reviewed the change and test results.