### PR TITLE
chore(deps): remove `aggregate-error` polyfill

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,5 +1,4 @@
 import { isPlainObject, isString, template } from "lodash-es";
-import AggregateError from "aggregate-error";
 import { isGitRepo, verifyTagName } from "./git.js";
 import getError from "./get-error.js";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@semantic-release/github": "^12.0.0",
         "@semantic-release/npm": "^13.1.1",
         "@semantic-release/release-notes-generator": "^14.1.0",
-        "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
         "debug": "^4.0.0",
         "env-ci": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@semantic-release/github": "^12.0.0",
     "@semantic-release/npm": "^13.1.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
-    "aggregate-error": "^5.0.0",
     "cosmiconfig": "^9.0.0",
     "debug": "^4.0.0",
     "env-ci": "^11.0.0",


### PR DESCRIPTION
Removes `aggregate-error` dependency

`AggregateError` is available natively since Node 15.0.0
