### PR TITLE
fix: ignore build metadata when determining version precedence

### DIFF
--- a/lib/branches/get-tags.js
+++ b/lib/branches/get-tags.js
@@ -1,4 +1,4 @@
-import { escapeRegExp, template } from "lodash-es";
+import { escapeRegExp } from "lodash-es";
 import semver from "semver";
 import pReduce from "p-reduce";
 import debugTags from "debug";
@@ -8,13 +8,16 @@ const debug = debugTags("semantic-release:get-tags");
 
 export default async ({ cwd, env, options: { tagFormat } }, branches) => {
   // Generate a regex to parse tags formatted with `tagFormat`
-  // by replacing the `version` variable in the template by `(.+)`.
-  // The `tagFormat` is compiled with space as the `version` as it's an invalid tag character,
-  // so it's guaranteed to no be present in the `tagFormat`.
-  const tagRegexp = `^${escapeRegExp(template(tagFormat, { evaluate: false, escape: false })({ version: " " })).replace(
-    " ",
-    "(.+)"
-  )}`;
+  // by replacing the any variable `${...}` in the template by `(.+)`.
+  // The `tagFormat` is compiled with space as variable placeholders as it's an
+  // invalid tag character, so it's guaranteed to no be present in the `tagFormat`.
+
+  const tagRegexp =
+    "^" + // anchor every tagRegexp
+    // escape any other regex special characters
+    escapeRegExp(
+      tagFormat.replace(/\$\{.*?\}/g, " ") // place a space for each variable in the template string
+    ).replaceAll(" ", "(.+)"); // then place capture groups for every variable
 
   // Get the tags notes for all the tags in the repository
   const tagsNotesMap = await getTagsNotes({ cwd, env });


### PR DESCRIPTION
Tag finding now scans for _any_ variable in `tagFormat` (not just "version") and does no longer treat the passed values as static strings when building the regular expression to search for previously created tags.

Fixes #2355 

Examples for different tagFormats and their respective resulting regex tag search expressions before and after the change
with `export foo=bar`:

| `tagFormat` | Regex before | Regex now |
| - | - | - |
| `${version}` | `^(.+)` | `^(.+)` |
| `v${version}` | `^v(.+)` | `^v(.+)` |
| `${version}+${process.env.foo}` | `^(.+)\+bar` | `^(.+)\+(.+)` |
| `${version}+constant` | `^(.+)\+constant` | `^(.+)\+constant` |
| `alpha-1.2+${version}` | `^alpha-1\.2\+(.+)` | `^alpha-1\.2\+(.+)` |
| `${version}-$process.env.foo` | `^(.+)-\$process\.env\.foo` | `^(.+)-\$process\.env\.foo` |
| `${version}-${process.env.foo}` | `^(.+)-bar` | `^(.+)-(.+)` |
| `${process.env.foo}}-${version}` | `^bar\}-(.+)` | `^(.+)\}-(.+)` |
